### PR TITLE
fix: allow zero-diff contributor merges

### DIFF
--- a/tools/scripts/merge_batch.cjs
+++ b/tools/scripts/merge_batch.cjs
@@ -408,7 +408,7 @@ function readRawChangeRecords(projectRoot, baseOid, headOid, dependencies = {}) 
     ["diff", "--raw", "--no-abbrev", "-z", "-M", "--find-copies-harder", baseOid, headOid, "--"],
     projectRoot,
   );
-  return parseRawDiff(raw);
+  return parseRawDiff(raw, { allowEmpty: true });
 }
 
 function runGhJson(projectRoot, args, options = {}) {

--- a/tools/scripts/tests/merge_batch.test.js
+++ b/tools/scripts/tests/merge_batch.test.js
@@ -215,6 +215,19 @@ function evidenceSnapshot(overrides = {}) {
   assert.throws(() => mergeBatch.parseRawDiff(invalidUtf8), /canonical UTF-8/);
 }
 
+{
+  const records = mergeBatch.readRawChangeRecords("/tmp/repo", BASE_SHA, HEAD_SHA, {
+    runCommandBuffer() {
+      return Buffer.alloc(0);
+    },
+  });
+  assert.deepStrictEqual(
+    records,
+    [],
+    "a zero-diff contributor PR should remain mergeable through the protected batch workflow",
+  );
+}
+
 function workflowFixture(overrides = {}) {
   return {
     id: 100,


### PR DESCRIPTION
# Pull Request Description

Allow `npm run merge:batch` to accept an empty raw Git diff. This preserves the protected maintainer workflow for contributor PRs whose reviewed content has already landed through a same-repository intake PR, while retaining strict parsing for every non-empty diff.

The regression test exercises `readRawChangeRecords` with an empty `git diff --raw -z` result and requires an empty record set.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

None.

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; no `SKILL.md` changes.
- [x] **Risk Label**: Not applicable; no skill content changes.
- [x] **Triggers**: Not applicable; no skill content changes.
- [x] **Limitations**: Not applicable; no skill content changes.
- [x] **Security**: Not applicable; no offensive skill changes.
- [x] **Safety scan**: Not applicable; no skill command guidance, network examples, or token-like strings changed.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` changes.
- [x] **Manual Logic Review**: Reviewed the empty-diff trust boundary and confirmed non-empty malformed raw diffs still fail closed.
- [x] **Local Test**: `node tools/scripts/tests/merge_batch.test.js` and the complete `npm run test` suite pass (111 tests).
- [x] **Repo Checks**: No references changed; the full repository test suite passed.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Not applicable; no external source content added.
- [x] **License provenance**: Not applicable; no external skill source imported.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

## Screenshots (if applicable)

Not applicable.
