### PR TITLE
fix: keep unified gateway demos on reviewed image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Removed the Unified AI Gateway's mutable upstream demo shortcut so all demos
+  remain on the reviewed, digest-pinned, sandboxed container procedure.
+
 ## [15.11.0] - 2026-08-07 - "Agent Plugin Directory Readiness"
 
 > Prepared the flagship AAS Agent & MCP Builder for the OpenAI Plugins Directory with production metadata, public policies, and a reproducible evaluation dossier.

--- a/skills/unified-ai-gateway/SKILL.md
+++ b/skills/unified-ai-gateway/SKILL.md
@@ -29,9 +29,9 @@ installations require the manual setup below.
 The current public project release is `v0.4.3`. The inspection procedure below
 intentionally pins the reviewed, immutable `v0.4.0` image and its recorded
 digests; those values are a historical security baseline and must not be
-silently replaced with a mutable tag. For a normal provider-free demo, use the
-current `v0.4.3` command in the [project README](https://github.com/happy520ai/unified-ai-system#try-it-in-60-seconds).
-A new content review is required before changing this pinned procedure.
+silently replaced with a mutable tag. Use only the reviewed procedure below,
+including for provider-free demos. A new content review is required before
+changing this pinned procedure or following a newer upstream quickstart.
 
 ## Prerequisites And Setup
 


### PR DESCRIPTION
### Motivation

- Remove an unsafe alternate quickstart that directed demos to an unpinned, upstream README command and could cause agents to run a mutable, unreviewed container image instead of the reviewed digest-pinned workflow.
- Ensure the Unified AI Gateway demos and operator guidance always follow the repository's reviewed, digest-pinned, sandboxed inspection and registration procedure.

### Description

- Updated `skills/unified-ai-gateway/SKILL.md` to remove the mutable upstream quickstart shortcut and require using the reviewed, digest-pinned procedure (no silent substitution of mutable tags or upstream quickstarts). 
- Added a short `### Security` entry to `CHANGELOG.md` documenting the correction.
- Kept the change source-only (did not commit generated catalog artefacts or plugin mirrors); evidence and catalog generation were exercised locally as part of validation but derived files were not staged in the source commit.
- Committed as `fix: pin unified gateway demo workflow` (HEAD: `4d1146bc09f0cc7c91f370c980d43427687b559d`).

### Testing

- Ran `npm run chain` (indexing/catalog build) and `npm run validate:references`, and both completed successfully.
- Ran `npm run security:docs`, `npm run check:warning-budget`, and `npm run check:readme-credits -- --base HEAD^ --head HEAD`, which passed after removing generated drift from the commit.
- Executed the test suite via `npm run test`; all functional tests reached passed except an environment-only failure in `tools/scripts/tests/git_pushing_helper.test.js` caused by the installed `git` not supporting `git init --ref-format=reftable`, so the CI-only git-pushing helper test failed but all upstream validation, catalog, and skill-security checks exercised for this change passed; `tools/scripts/run-python.js tools/scripts/changed_skill_evidence.py --base HEAD^ --head HEAD` reported no blocking findings for the changed skill.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78178ac5ac83238a32c1464d38017d)