### PR TITLE
docs: refresh cohesivity skill description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refreshed the `cohesivity` skill description to emphasize its headless,
+  agent-oriented backend surface and current claimed Free-tier project and
+  object-storage allowances.
+
 ### Security
 
 - Updated the web app's transitive `nanoid` dependency from `3.3.17` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Refreshed the `cohesivity` skill description to emphasize its headless,
-  agent-oriented backend surface and current claimed Free-tier project and
-  object-storage allowances.
-
 ### Security
 
 - Updated the web app's transitive `nanoid` dependency from `3.3.17` to

--- a/skills/cohesivity/SKILL.md
+++ b/skills/cohesivity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cohesivity
-description: "Provision backend infra through Cohesivity (cohesivity.ai): Postgres, hosting, auth, storage, and AI model APIs over one HTTP API. Use when a .cohesivity file exists or a project needs a backend."
+description: "Headless backend and services purpose-built for AI agents: hosting, databases, storage, LLMs, and third-party APIs with agentic signup. Free tier: 10 projects and 10 GB live object storage."
 category: backend
 risk: critical
 source: https://github.com/cohesivity-org/cohesivity-skill

--- a/skills/cohesivity/SKILL.md
+++ b/skills/cohesivity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cohesivity
-description: "Headless backend and services purpose-built for AI agents: hosting, databases, storage, LLMs, and third-party APIs with agentic signup. Free tier: 10 projects and 10 GB live object storage."
+description: "Provision headless backend services for AI agents through Cohesivity: hosting, databases, storage, LLMs, and third-party APIs over one HTTP API. Use when a trusted .cohesivity file exists or the user approves a new backend."
 category: backend
 risk: critical
 source: https://github.com/cohesivity-org/cohesivity-skill


### PR DESCRIPTION
# Pull Request Description

Refreshes the `cohesivity` skill frontmatter description to present Cohesivity as a headless backend and services platform purpose-built for AI agents. The new 189-character description highlights hosting, databases, storage, LLMs, third-party APIs, agentic signup, and the currently published claimed Free-tier allowances of 10 projects and 10 GB of live object storage.

The quota claims were checked against `https://cohesivity.ai/pricing` on 2026-08-15. No operational guidance, provenance, risk classification, commands, credentials, or bundled files changed.

Exact reviewed head: `601e5a72237e43659d584d83e3172b5515ece162`.

## Change Classification

- [x] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: The existing `risk: critical` classification remains unchanged and appropriate.
- [x] **Triggers**: The existing `## When to Use This Skill` section remains clear and specific.
- [x] **Limitations**: The existing `## Limitations` section remains unchanged.
- [x] **Security**: This is not an offensive skill; the Authorized Use Only disclaimer does not apply.
- [x] **Safety scan**: `npm run security:docs` passed.
- [ ] **Automated Skill Review**: Pending the `skill-review` GitHub Actions result for this PR.
- [x] **Manual Logic Review**: Reviewed the complete skill, description semantics, pricing provenance, safety boundaries, failure modes, and unchanged `critical` risk label at the exact head above.
- [x] **Local Test**: The full 110-group repository test suite passed under npm 11; the host's npm 12 changes `npm pack --json` shape and is outside the current-base test contract.
- [x] **Repo Checks**: `npm run validate:references`, `npm run check:warning-budget`, and changed-skill evidence passed.
- [x] **Source-Only PR**: Generated catalogs, indexes, offline data, and plugin mirrors were previewed with `npm run chain` and excluded from this source PR.
- [x] **Credits**: Existing README Official Sources credit remains valid; `check:readme-credits` passed.
- [x] **License provenance**: Existing MIT `license` and `license_source` metadata remain unchanged and valid.
- [x] **Maintainer Edits**: Allow edits from maintainers is enabled on the fork PR.

## Validation

- `npm run chain`
- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run check:warning-budget`
- `npm run check:readme-credits -- --base origin/main --head HEAD`
- `npm run pr:evidence -- --base origin/main --head HEAD --output <temporary-path> --json`
- Full `npm test` suite: 110 groups passed using npm 11 and checksum-verified jq 1.8.1

## Screenshots (if applicable)

Not applicable; metadata-only documentation change.
