### PR TITLE
feat: add paired Workbench artifact review

### DIFF
--- a/apps/web-app/src/index.css
+++ b/apps/web-app/src/index.css
@@ -1334,6 +1334,87 @@ textarea {
   margin: 26px auto 0;
 }
 
+.workbench-pair-review {
+  border: 1px solid var(--stroke-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-card);
+}
+
+.workbench-pair-review > header,
+.workbench-pair-review > ul,
+.workbench-pair-review > p {
+  margin: 0;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--stroke-subtle);
+}
+
+.workbench-pair-review > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.workbench-pair-review > header p {
+  margin: 0 0 4px;
+  color: var(--accent-solid);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.workbench-pair-review--inconsistent > header p,
+.workbench-pair-review--inconsistent li strong {
+  color: var(--status-danger, #c02c3f);
+}
+
+.workbench-pair-review h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.workbench-pair-review > header span {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
+.workbench-pair-review ul {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0 20px;
+  list-style: none;
+}
+
+.workbench-pair-review li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--stroke-subtle);
+  font-size: 0.74rem;
+}
+
+.workbench-pair-review li span {
+  color: var(--text-secondary);
+}
+
+.workbench-pair-review li strong {
+  color: var(--accent-solid);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+}
+
+.workbench-pair-review > :last-child {
+  border-bottom: 0;
+}
+
+.workbench-pair-review__note {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
 .workbench-review-empty {
   padding: 72px 24px;
   border: 1px dashed var(--stroke-strong);
@@ -2373,6 +2454,15 @@ textarea {
   }
 
   .workbench-review__operation-list .workbench-review__facts {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .workbench-pair-review > header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .workbench-pair-review > ul {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/apps/web-app/src/pages/Workbench.tsx
+++ b/apps/web-app/src/pages/Workbench.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useRef, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { usePageMeta } from '../hooks/usePageMeta';
 import {
   WORKBENCH_MAX_IMPORT_BYTES,
@@ -6,6 +6,8 @@ import {
   WorkbenchImportError,
   parseWorkbenchArtifact,
   readWorkbenchFile,
+  reviewWorkbenchPair,
+  sha256WorkbenchDigest,
   verifyPlanDigest,
   type PlanReview,
   type StackManifestReview,
@@ -207,6 +209,50 @@ function PlanReviewView({ plan }: { plan: PlanReview }): React.ReactElement {
   );
 }
 
+function PairReview({ stack, plan }: { stack: StackManifestReview; plan: PlanReview }): React.ReactElement {
+  const [review, setReview] = useState<ReturnType<typeof reviewWorkbenchPair> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void sha256WorkbenchDigest(stack).then((manifestDigest) => {
+      if (active) {
+        setReview(reviewWorkbenchPair(stack, plan, manifestDigest));
+        setError(null);
+      }
+    }).catch((reason: unknown) => {
+      if (active) setError(displayError(reason));
+    });
+    return () => { active = false; };
+  }, [stack, plan]);
+
+  if (error) {
+    return <section className="workbench-pair-review workbench-pair-review--error" aria-live="polite"><h2>Artifact consistency</h2><p role="alert">{error}</p></section>;
+  }
+  if (!review) return <section className="workbench-pair-review" aria-live="polite"><h2>Artifact consistency</h2><p>Checking bindings…</p></section>;
+  const consistent = review.status === 'consistent';
+  return (
+    <section className={`workbench-pair-review ${consistent ? 'workbench-pair-review--consistent' : 'workbench-pair-review--inconsistent'}`} aria-labelledby="pair-review-title">
+      <header>
+        <div>
+          <p>{consistent ? 'All bindings match' : 'Bindings need attention'}</p>
+          <h2 id="pair-review-title">Artifact consistency</h2>
+        </div>
+        <span>{consistent ? 'Ready to compare' : `${review.checks.filter((check) => check.status === 'mismatch').length} mismatches`}</span>
+      </header>
+      <ul aria-label="Artifact consistency checks">
+        {review.checks.map((check) => (
+          <li key={check.id}>
+            <span>{check.label}</span>
+            <strong>{check.status === 'match' ? 'Match' : 'Mismatch'}</strong>
+          </li>
+        ))}
+      </ul>
+      <p className="workbench-pair-review__note">This comparison uses only the two imported artifacts and stays in page memory.</p>
+    </section>
+  );
+}
+
 function ArtifactImporter<T>({
   kind,
   title,
@@ -354,6 +400,7 @@ export function Workbench(): React.ReactElement {
       </div>
 
       <section className="workbench-review-area" aria-label="Imported artifact review">
+        {stack.value && plan.value ? <PairReview stack={stack.value} plan={plan.value} /> : null}
         {stack.value ? <StackReview stack={stack.value} /> : null}
         {plan.value ? <PlanReviewView plan={plan.value} /> : null}
         {!stack.value && !plan.value ? (

--- a/apps/web-app/src/pages/__tests__/Workbench.test.tsx
+++ b/apps/web-app/src/pages/__tests__/Workbench.test.tsx
@@ -76,6 +76,16 @@ function planFixture(reasonCode = 'AAS_MANAGED_DRIFT_APPROVED'): Record<string, 
   return plan;
 }
 
+async function boundPlanFixture(): Promise<Record<string, unknown>> {
+  const stack = stackFixture();
+  const manifestDigest = `sha256-${createHash('sha256').update(canonicalWorkbenchJson(stack)).digest('hex')}`;
+  const plan = planFixture() as { digest: string; payload: Record<string, unknown> };
+  plan.payload.manifestDigest = manifestDigest;
+  plan.payload.desiredSkills = ['react-best-practices', 'playwright-skill'];
+  plan.digest = `sha256-${createHash('sha256').update(canonicalWorkbenchJson(plan.payload)).digest('hex')}`;
+  return plan;
+}
+
 function paste(label: 'Paste JSON', value: unknown, index = 0): void {
   const inputs = screen.getAllByLabelText(label);
   fireEvent.change(inputs[index], { target: { value: JSON.stringify(value) } });
@@ -112,6 +122,34 @@ describe('Workbench review UI', () => {
     expect(screen.getAllByText('AAS_MANAGED_DRIFT_APPROVED', { exact: false })).toHaveLength(2);
     expect(screen.getByText('1 overrides')).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: 'Bound project profile' })).toBeInTheDocument();
+  });
+
+  it('shows a paired consistency gate after a bound stack and plan are both loaded', async () => {
+    renderWithRouter(<Workbench />, { route: '/workbench', path: '/workbench', useProvider: false });
+    paste('Paste JSON', stackFixture());
+    fireEvent.click(screen.getByRole('button', { name: 'Review pasted stack' }));
+    paste('Paste JSON', await boundPlanFixture(), 1);
+    fireEvent.click(screen.getByRole('button', { name: 'Review pasted plan' }));
+
+    expect(await screen.findByText('All bindings match')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Artifact consistency' })).toBeInTheDocument();
+    for (const label of ['Manifest digest', 'Catalog identity', 'Selected skills', 'Plan target']) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+    }
+    expect(screen.getAllByText('Match')).toHaveLength(4);
+  });
+
+  it('surfaces a selected-skill mismatch without hiding either valid artifact', async () => {
+    renderWithRouter(<Workbench />, { route: '/workbench', path: '/workbench', useProvider: false });
+    paste('Paste JSON', stackFixture());
+    fireEvent.click(screen.getByRole('button', { name: 'Review pasted stack' }));
+    paste('Paste JSON', planFixture(), 1);
+    fireEvent.click(screen.getByRole('button', { name: 'Review pasted plan' }));
+
+    expect(await screen.findByText('Bindings need attention')).toBeInTheDocument();
+    expect(screen.getAllByText('Mismatch').length).toBeGreaterThan(0);
+    expect(screen.getByRole('heading', { level: 2, name: 'reviewed-web-stack' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Single-target change review' })).toBeInTheDocument();
   });
 
   it('fails closed on schema drift and clears the previous review', () => {

--- a/apps/web-app/src/utils/__tests__/workbenchReview.test.ts
+++ b/apps/web-app/src/utils/__tests__/workbenchReview.test.ts
@@ -3,8 +3,10 @@ import {
   WORKBENCH_MAX_IMPORT_BYTES,
   WORKBENCH_MAX_JSON_DEPTH,
   WorkbenchImportError,
+  type WorkbenchPairPlan,
   parseWorkbenchArtifact,
   readWorkbenchFile,
+  reviewWorkbenchPair,
 } from '../workbenchReview';
 
 const D = `sha256-${'a'.repeat(64)}`;
@@ -27,6 +29,38 @@ function validStack(): Record<string, unknown> {
 }
 
 describe('workbenchReview', () => {
+  it('compares manifest digest, catalog, desired skills, and target across a stack-plan pair', async () => {
+    const stack = parseWorkbenchArtifact(JSON.stringify(validStack()), 'stack');
+    expect(stack.kind).toBe('stack');
+    if (stack.kind !== 'stack') throw new Error('expected stack');
+    const stackDigest = `sha256-${'b'.repeat(64)}`;
+    const matchingPlan: WorkbenchPairPlan = {
+      payload: {
+        manifestDigest: stackDigest,
+        catalog: stack.value.catalog,
+        desiredSkills: ['react-best-practices'],
+        target: { host: 'codex', scope: 'project' },
+      },
+    };
+
+    expect(reviewWorkbenchPair(stack.value, matchingPlan, stackDigest)).toEqual({
+      status: 'consistent',
+      checks: [
+        { id: 'manifestDigest', label: 'Manifest digest', status: 'match' },
+        { id: 'catalog', label: 'Catalog identity', status: 'match' },
+        { id: 'skills', label: 'Selected skills', status: 'match' },
+        { id: 'target', label: 'Plan target', status: 'match' },
+      ],
+    });
+
+    const mismatchedPlan = structuredClone(matchingPlan);
+    mismatchedPlan.payload.desiredSkills = ['other-skill'];
+    mismatchedPlan.payload.target = { host: 'claude', scope: 'user' };
+    const mismatch = reviewWorkbenchPair(stack.value, mismatchedPlan, stackDigest);
+    expect(mismatch.status).toBe('inconsistent');
+    expect(mismatch.checks.filter((check) => check.status === 'mismatch').map((check) => check.id)).toEqual(['skills', 'target']);
+  });
+
   it('accepts the public stack shape and rejects duplicate skill IDs', () => {
     expect(parseWorkbenchArtifact(JSON.stringify(validStack()), 'stack').kind).toBe('stack');
     const withoutProjectType = validStack();

--- a/apps/web-app/src/utils/workbenchReview.ts
+++ b/apps/web-app/src/utils/workbenchReview.ts
@@ -90,6 +90,20 @@ export type ParsedWorkbenchArtifact =
   | { kind: 'stack'; value: StackManifestReview }
   | { kind: 'plan'; value: PlanReview };
 
+export type PairCheckId = 'manifestDigest' | 'catalog' | 'skills' | 'target';
+export interface WorkbenchPairReview {
+  status: 'consistent' | 'inconsistent';
+  checks: Array<{ id: PairCheckId; label: string; status: 'match' | 'mismatch' }>;
+}
+export interface WorkbenchPairPlan {
+  payload: {
+    manifestDigest: string;
+    catalog: CatalogIdentity;
+    desiredSkills: string[];
+    target: Target;
+  };
+}
+
 export class WorkbenchImportError extends Error {
   constructor(message: string) {
     super(message);
@@ -385,6 +399,55 @@ function canonicalize(value: unknown): unknown {
 
 export function canonicalWorkbenchJson(value: unknown): string {
   return JSON.stringify(canonicalize(value));
+}
+
+function targetKey(target: Target): string {
+  return `${target.host}:${target.scope}`;
+}
+
+function sortedIds(ids: string[]): string[] {
+  return [...ids].sort((left, right) => left.localeCompare(right));
+}
+
+export function reviewWorkbenchPair(
+  stack: StackManifestReview,
+  plan: WorkbenchPairPlan,
+  stackManifestDigest: string,
+): WorkbenchPairReview {
+  const checks: WorkbenchPairReview['checks'] = [
+    {
+      id: 'manifestDigest',
+      label: 'Manifest digest',
+      status: plan.payload.manifestDigest === stackManifestDigest ? 'match' : 'mismatch',
+    },
+    {
+      id: 'catalog',
+      label: 'Catalog identity',
+      status: canonicalWorkbenchJson(stack.catalog) === canonicalWorkbenchJson(plan.payload.catalog) ? 'match' : 'mismatch',
+    },
+    {
+      id: 'skills',
+      label: 'Selected skills',
+      status: canonicalWorkbenchJson(sortedIds(stack.skills.map((skill) => skill.id)))
+        === canonicalWorkbenchJson(sortedIds(plan.payload.desiredSkills)) ? 'match' : 'mismatch',
+    },
+    {
+      id: 'target',
+      label: 'Plan target',
+      status: stack.targets.some((target) => targetKey(target) === targetKey(plan.payload.target)) ? 'match' : 'mismatch',
+    },
+  ];
+  return {
+    status: checks.every((check) => check.status === 'match') ? 'consistent' : 'inconsistent',
+    checks,
+  };
+}
+
+export async function sha256WorkbenchDigest(value: unknown): Promise<string> {
+  if (!globalThis.crypto?.subtle) fail('This browser cannot verify artifact digests.');
+  const bytes = new TextEncoder().encode(canonicalWorkbenchJson(value));
+  const digestBytes = new Uint8Array(await globalThis.crypto.subtle.digest('SHA-256', bytes));
+  return `sha256-${Array.from(digestBytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
 }
 
 export async function verifyPlanDigest(plan: PlanReview): Promise<boolean> {


### PR DESCRIPTION
# Pull Request Description

## Summary

Add an in-browser consistency gate when a user imports both an AAS stack
manifest and immutable plan into Workbench. The review compares the manifest
digest, catalog identity, selected skills, and target while keeping both
artifacts in page memory and preserving the existing read-only boundary.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; this PR does not change a `SKILL.md` file.
- [x] **Risk Label**: Not applicable; this PR does not add or modify a skill.
- [x] **Triggers**: Not applicable; this PR does not add or modify a skill.
- [x] **Limitations**: The UI explicitly states that comparison stays in page memory and does not install, apply, share, persist, or use the network.
- [x] **Security**: Not applicable; this PR is not an offensive skill.
- [x] **Safety scan**: Existing Workbench import limits and strict schema projection remain unchanged.
- [x] **Automated Skill Review**: Not applicable; this PR does not change `SKILL.md`.
- [x] **Manual Logic Review**: Canonical digest parity, target matching, set-equivalent skill matching, and async UI lifecycle were manually reviewed.
- [x] **Local Test**: The full web-app suite passes with 21 files and 176 tests.
- [x] **Repo Checks**: TypeScript, Vite build, prerender, and `git diff --check` passed.
- [x] **Source-Only PR**: Generated sitemap, catalog, copied skills, and build output are not included.
- [x] **Credits**: Not applicable; no external source was imported.
- [x] **License provenance**: Not applicable; no external source was imported.
- [x] **Maintainer Edits**: Allow edits from maintainers is enabled.

## Validation

```text
npm run app:setup && npm run app:test   # 21 files, 176 tests passed
npm run app:build                       # TypeScript, Vite, prerender passed
git diff --check                        # passed
```

Local browser smoke testing also loaded a synthetic stack/plan pair at
`/workbench/`, displayed all four checks, reported a manifest mismatch without
hiding either artifact, emitted no console errors, and showed no horizontal
overflow at 1280 px or 390 px widths.

## Known Limitations / Risks

- The page verifies the imported relationship only; it does not fetch catalog bytes or prove deployed host state.
- The consistency panel appears only after both individually valid artifacts are loaded.
- Reloading the page clears both artifacts by design.

## AI Assistance Disclosure

AI assistance was used to inspect Workbench conventions, implement the review utility and UI, exercise responsive browser states, and draft this PR. The resulting diff and validation output were manually reviewed.

## Screenshots (if applicable)

Responsive behavior was exercised locally at desktop and mobile widths; no screenshot artifact is attached because the PR can be verified with synthetic local inputs and automated tests.
