### PR TITLE
fix: point UIZZE skill metadata at canonical source

### DIFF
--- a/skills/uizze-ui-research/SKILL.md
+++ b/skills/uizze-ui-research/SKILL.md
@@ -3,11 +3,11 @@ name: uizze-ui-research
 description: "Use when building or reviewing web and iOS UI and you need real references from the free UIZZE public catalog, a structured design contract, a consent-gated rendered HTML/CSS preview, or a hard pre-ship finish gate."
 category: design
 risk: safe
-source: https://github.com/aislon/uizze-mcp/tree/main/skills/uizze-ui-research
-source_repo: aislon/uizze-mcp
+source: https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop
+source_repo: uizze/uizze
 source_type: official
 license: MIT
-license_source: https://github.com/aislon/uizze-mcp/blob/main/LICENSE
+license_source: https://github.com/uizze/uizze/blob/main/LICENSE
 date_added: "2026-07-12"
 author: UIZZE
 tags: [ui-design, ui-research, mcp, design-contracts, agent-workflows]


### PR DESCRIPTION
## Summary
- repair the canonical source-backed UIZZE Skill record that still identifies retired `aislon/uizze-mcp` metadata
- point `source`, `source_repo`, and `license_source` at the canonical `uizze/uizze` `anti-ui-slop` Skill and MIT license
- keep the existing `uizze-ui-research` catalog ID and skill content unchanged

This follows the merged UIZZE refresh in #1166 and prevents the 45,000+ star catalog’s source record from sending users to a retired repository. The two plugin mirrors are generated copies and are intentionally left for the repository’s maintainer sync after this source-only PR merges.

## Verification
- `git diff --check`
- canonical source and license URLs both return HTTP 200
- generated registry artifacts and plugin mirrors are intentionally omitted per the repository’s source-only/fork-safety policy

Disclosure: UIZZE is my project; this is a canonical-source correction to an existing listing, not a new duplicate entry.
