### PR TITLE
fix: pin unified-ai-gateway demo flow to reviewed digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Removed mutable upstream demo guidance from `unified-ai-gateway`; all demos
+  now remain inside its reviewed, digest-pinned image procedure.
+
 ## [15.12.0] - 2026-08-09 - "Catalog Discovery and Safer Context Skills"
 
 > Upgraded the public catalog into a practical discovery dashboard, added two focused research and planning skills, and repaired unsafe or malformed context-management guidance.

--- a/skills/unified-ai-gateway/SKILL.md
+++ b/skills/unified-ai-gateway/SKILL.md
@@ -28,10 +28,9 @@ installations require the manual setup below.
 
 The current public project release and latest reviewed immutable MCP image are
 both `v0.4.9`. The inspection procedure below pins its recorded digests; those
-values must not be silently replaced with a mutable tag. For a normal
-provider-free demo, use the current `v0.4.9` command in the
-[project README](https://github.com/happy520ai/unified-ai-system#try-it-in-60-seconds).
-A new content review is required before changing this pinned procedure.
+values must not be silently replaced with a mutable tag. Use only the reviewed,
+digest-pinned procedure below, including for a provider-free demo. A new content
+review is required before changing this pinned procedure.
 
 ## Prerequisites And Setup
 


### PR DESCRIPTION
### Motivation
- Remove an unsafe alternate demo path that pointed to a mutable upstream README command and therefore bypassed the repository's reviewed, digest-pinned image inspection and activation procedure.

### Description
- Update `skills/unified-ai-gateway/SKILL.md` to remove the mutable README demo guidance and require the reviewed, digest-pinned inspection/activation procedure for provider-free demos, and add an unreleased security note to `CHANGELOG.md` documenting the remediation.

### Testing
- Ran `npm run validate`, `npm run validate:references`, and `npm run security:docs` (passed after isolating an installed `node_modules` subtree that the validator otherwise treated as skill content); ran `npm run chain` (completed); ran `npm run test` (most test groups passed, but a platform `git` incompatibility in this execution environment caused a single git-helper test to fail); and ran `npm run check:warning-budget` which reported warnings attributable to the installed `node_modules` subtree rather than the patched skill files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ac07e7c488323966036ce1cd6d16a)