### PR TITLE
fix: allow zero-diff fork preflight

### DIFF
--- a/tools/scripts/pr_preflight.cjs
+++ b/tools/scripts/pr_preflight.cjs
@@ -199,6 +199,19 @@ function evaluateForkSafety(projectRoot, changeRecords, pullRequest) {
   if (headRepository === baseRepository) {
     return { applicable: false, approvalSafe: true, reasons: [], requiresHumanReview: false };
   }
+  if (Array.isArray(changeRecords) && changeRecords.length === 0) {
+    return {
+      applicable: true,
+      safe: true,
+      sensitive: false,
+      approvalSafe: true,
+      reasons: [],
+      paths: [],
+      requiresHumanReview: false,
+      canonicalSkillChanges: [],
+      skillContentChanges: [],
+    };
+  }
 
   const preliminary = classifyChangeRecords(changeRecords, { requireBlobSizes: false });
   if (!preliminary.approvalSafe) {

--- a/tools/scripts/tests/pr_preflight.test.js
+++ b/tools/scripts/tests/pr_preflight.test.js
@@ -79,6 +79,19 @@ assert.ok(
   `PR #974-style root walkthrough.md must fail before merge: ${walkthroughPolicy.reasons.join(", ")}`,
 );
 
+const emptyForkPolicy = evaluateForkSafety(
+  repoRoot,
+  [],
+  {
+    base: { repo: { full_name: "sickn33/agentic-awesome-skills" } },
+    head: { repo: { full_name: "community/example-fork" } },
+  },
+);
+assert.strictEqual(emptyForkPolicy.applicable, true);
+assert.strictEqual(emptyForkPolicy.approvalSafe, true);
+assert.strictEqual(emptyForkPolicy.requiresHumanReview, false);
+assert.deepStrictEqual(emptyForkPolicy.reasons, []);
+
 const readmeOid = spawnSync("git", ["rev-parse", "HEAD:README.md"], {
   cwd: repoRoot,
   encoding: "utf8",


### PR DESCRIPTION
# Pull Request Description

Allow the trusted fork-safety preflight to accept a zero-file Git diff. This completes the protected contributor-credit workflow after reviewed content has already landed through a maintainer intake PR.

The special case is confined to `evaluateForkSafety` after repository identities are validated and after Git has produced an authoritative empty diff. The shared change-record classifier remains fail-closed for missing evidence elsewhere.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

None.

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; no `SKILL.md` changes.
- [x] **Risk Label**: Not applicable; no skill content changes.
- [x] **Triggers**: Not applicable; no skill content changes.
- [x] **Limitations**: Not applicable; no skill content changes.
- [x] **Security**: Not applicable; no offensive skill changes.
- [x] **Safety scan**: Not applicable; no skill command guidance, network examples, or token-like strings changed.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` changes.
- [x] **Manual Logic Review**: Reviewed repository-identity validation, authoritative empty-diff handling, and the unchanged fail-closed classifier behavior.
- [x] **Local Test**: `pr_preflight.test.js`, `merge_batch.test.js`, and an end-to-end zero-diff fork preflight invocation pass.
- [x] **Repo Checks**: No references changed; targeted maintainer tests pass.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Not applicable; no external source content added.
- [x] **License provenance**: Not applicable; no external skill source imported.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

## Screenshots (if applicable)

Not applicable.
