### PR TITLE
fix: update nanoid to 3.3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Updated the web app's transitive `nanoid` dependency from `3.3.17` to
+  `3.3.18`, resolving the zero-length custom-generator denial-of-service
+  advisory without changing the direct dependency set.
 - Bound default and `--release` installer clones to the immutable `gitHead`
   recorded by the exact npm package version, failing closed if a GitHub release
   tag is moved or npm identity metadata cannot be verified. Explicit `--tag`

--- a/apps/web-app/package-lock.json
+++ b/apps/web-app/package-lock.json
@@ -5441,9 +5441,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- Update the web app transitive `nanoid` lockfile entry from `3.3.17` to `3.3.18`.
- Resolve GHSA-2v37-7h3g-55p8 without changing direct dependencies.
- Record the maintenance fix in the Unreleased changelog.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Issue Link (Optional)

No linked issue.

## Quality Bar Checklist

- [x] **Standards**: Read the repository quality and security guidance.
- [x] **Metadata**: No `SKILL.md` metadata changed; repository validation passed.
- [x] **Risk Label**: No skill risk metadata changed.
- [x] **Triggers**: No skill trigger guidance changed.
- [x] **Limitations**: No skill limitations changed.
- [x] **Security**: No offensive skill content changed.
- [x] **Safety scan**: `npm run security:docs` and `npm run security:scan:strict` passed.
- [x] **Automated Skill Review**: Not applicable because no skill content changed.
- [x] **Manual Logic Review**: Reviewed the exact two-file diff and transitive dependency path.
- [x] **Local Test**: Clean web install resolves `nanoid@3.3.18`; root and web audits report zero vulnerabilities.
- [x] **Repo Checks**: `npm run validate:references`, full repository tests, web tests, and production build passed.
- [x] **Source-Only PR**: No generated registry, plugin mirror, marketplace, or sitemap artifact is included.
- [x] **Credits**: Not applicable; no sourced skill content changed.
- [x] **License provenance**: Not applicable; no skill source was imported.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

## Validation

- `npm run test`: 110 test groups passed.
- `npm run app:test`: 21 files and 173 tests passed.
- `npm run app:build`: production build and SEO prerender passed.
- `npm audit --package-lock-only`: 0 vulnerabilities.
- `npm audit --prefix apps/web-app`: 0 vulnerabilities.
- `npm run sync:repo-state`: passed; generated sitemap drift was excluded from this source PR.