### PR TITLE
fix: classify zero-diff contributor PRs

### DIFF
--- a/tools/scripts/merge_batch.cjs
+++ b/tools/scripts/merge_batch.cjs
@@ -411,6 +411,19 @@ function readRawChangeRecords(projectRoot, baseOid, headOid, dependencies = {}) 
   return parseRawDiff(raw, { allowEmpty: true });
 }
 
+function emptyChangePolicy() {
+  return {
+    safe: true,
+    sensitive: false,
+    approvalSafe: true,
+    reasons: [],
+    paths: [],
+    requiresHumanReview: false,
+    canonicalSkillChanges: [],
+    skillContentChanges: [],
+  };
+}
+
 function runGhJson(projectRoot, args, options = {}) {
   const stdout = runCommand(
     "gh",
@@ -1031,15 +1044,17 @@ function approveActionRequiredRuns(projectRoot, repoSlug, prDetails, options = {
   const ownerAuthorizedSensitiveChange = sameRepository
     && String(prDetails?.author?.login || "").toLowerCase() === repositoryOwner
     && reviewedHeads.has(headOid);
-  const preliminaryPolicy = classifyRecords(records, { requireBlobSizes: false });
+  const preliminaryPolicy = records.length === 0
+    ? emptyChangePolicy()
+    : classifyRecords(records, { requireBlobSizes: false });
   if (!preliminaryPolicy?.approvalSafe && !ownerAuthorizedSensitiveChange) {
     const reasons = Array.isArray(preliminaryPolicy?.reasons) && preliminaryPolicy.reasons.length
       ? preliminaryPolicy.reasons.slice(0, 12).join(", ")
       : "unclassified local diff";
     throw new Error(`PR #${prNumber} local base-to-head diff is not fork-approval-safe: ${reasons}.`);
   }
-  const blobSizes = getSizes(projectRoot, records, dependencies);
-  const policy = classifyRecords(records, { blobSizes });
+  const blobSizes = records.length === 0 ? new Map() : getSizes(projectRoot, records, dependencies);
+  const policy = records.length === 0 ? emptyChangePolicy() : classifyRecords(records, { blobSizes });
   if (!policy?.approvalSafe && !ownerAuthorizedSensitiveChange) {
     const reasons = Array.isArray(policy?.reasons) && policy.reasons.length
       ? policy.reasons.slice(0, 12).join(", ")

--- a/tools/scripts/tests/merge_batch.test.js
+++ b/tools/scripts/tests/merge_batch.test.js
@@ -364,6 +364,27 @@ function approvalDependencies(overrides = {}) {
 
 {
   const prDetails = { number: 450, baseRefName: "main", baseRefOid: BASE_SHA, headRefOid: HEAD_SHA };
+  let blobReads = 0;
+  let classifications = 0;
+  const dependencies = approvalDependencies({
+    readRawChangeRecords() { return []; },
+    resolveBlobSizes() { blobReads += 1; return new Map(); },
+    classifyChangeRecords() { classifications += 1; throw new Error("empty diffs need no path classification"); },
+    listActionRequiredRuns() { return []; },
+  });
+  const result = mergeBatch.approveActionRequiredRuns("/repo", "owner/repo", prDetails, {
+    dependencies,
+    dryRun: true,
+  });
+  assert.strictEqual(result.policy.approvalSafe, true);
+  assert.deepStrictEqual(result.records, []);
+  assert.strictEqual(result.policy.requiresHumanReview, false);
+  assert.strictEqual(blobReads, 0);
+  assert.strictEqual(classifications, 0);
+}
+
+{
+  const prDetails = { number: 450, baseRefName: "main", baseRefOid: BASE_SHA, headRefOid: HEAD_SHA };
   const supportRecord = {
     status: "M",
     old_path: "skills/example/references/guide.md",


### PR DESCRIPTION
# Pull Request Description

Complete the zero-diff maintainer workflow by treating an authoritative empty merge-base-to-head raw diff as approval-safe inside `merge:batch`. The general workflow classifier remains fail-closed when change records are missing in any other context.

The regression test proves that an empty PR skips path and blob classification, requires no skill review, and still traverses the trusted evidence and workflow identity gates.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

None.

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; no `SKILL.md` changes.
- [x] **Risk Label**: Not applicable; no skill content changes.
- [x] **Triggers**: Not applicable; no skill content changes.
- [x] **Limitations**: Not applicable; no skill content changes.
- [x] **Security**: Not applicable; no offensive skill changes.
- [x] **Safety scan**: Not applicable; no skill command guidance, network examples, or token-like strings changed.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` changes.
- [x] **Manual Logic Review**: Reviewed the empty-diff trust boundary; the special case is limited to a locally fetched, merge-base-to-head Git diff and does not change the shared fail-closed classifier.
- [x] **Local Test**: `node tools/scripts/tests/merge_batch.test.js` passes; the immediately preceding parser fix passed the complete 111-test suite.
- [x] **Repo Checks**: No references changed; the targeted maintainer test passes.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Not applicable; no external source content added.
- [x] **License provenance**: Not applicable; no external skill source imported.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

## Screenshots (if applicable)

Not applicable.
