### PR TITLE
feat: add stack artifact audit

### DIFF
--- a/docs/users/aas-core.md
+++ b/docs/users/aas-core.md
@@ -18,6 +18,7 @@ your project
   -> you review the artifacts
   -> aas stack validate
   -> aas stack plan (preview; no skill changes)
+  -> aas stack audit (optional cross-artifact consistency check)
 ```
 
 AAS MCP does not scan the repository and does not decide which skills are best. Codex or Claude uses its own project understanding and judgment. Every current catalog skill remains individually searchable, readable, and available for agent selection; missing or incomplete metadata never makes a skill ineligible. Core has no semantic policy that favors a small stack, while every stack manifest has an explicit technical maximum of 128 skills.
@@ -170,9 +171,16 @@ aas stack plan \
   --cache-root /absolute/path/to/aas-cache \
   --runtime-integrity '<npm-sri>' \
   --out /absolute/path/to/plan.json
+
+aas stack audit \
+  --manifest /absolute/path/to/aas-stack.json \
+  --evidence /absolute/path/to/aas-selection-evidence.json \
+  --plan /absolute/path/to/plan.json
 ```
 
 `stack validate` is read-only. `stack plan` writes only the requested plan artifact and does not materialize skills or AAS managed state in the target. The immutable plan binds the manifest, runtime, catalog, target identity, current managed state, and exact logical operations.
+
+`stack audit` is also read-only. It validates all three artifacts independently, resolves the manifest's pinned verified catalog, and reports whether their manifest digests, catalog identities, target, and selected skill IDs remain consistent. A structurally invalid or unverifiable artifact fails closed; a valid but differently bound artifact returns `status: "inconsistent"` with stable reason codes.
 
 Stop after reviewing the plan unless you are deliberately participating in controlled preview development. `stack apply` and `stack recover` remain experimental and require explicit opt-in.
 

--- a/tools/lib/aas-v1/cli/main.js
+++ b/tools/lib/aas-v1/cli/main.js
@@ -58,6 +58,7 @@ const COMMAND_OPTIONS = Object.freeze({
   "mcp backups cleanup": new Set(["config", "backup-dir", "keep", "approve", "help"]),
   "stack init": new Set(["goal", "catalog-digest", "cache-root", "host", "scope", "name", "out", "preview-windows-output", "help"]),
   "stack create": new Set(["selection", "evidence", "artifact-dir", "require-evidence", "catalog-digest", "cache-root", "out", "preview-windows-output", "help"]),
+  "stack audit": new Set(["manifest", "evidence", "plan", "cache-root", "help"]),
   "stack validate": new Set(["manifest", "help"]),
   "stack plan": new Set(["manifest", "target", "target-root", "cache-root", "runtime-version", "runtime-integrity", "out", "override-managed-drift", "preview-windows-output", "help"]),
   "stack apply": new Set(["plan", "target-root", "cache-root", "approve", "experimental-apply", "help"]),
@@ -456,6 +457,60 @@ async function stackPlan(options, dependencies = {}) {
   };
 }
 
+async function stackAudit(options) {
+  const manifest = readJsonFile(requireOption(options, "manifest"));
+  const manifestValidation = core.stack.validateManifest(manifest);
+  if (!manifestValidation.ok) {
+    throw cliError(manifestValidation.code, manifestValidation.category, manifestValidation.details);
+  }
+  const catalog = await catalogFor(options, manifest.catalog.integrity);
+  if (manifest.catalog.package !== catalog.package
+    || manifest.catalog.version !== catalog.version
+    || manifest.catalog.integrity !== catalog.digest) {
+    throw cliError("AAS_AUDIT_CATALOG_NOT_VERIFIED", "integrity", {});
+  }
+  for (const skill of manifest.skills) core.getSkill(catalog, skill.id);
+
+  const evidence = readJsonFile(requireOption(options, "evidence"));
+  const evidenceValidation = core.validateSelectionEvidence(evidence);
+  const plan = readJsonFile(requireOption(options, "plan"));
+  core.stack.validatePlanEnvelope(plan);
+
+  const manifestCatalog = manifest.catalog;
+  const manifestSkills = manifest.skills.map((skill) => skill.id).sort();
+  const manifestTargets = new Set(manifest.targets.map(targetKey));
+  const checks = {
+    evidenceManifest: evidence.payload.manifestDigest === manifestValidation.manifestDigest ? "match" : "mismatch",
+    planManifest: plan.payload.manifestDigest === manifestValidation.manifestDigest ? "match" : "mismatch",
+    catalog: core.canonicalJson(evidence.payload.catalog) === core.canonicalJson(manifestCatalog)
+      && core.canonicalJson(plan.payload.catalog) === core.canonicalJson(manifestCatalog) ? "match" : "mismatch",
+    target: manifestTargets.has(targetKey(plan.payload.target)) ? "match" : "mismatch",
+    skills: core.canonicalJson([...evidence.payload.selectedSkillIds].sort()) === core.canonicalJson(manifestSkills)
+      && core.canonicalJson([...plan.payload.desiredSkills].sort()) === core.canonicalJson(manifestSkills) ? "match" : "mismatch",
+  };
+  const reasonCodeByCheck = {
+    evidenceManifest: "AAS_AUDIT_EVIDENCE_MANIFEST_MISMATCH",
+    planManifest: "AAS_AUDIT_PLAN_MANIFEST_MISMATCH",
+    catalog: "AAS_AUDIT_CATALOG_MISMATCH",
+    target: "AAS_AUDIT_TARGET_MISMATCH",
+    skills: "AAS_AUDIT_SKILLS_MISMATCH",
+  };
+  const reasonCodes = Object.entries(checks)
+    .filter(([, status]) => status === "mismatch")
+    .map(([check]) => reasonCodeByCheck[check]);
+  return {
+    ok: true,
+    status: reasonCodes.length === 0 ? "consistent" : "inconsistent",
+    reasonCodes,
+    unknown: [],
+    details: {},
+    manifestDigest: manifestValidation.manifestDigest,
+    evidenceDigest: evidenceValidation.evidenceDigest,
+    planDigest: plan.digest,
+    checks,
+  };
+}
+
 function help() {
   return {
     ok: true,
@@ -468,6 +523,7 @@ function help() {
       "stack init --goal <goal> [--catalog-digest <sha256> --cache-root <absolute>] [--preview-windows-output]",
       "stack create --selection <json> --out <aas-stack.json> [--catalog-digest <sha256> --cache-root <absolute>]",
       "stack create --selection <json> --evidence <json> --artifact-dir <new-dir> --require-evidence [--catalog-digest <sha256> --cache-root <absolute>]",
+      "stack audit --manifest <aas-stack.json> --evidence <aas-selection-evidence.json> --plan <plan.json> [--cache-root <absolute>]",
       "stack validate --manifest <aas-stack.json>",
       "stack plan --manifest <file> --target <host:scope> --target-root <dir> --cache-root <absolute> --runtime-integrity <npm-sri> --out <file> [--preview-windows-output]",
       "stack apply --experimental-apply --plan <file> --target-root <dir> --cache-root <absolute> --approve <plan-digest> (EXPERIMENTAL; NOT CERTIFIED)",
@@ -634,6 +690,7 @@ async function execute(argv, dependencies = {}) {
   if (root !== "stack") throw cliError("AAS_CLI_COMMAND_UNKNOWN", "invalidInput", { command: root });
   if (command === "init") return stackInit(options);
   if (command === "create") return stackCreate(options);
+  if (command === "audit") return stackAudit(options);
   if (command === "validate") {
     const validation = core.stack.validateManifest(readJsonFile(requireOption(options, "manifest")));
     if (!validation.ok) throw cliError(validation.code, validation.category, validation.details);
@@ -739,6 +796,7 @@ module.exports = {
   mcpConfigure,
   parseOptions,
   readJsonFile,
+  stackAudit,
   stackPlan,
   windowsOutputDurabilityDetails,
   writeNewJson,

--- a/tools/scripts/tests/aas_v1_cli.test.js
+++ b/tools/scripts/tests/aas_v1_cli.test.js
@@ -34,6 +34,53 @@ function fixture() {
   return { root, runtime, dependencies };
 }
 
+function selectionEvidenceFor(catalog, manifest) {
+  const manifestDigest = core.stack.validateManifest(manifest).manifestDigest;
+  const fileDigest = core.sha256("package fixture");
+  const skillId = manifest.skills[0].id;
+  const capabilityId = "runtime-design";
+  return core.createSelectionEvidence({
+    catalog,
+    manifest,
+    project: {
+      schemaVersion: 1,
+      files: [{ path: "package.json", size: 15, sha256: fileDigest }],
+    },
+    dimensions: core.evidence.DIMENSION_IDS.map((id) => ({
+      id,
+      status: id === "architecture-runtime" ? "applicable" : "not-applicable",
+      capabilityIds: id === "architecture-runtime" ? [capabilityId] : [],
+    })),
+    capabilities: [{
+      id: capabilityId,
+      dimensionId: "architecture-runtime",
+      status: "covered",
+      evidence: [{ path: "package.json", sha256: fileDigest }],
+      selectedSkillIds: [skillId],
+    }],
+    processTrace: {
+      schemaVersion: 1,
+      calls: [{
+        sequence: 1,
+        tool: "compose_stack",
+        attempt: 1,
+        input: { skillIds: [skillId] },
+        output: { ok: true, manifestDigest, selectedSkillIds: [skillId] },
+        canonicalInputBytes: 25,
+        canonicalOutputBytes: 140,
+      }, {
+        sequence: 2,
+        tool: "inspect_stack",
+        attempt: 1,
+        input: { manifestDigest },
+        output: { ok: true, status: "valid", manifestDigest, selectedSkillIds: [skillId] },
+        canonicalInputBytes: 96,
+        canonicalOutputBytes: 160,
+      }],
+    },
+  });
+}
+
 test("Windows output reports certified durability without marking the preview fallback", () => {
   assert.deepEqual(
     windowsOutputDurabilityDetails({ outputDurability: "directorySynced", certificationStatus: "certifiable" }, "win32"),
@@ -120,6 +167,80 @@ test("CLI stack lifecycle persists an explicit agent selection, plans it, applie
     "--approve", plan.digest,
   ], item.dependencies);
   assert.equal(again.status, "alreadyApplied");
+});
+
+test("CLI stack audit verifies a bound manifest, selection evidence, and immutable plan without writes", async (context) => {
+  const item = fixture();
+  context.after(() => fs.rmSync(item.root, { recursive: true, force: true }));
+  const catalog = core.loadBundledCatalog({ root: ROOT });
+  const selectionPath = path.join(item.root, "selection.json");
+  const manifestPath = path.join(item.root, "aas-stack.json");
+  const evidencePath = path.join(item.root, "aas-selection-evidence.json");
+  const planPath = path.join(item.root, "plan.json");
+  fs.writeFileSync(selectionPath, `${core.canonicalJson({
+    name: "audited-stack",
+    targets: [{ host: "codex", scope: "project" }],
+    profile: { goals: ["audit agent artifacts"], languages: ["javascript"], frameworks: [], constraints: ["local-only"] },
+    skillIds: ["ai-agents-architect"],
+  })}\n`);
+  await execute(["stack", "create", "--selection", selectionPath, "--out", manifestPath]);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  fs.writeFileSync(evidencePath, `${core.canonicalJson(selectionEvidenceFor(catalog, manifest))}\n`);
+  await execute([
+    "stack", "plan", "--manifest", manifestPath, "--target", "codex:project",
+    "--target-root", item.root, "--out", planPath,
+  ], item.dependencies);
+  const before = fs.readdirSync(item.root).sort();
+
+  const result = await execute([
+    "stack", "audit", "--manifest", manifestPath, "--evidence", evidencePath, "--plan", planPath,
+  ]);
+
+  assert.equal(result.status, "consistent");
+  assert.deepEqual(result.reasonCodes, []);
+  assert.equal(result.manifestDigest, core.stack.validateManifest(manifest).manifestDigest);
+  assert.equal(result.evidenceDigest, JSON.parse(fs.readFileSync(evidencePath, "utf8")).digest);
+  assert.equal(result.planDigest, JSON.parse(fs.readFileSync(planPath, "utf8")).digest);
+  assert.deepEqual(fs.readdirSync(item.root).sort(), before, "audit must not write files");
+});
+
+test("CLI stack audit reports a valid plan bound to another manifest with stable reason codes", async (context) => {
+  const item = fixture();
+  context.after(() => fs.rmSync(item.root, { recursive: true, force: true }));
+  const catalog = core.loadBundledCatalog({ root: ROOT });
+  const composed = core.composeStack(catalog, {
+    name: "audited-stack",
+    targets: [{ host: "codex", scope: "project" }],
+    profile: { goals: ["audit agent artifacts"], languages: [], frameworks: [], constraints: [] },
+    skillIds: ["ai-agents-architect"],
+  });
+  const manifestPath = path.join(item.root, "aas-stack.json");
+  const evidencePath = path.join(item.root, "aas-selection-evidence.json");
+  const planPath = path.join(item.root, "plan.json");
+  fs.writeFileSync(manifestPath, `${core.canonicalJson(composed.manifest)}\n`);
+  fs.writeFileSync(evidencePath, `${core.canonicalJson(selectionEvidenceFor(catalog, composed.manifest))}\n`);
+  await execute([
+    "stack", "plan", "--manifest", manifestPath, "--target", "codex:project",
+    "--target-root", item.root, "--out", planPath,
+  ], item.dependencies);
+  const plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+  plan.payload.manifestDigest = `sha256-${"f".repeat(64)}`;
+  plan.digest = core.sha256(core.canonicalJson(plan.payload));
+  fs.writeFileSync(planPath, `${core.canonicalJson(plan)}\n`);
+
+  const result = await execute([
+    "stack", "audit", "--manifest", manifestPath, "--evidence", evidencePath, "--plan", planPath,
+  ]);
+
+  assert.equal(result.status, "inconsistent");
+  assert.deepEqual(result.reasonCodes, ["AAS_AUDIT_PLAN_MANIFEST_MISMATCH"]);
+  assert.deepEqual(result.checks, {
+    evidenceManifest: "match",
+    planManifest: "mismatch",
+    catalog: "match",
+    target: "match",
+    skills: "match",
+  });
 });
 
 test("CLI exits stably on missing approval and never prints a stack trace", async () => {


### PR DESCRIPTION
# Pull Request Description

## Summary

Add a read-only `aas stack audit` command that validates a stack manifest,
selection-evidence sidecar, and immutable plan as one artifact set. The command
reports stable mismatch reason codes for manifest binding, catalog identity,
target, and selected skills without writing project or managed state.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; this PR does not change a `SKILL.md` file.
- [x] **Risk Label**: Not applicable; this PR does not add or modify a skill.
- [x] **Triggers**: Not applicable; this PR does not add or modify a skill.
- [x] **Limitations**: The user documentation states that audit is read-only, fails closed on invalid or unverifiable artifacts, and reports valid binding mismatches separately.
- [x] **Security**: Not applicable; this PR is not an offensive skill.
- [x] **Safety scan**: `npm run security:docs` passed.
- [x] **Automated Skill Review**: Not applicable; this PR does not change `SKILL.md`.
- [x] **Manual Logic Review**: The artifact validation, catalog verification, mismatch mapping, and no-write behavior were manually reviewed.
- [x] **Local Test**: The AAS v1 CLI suite passes with 18/18 tests, including consistent and mismatched artifact sets.
- [x] **Repo Checks**: `npm run validate`, `npm run validate:references`, and `npm run security:docs` passed.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Not applicable; no external source was imported.
- [x] **License provenance**: Not applicable; no external source was imported.
- [x] **Maintainer Edits**: Allow edits from maintainers is enabled.

## Validation

```text
node --test tools/scripts/tests/aas_v1_cli.test.js  # 18 passed
npm run validate                                    # passed
npm run validate:references                         # passed
npm run security:docs                               # passed
git diff --check                                    # passed
```

## Known Limitations / Risks

- Audit verifies artifact structure and bindings against a locally verified catalog; it does not inspect whether a plan was applied to a host.
- A valid but differently bound artifact is reported as `inconsistent`; structurally invalid or unverifiable input still fails closed.
- A full local `npm test` run exercised the changed CLI tests successfully, but the repository-wide runner's final status was not captured after a long runtime test; required CI remains authoritative.

## AI Assistance Disclosure

AI assistance was used to inspect repository contracts, implement the command and tests, and draft this PR. The resulting diff and validation output were manually reviewed.

## Screenshots (if applicable)

Not applicable; this is a CLI and documentation change.
