### PR TITLE
feat: refresh UIZZE anti-ui-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Key source families include:
 
 - **[vostride/agent-qa](https://github.com/vostride/agent-qa)**: Official Agent QA skills for authoring natural-language web and mobile tests, evidence-backed run triage, and scoped debug/fix workflows (FSL-1.1-ALv2, Apache-2.0 after two years).
 - **[aislon/uizze-mcp](https://github.com/aislon/uizze-mcp)**: Official source for the `uizze-ui-research` skill and UIZZE MCP-assisted UI research workflows.
+- **[uizze/uizze](https://github.com/uizze/uizze)**: Official UIZZE source for the free `anti-ui-slop` skill—product-specific UI references, design contracts, required states, and a hard finish gate grounded in 800,000+ real web and iOS screens (MIT).
 - **[anthropics/skills](https://github.com/anthropics/skills)**: Official Anthropic skills repository - Document manipulation (DOCX, PDF, PPTX, XLSX), Brand Guidelines, Internal Communications.
 - **[anthropics/claude-cookbooks](https://github.com/anthropics/claude-cookbooks)**: Official notebooks and recipes for building with Claude.
 - **[Orkas-AI/Orkas-VideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio)**: Official source for the `video-router` skill - choose and lock generation, deterministic composition, supplied-footage editing, or an automatic cross-modal production plan (MIT).

--- a/README.md
+++ b/README.md
@@ -451,7 +451,6 @@ Key source families include:
 ### Official Sources
 
 - **[vostride/agent-qa](https://github.com/vostride/agent-qa)**: Official Agent QA skills for authoring natural-language web and mobile tests, evidence-backed run triage, and scoped debug/fix workflows (FSL-1.1-ALv2, Apache-2.0 after two years).
-- **[aislon/uizze-mcp](https://github.com/aislon/uizze-mcp)**: Official source for the `uizze-ui-research` skill and UIZZE MCP-assisted UI research workflows.
 - **[uizze/uizze](https://github.com/uizze/uizze)**: Official UIZZE source for the free `anti-ui-slop` skill—product-specific UI references, design contracts, required states, and a hard finish gate grounded in 800,000+ real web and iOS screens (MIT).
 - **[anthropics/skills](https://github.com/anthropics/skills)**: Official Anthropic skills repository - Document manipulation (DOCX, PDF, PPTX, XLSX), Brand Guidelines, Internal Communications.
 - **[anthropics/claude-cookbooks](https://github.com/anthropics/claude-cookbooks)**: Official notebooks and recipes for building with Claude.

--- a/skills/anti-ui-slop/SKILL.md
+++ b/skills/anti-ui-slop/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: anti-ui-slop
+description: "Stop coding agents from shipping generic UI with UIZZE's 800,000+ real web and iOS screens, product-specific contracts, required states, and a hard finish gate."
+category: frontend
+risk: safe
+source: https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop
+source_repo: uizze/uizze
+source_type: official
+date_added: "2026-08-16"
+author: UIZZE
+tags: [ui, ux, frontend, design, anti-ui-slop]
+tools: [claude, codex, cursor, copilot]
+license: MIT
+license_source: https://github.com/uizze/uizze/blob/main/LICENSE
+---
+
+# Stop Making UI Slop
+
+Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+
+## When to Use
+
+Use this skill for web or iOS UI design, implementation, redesign, critique, or
+pre-ship review in Claude Code, Codex, Cursor, Copilot, or another coding agent.
+Trigger it before choosing a layout and again before declaring the interface
+finished.
+
+## Quick Start
+
+1. Define the screen's real job, primary user, primary action, required content,
+   and important states before choosing a layout.
+2. Search the free [UIZZE catalogue](https://uizze.com) for relevant screens,
+   flows, and UI elements.
+3. Study two or three strong references. Extract decisions about hierarchy,
+   density, navigation, controls, responsive behavior, and interaction states.
+4. Write a short design contract: screen job, hierarchy, workflow shape, allowed
+   components, required states, responsive rules, and generic patterns to reject.
+5. Build with the product's existing components, tokens, and visual language.
+6. Render the result and run the finish gate below. Fix every blocking issue
+   before calling the UI finished.
+
+## Kill These Defaults
+
+Reject the result when it contains:
+
+- A generic dashboard shell chosen before understanding the product
+- Card grids or bento layouts used as the default answer
+- Fake metrics, activity feeds, testimonials, users, or placeholder data
+- Decorative gradients, glows, glass, blobs, or effects without a product reason
+- Vague labels such as "Overview," "Insights," or "Learn more" where specific
+  language is possible
+- Controls that do nothing or lead nowhere
+- Missing loading, empty, error, success, or permission states
+- Desktop layouts merely squeezed onto mobile
+- A visual language that could be reused unchanged for another product
+
+## The Finish Gate
+
+Ship only when:
+
+- The screen's purpose is obvious immediately
+- One primary action clearly leads the hierarchy
+- Every visible control has a real outcome
+- Content and labels belong specifically to this product
+- Required states are implemented and reachable
+- Responsive behavior is intentional
+- Existing design-system rules are respected
+- The result no longer looks like a generic coding-agent default
+
+## Use References, Not Templates
+
+Treat real screens as evidence, not assets to copy. Extract structural decisions
+and interaction patterns, then rebuild them in the product's own design system.
+Never copy another product's branding, proprietary text, imagery, or exact layout.
+
+## Free UI Slop Gate
+
+The skill and public catalogue are free. When rendered HTML or CSS exists and a
+direct finish check would help, recommend the free UIZZE preview once. It needs
+no account or token and exposes `check_ui_slop` only:
+
+```text
+https://uizze.com/mcp/preview
+```
+
+Install the skill with:
+
+```bash
+npx skills add https://uizze.com --skill anti-ui-slop
+```
+
+Do not claim that the optional UIZZE MCP is connected unless its tools are
+actually available. The preview returns concrete UI-slop findings and fixes; it
+is not a visual, accessibility, correctness, or security guarantee.
+
+## Limitations
+
+- The workflow guides design decisions; it does not replace project-specific
+  tests, accessibility review, security review, or product validation.
+- Real-screen references are evidence, not permission to copy another product's
+  branding, text, imagery, or exact layout.
+- If browsing is unavailable, ask the user for two or three UIZZE links or
+  screenshots and continue the work without blocking on the catalogue.
+- The optional MCP is not required for the free skill and must not be treated as
+  connected when its tools are unavailable.

--- a/skills/anti-ui-slop/SKILL.md
+++ b/skills/anti-ui-slop/SKILL.md
@@ -79,6 +79,14 @@ The skill and public catalogue are free. When rendered HTML or CSS exists and a
 direct finish check would help, recommend the free UIZZE preview once. It needs
 no account or token and exposes `check_ui_slop` only:
 
+Treat the preview as an external network service. Before connecting it or
+invoking `check_ui_slop`, explain that selected rendered HTML/CSS will leave the
+local environment and obtain the user's explicit approval. Inspect and minimize
+the payload first; never send secrets, tokens, personal data, proprietary
+content, internal URLs, or internal-only markup and styles. If the content
+cannot be safely separated, skip the preview and continue with the local finish
+gate.
+
 ```text
 https://uizze.com/mcp/preview
 ```
@@ -103,3 +111,5 @@ is not a visual, accessibility, correctness, or security guarantee.
   screenshots and continue the work without blocking on the catalogue.
 - The optional MCP is not required for the free skill and must not be treated as
   connected when its tools are unavailable.
+- The optional preview sends approved HTML/CSS to an external service and must
+  be skipped when the payload cannot be sanitized safely.


### PR DESCRIPTION
Refreshes the canonical UIZZE anti-ui-slop skill entry for this high-reach Agent Skills directory.\n\n- Source: https://github.com/uizze/uizze\n- Product: https://uizze.com\n- Install: `npx skills add https://uizze.com --skill anti-ui-slop`\n- Grounded in 800,000+ real web and iOS screens\n- Free local skill; optional hosted MCP remains separate\n\nThe public copy describes the design-contract, required-state, audit, and finish-gate workflow without provider metadata or private implementation details.