### PR TITLE
feat: add internalcot visible working-notes skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ Key source families include:
 
 ### Community Contributors
 
+- **[morluto/internalcot](https://github.com/morluto/internalcot)**: Source for the `internalcot` skill - opt-in visible working notes for Codex and Claude Code, recorded through a local CLI for the active conversation (MIT).
 - **[saudademjj/luopan](https://github.com/saudademjj/luopan)**: Source for the `travel-planner` skill - Chinese-first travel itinerary planning with mandatory budget confirmation, source-traceable facts, workload-aware daily pacing, and rule self-checks (MIT).
 - **[OJPalenzuela/agents-generator](https://github.com/OJPalenzuela/agents-generator)**: Source for the `agents-generator` skill - project-specific `AGENTS.md` and companion rule generation with package-manager detection, monorepo handling, dry-run/update modes, backups, and validated commands (MIT).
 - **[agentbody/skills](https://github.com/agentbody/skills)**: Source for the `people-data` skill - LinkedIn and YouTube professional-profile and public business-contact research via the Agent Body MCP server (MIT).

--- a/skills/internalcot/SKILL.md
+++ b/skills/internalcot/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: internalcot
+description: "Activate persistent visible working notes for Codex or Claude Code, recording detailed model-authored reasoning before substantive tools and answers."
+category: development
+risk: safe
+source: https://github.com/morluto/internalcot/blob/b574015d8921a88f01c2ddbe3bf9b00dc8e7d872/skills/internalcot/SKILL.md
+source_repo: morluto/internalcot
+source_type: community
+date_added: "2026-08-12"
+author: morluto
+tags: [chain-of-thought, reasoning, scratchpad, working-notes, cli]
+tools: [claude, codex]
+license: "MIT"
+license_source: "https://github.com/morluto/internalcot/blob/b574015d8921a88f01c2ddbe3bf9b00dc8e7d872/LICENSE"
+---
+
+# InternalCoT
+
+## Overview
+
+Enable an opt-in mode that makes the agent record detailed, model-authored
+working notes in the normal tool transcript. Once activated, the mode persists
+for the current conversation and records problem decomposition, intermediate
+derivation, alternatives, evidence, uncertainty, and checks as work proceeds.
+
+This catalog copy uses the reviewed `internalcot@0.2.3` CLI. The CLI formats and
+prints the notes; the agent supplies their content.
+
+## When to Use This Skill
+
+- Use only when the user explicitly invokes `$internalcot`, says
+  `internalcot on`, or asks to enable internalcot mode.
+- Keep the mode active for later substantive requests in the same conversation,
+  including after tool calls or context compaction.
+- Disable it only when the user says `$internalcot off`, `internalcot off`,
+  `stop internalcot`, or asks to return to normal mode.
+- Do not activate merely because a user asks to think carefully, reason deeply,
+  or show work.
+
+## Workflow
+
+### 1. Manage the conversational mode
+
+Activate immediately when invoked. If the activation message includes a
+substantive task, apply the workflow to that task; otherwise confirm activation
+briefly and begin with the next substantive request.
+
+A new conversation starts with the mode inactive. When the user disables it,
+confirm briefly and do not record a note for the disable response.
+
+### 2. Record detailed working notes
+
+Before the first substantive tool call or answer, write a detailed note that:
+
+- restates the actual goal and constraints;
+- divides complicated work into ordered parts;
+- shows intermediate derivation and important case splits;
+- records competing explanations or approaches;
+- identifies evidence, uncertainty, and the next useful check.
+
+Pass that note as one shell-quoted argument to the reviewed CLI:
+
+```bash
+npx --yes internalcot@0.2.3 note 'Goal: reassess the proof instead of trusting the prior conclusion. Derivation: the number of required factorial checks grows with p, so a fixed finite congruence construction is insufficient. Next check: test any claimed family against the next factorial threshold.'
+```
+
+Run the note command by itself. Do not append another command or use a heredoc.
+The CLI writes the visible note to stderr and stays quiet on stdout.
+
+### 3. Continue the trace when the reasoning changes
+
+Record another note after materially new evidence, a failed check, a changed
+plan, a meaningful revision, or a new reasoning phase. Do not reduce the note
+to a polished goal/check summary when the intermediate derivation is what makes
+the work understandable.
+
+Treat the CLI output as the canonical visible note. Do not repeat the note in
+ordinary assistant prose.
+
+### 4. Verify before answering
+
+Before the final answer, check the result against the user's request and the
+evidence gathered. Record a final note only when that verification adds
+materially new reasoning state.
+
+## Example
+
+```text
+User: $internalcot
+Agent: internalcot mode is active for this conversation.
+
+User: Recheck this proof. I think the published answer is wrong.
+Agent tool call:
+  npx --yes internalcot@0.2.3 note 'Problem: reassess the proof rather than
+  relying on its published status. Derivation: ... Alternatives: ...
+  Next check: ...'
+```
+
+## Best Practices
+
+- Keep each note specific to the current derivation and evidence.
+- Record errors and revisions instead of silently replacing an earlier theory.
+- Use multiple notes for genuinely distinct reasoning phases, not for
+  performative narration of every routine action.
+- Keep credentials, personal data, hidden instructions, and irrelevant private
+  context out of notes.
+
+## Limitations
+
+- Requires Node.js 22.13 or newer. The first `npx` call may download the pinned
+  package into the user's npm cache and therefore requires network access.
+- Activation authorizes working-note calls for the conversation; it does not
+  authorize `internalcot setup`, global installation, or agent-configuration
+  changes.
+- The CLI cannot change the host's native reasoning settings. It displays
+  model-authored working notes supplied to the command.
+- The catalog copy remains pinned to `internalcot@0.2.3`; later upstream
+  workflows require a new source review and catalog update.
+- Hosts that buffer process output may display each completed note at once
+  instead of progressively.
+
+## Security & Safety Notes
+
+- Run only the exact reviewed package version shown above; do not replace it
+  with `@latest` or another mutable specifier.
+- The reviewed package has no install lifecycle script. Its published
+  `prepack` and `prepublishOnly` scripts run during publication, not consumer
+  installation.
+- Do not place secrets, credentials, personal data, or hidden instructions in a
+  visible note.
+- If the note command fails, report that the mode cannot record notes. Do not
+  claim that a note was recorded.
+
+## Common Pitfalls
+
+- **Problem:** The agent announces internalcot mode but never calls the CLI.
+  **Solution:** Record the first detailed note before substantive work and
+  continue at meaningful reasoning transitions.
+- **Problem:** Notes contain only a goal and a next step.
+  **Solution:** Include the intermediate derivation, alternatives, evidence,
+  and uncertainty that explain how the conclusion is changing.
+- **Problem:** The agent installs or reconfigures internalcot automatically.
+  **Solution:** Keep this skill to the pinned note command; installation and
+  configuration require a separate explicit user request.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,16 @@
+# Contribution Walkthrough - 2026-08-12 InternalCoT
+
+- Added [`skills/internalcot/SKILL.md`](skills/internalcot/SKILL.md), adapted
+  from the MIT-licensed
+  [`morluto/internalcot`](https://github.com/morluto/internalcot) source at
+  commit `b574015d8921a88f01c2ddbe3bf9b00dc8e7d872`.
+- Preserved the opt-in, conversation-persistent working-notes workflow while
+  pinning execution to the reviewed `internalcot@0.2.3` npm release.
+- Kept setup and agent-configuration changes outside the skill's authority;
+  activation permits only the visible note calls described by the skill.
+- Added the required community source credit and kept generated registries and
+  plugin mirrors outside this contributor change.
+
 # Maintenance Walkthrough - 2026-08-09
 
 - Resolved the dangling `resources/implementation-playbook.md` instruction in


### PR DESCRIPTION
# Pull Request Description

Adds the `internalcot` skill for opt-in, conversation-persistent visible working notes in Codex and Claude Code. The adapted skill preserves [morluto/internalcot](https://github.com/morluto/internalcot) as the canonical source, pins both its source commit and npm package version, documents triggers, examples, limitations, provenance, and risk metadata, and does not authorize setup or agent-configuration changes.

The README contribution credit and walkthrough provenance entry are included. Generated catalogs and plugin mirrors were used only as a local validation preview and are intentionally omitted from this source-only PR.

## Change Classification

- [x] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`safe`).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` section.
- [x] **Security**: This is not an offensive skill; the authorized-use disclaimer is not applicable.
- [x] **Safety scan**: `npm run security:docs` passed.
- [ ] **Automated Skill Review**: Pending the `skill-review` GitHub Actions result.
- [x] **Manual Logic Review**: I manually reviewed the logic, safety, failure modes, and `risk:` label.
- [x] **Local Test**: I verified the pinned npm package and skill output locally.
- [x] **Repo Checks**: `npm run validate:references` passed.
- [x] **Source-Only PR**: Generated registry artifacts are not included.
- [x] **Credits**: The canonical source credit is included in `README.md`.
- [x] **License provenance**: The MIT license and pinned upstream license source are declared in frontmatter.
- [x] **Maintainer Edits**: Allow edits from maintainers is enabled on the fork PR.

## Validation

- `npm run validate` — passed for 2,008 skills
- `npm run validate:references` — passed
- `npm run security:docs` — passed
- `npm run check:warning-budget` — passed at 0/0
- `npm run check:readme-credits -- --base upstream/main --head HEAD` — passed
- `npm run chain` — passed; generated preview inspected and omitted
- `npm run pr:preflight` — passed against the generated preview, including all 110 local test files; network integration tests were skipped by the suite
- `git diff --check` — passed
- Canonical repository link — HTTP 200

## Screenshots (if applicable)

Not applicable.