### PR TITLE
fix(youtube-summarizer): support youtube-transcript-api 1.x

### DIFF
--- a/plugins/agentic-awesome-skills-claude/skills/youtube-summarizer/SKILL.md
+++ b/plugins/agentic-awesome-skills-claude/skills/youtube-summarizer/SKILL.md
@@ -157,11 +157,18 @@ echo "[████████░░░░░░░░░░░░] 40% - Step 
 from youtube_transcript_api import YouTubeTranscriptApi, TranscriptsDisabled, NoTranscriptFound
 import sys
 
+# youtube-transcript-api 1.0 replaced the get_transcript/list_transcripts class
+# methods with an instance API. Support both versions.
+_legacy = hasattr(YouTubeTranscriptApi, 'get_transcript')
+
 video_id = sys.argv[1]
 
 try:
     # Get list of available transcripts
-    transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    if _legacy:
+        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    else:
+        transcript_list = YouTubeTranscriptApi().list(video_id)
     
     print(f"✅ Video accessible: {video_id}")
     print("📝 Available transcripts:")
@@ -207,22 +214,29 @@ echo "[████████████░░░░░░░░] 60% - Step 
 ```python
 from youtube_transcript_api import YouTubeTranscriptApi
 
+# youtube-transcript-api 1.0 replaced the get_transcript/list_transcripts class
+# methods with an instance API. Support both versions.
+_legacy = hasattr(YouTubeTranscriptApi, 'get_transcript')
+
 video_id = "VIDEO_ID"
 
 try:
     # Try to get transcript in user's preferred language first
     # Fall back to English if not available
-    transcript = YouTubeTranscriptApi.get_transcript(
-        video_id, 
-        languages=['pt', 'en']  # Prefer Portuguese, fallback to English
-    )
+    languages = ['pt', 'en']  # Prefer Portuguese, fallback to English
+    if _legacy:
+        transcript = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+    else:
+        transcript = YouTubeTranscriptApi().fetch(video_id, languages=languages).to_raw_data()
     
     # Combine transcript segments into full text
     full_text = " ".join([entry['text'] for entry in transcript])
     
     # Get video metadata
-    from youtube_transcript_api import YouTubeTranscriptApi
-    transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    if _legacy:
+        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    else:
+        transcript_list = YouTubeTranscriptApi().list(video_id)
     
     print("✅ Transcript extracted successfully")
     print(f"📊 Transcript length: {len(full_text)} characters")

--- a/plugins/agentic-awesome-skills-claude/skills/youtube-summarizer/scripts/extract-transcript.py
+++ b/plugins/agentic-awesome-skills-claude/skills/youtube-summarizer/scripts/extract-transcript.py
@@ -1,25 +1,55 @@
 #!/usr/bin/env python3
 """
 Extract YouTube video transcript
-Usage: ./extract-transcript.py VIDEO_ID [LANGUAGE_CODE]
+Usage: ./extract-transcript.py VIDEO_ID_OR_URL [LANGUAGE_CODE]
 """
 
+import re
 import sys
 from youtube_transcript_api import YouTubeTranscriptApi, TranscriptsDisabled, NoTranscriptFound
+
+# Windows consoles default to a legacy codepage that cannot encode the emoji below,
+# or non-Latin transcript text. Force UTF-8 so output never dies on encoding.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, 'reconfigure'):
+        _stream.reconfigure(encoding='utf-8', errors='replace')
+
+# youtube-transcript-api 1.0 replaced the class methods get_transcript/list_transcripts
+# with an instance API (fetch/list). Support both so the skill works on either version.
+_IS_LEGACY_API = hasattr(YouTubeTranscriptApi, 'get_transcript')
+
+def parse_video_id(value):
+    """Accept a bare video ID or any common YouTube URL form"""
+    if not re.search(r'[/.]', value):
+        return value
+
+    patterns = [
+        r'(?:v=|/embed/|/shorts/|/live/|youtu\.be/)([A-Za-z0-9_-]{11})',
+        r'/v/([A-Za-z0-9_-]{11})',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, value)
+        if match:
+            return match.group(1)
+
+    print(f"❌ Could not find a video ID in: {value}", file=sys.stderr)
+    sys.exit(1)
 
 def extract_transcript(video_id, language='en'):
     """Extract transcript from YouTube video"""
     try:
         # Try to get transcript in specified language with fallback to English
-        transcript = YouTubeTranscriptApi.get_transcript(
-            video_id,
-            languages=[language, 'en']
-        )
-        
+        languages = [language, 'en'] if language != 'en' else ['en']
+
+        if _IS_LEGACY_API:
+            transcript = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+        else:
+            transcript = YouTubeTranscriptApi().fetch(video_id, languages=languages).to_raw_data()
+
         # Combine all transcript segments
         full_text = " ".join([entry['text'] for entry in transcript])
         return full_text
-        
+
     except TranscriptsDisabled:
         print(f"❌ Transcripts are disabled for video {video_id}", file=sys.stderr)
         sys.exit(1)
@@ -33,7 +63,10 @@ def extract_transcript(video_id, language='en'):
 def list_available_transcripts(video_id):
     """List all available transcripts for a video"""
     try:
-        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        if _IS_LEGACY_API:
+            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        else:
+            transcript_list = YouTubeTranscriptApi().list(video_id)
         print(f"✅ Available transcripts for {video_id}:")
         
         for transcript in transcript_list:
@@ -48,11 +81,11 @@ def list_available_transcripts(video_id):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: ./extract-transcript.py VIDEO_ID [LANGUAGE_CODE]")
-        print("       ./extract-transcript.py VIDEO_ID --list  (list available transcripts)")
+        print("Usage: ./extract-transcript.py VIDEO_ID_OR_URL [LANGUAGE_CODE]")
+        print("       ./extract-transcript.py VIDEO_ID_OR_URL --list  (list available transcripts)")
         sys.exit(1)
-    
-    video_id = sys.argv[1]
+
+    video_id = parse_video_id(sys.argv[1])
     
     # Check if user wants to list available transcripts
     if len(sys.argv) > 2 and sys.argv[2] == "--list":

--- a/plugins/agentic-awesome-skills/skills/youtube-summarizer/SKILL.md
+++ b/plugins/agentic-awesome-skills/skills/youtube-summarizer/SKILL.md
@@ -157,11 +157,18 @@ echo "[████████░░░░░░░░░░░░] 40% - Step 
 from youtube_transcript_api import YouTubeTranscriptApi, TranscriptsDisabled, NoTranscriptFound
 import sys
 
+# youtube-transcript-api 1.0 replaced the get_transcript/list_transcripts class
+# methods with an instance API. Support both versions.
+_legacy = hasattr(YouTubeTranscriptApi, 'get_transcript')
+
 video_id = sys.argv[1]
 
 try:
     # Get list of available transcripts
-    transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    if _legacy:
+        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    else:
+        transcript_list = YouTubeTranscriptApi().list(video_id)
     
     print(f"✅ Video accessible: {video_id}")
     print("📝 Available transcripts:")
@@ -207,22 +214,29 @@ echo "[████████████░░░░░░░░] 60% - Step 
 ```python
 from youtube_transcript_api import YouTubeTranscriptApi
 
+# youtube-transcript-api 1.0 replaced the get_transcript/list_transcripts class
+# methods with an instance API. Support both versions.
+_legacy = hasattr(YouTubeTranscriptApi, 'get_transcript')
+
 video_id = "VIDEO_ID"
 
 try:
     # Try to get transcript in user's preferred language first
     # Fall back to English if not available
-    transcript = YouTubeTranscriptApi.get_transcript(
-        video_id, 
-        languages=['pt', 'en']  # Prefer Portuguese, fallback to English
-    )
+    languages = ['pt', 'en']  # Prefer Portuguese, fallback to English
+    if _legacy:
+        transcript = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+    else:
+        transcript = YouTubeTranscriptApi().fetch(video_id, languages=languages).to_raw_data()
     
     # Combine transcript segments into full text
     full_text = " ".join([entry['text'] for entry in transcript])
     
     # Get video metadata
-    from youtube_transcript_api import YouTubeTranscriptApi
-    transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    if _legacy:
+        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    else:
+        transcript_list = YouTubeTranscriptApi().list(video_id)
     
     print("✅ Transcript extracted successfully")
     print(f"📊 Transcript length: {len(full_text)} characters")

--- a/plugins/agentic-awesome-skills/skills/youtube-summarizer/scripts/extract-transcript.py
+++ b/plugins/agentic-awesome-skills/skills/youtube-summarizer/scripts/extract-transcript.py
@@ -1,25 +1,55 @@
 #!/usr/bin/env python3
 """
 Extract YouTube video transcript
-Usage: ./extract-transcript.py VIDEO_ID [LANGUAGE_CODE]
+Usage: ./extract-transcript.py VIDEO_ID_OR_URL [LANGUAGE_CODE]
 """
 
+import re
 import sys
 from youtube_transcript_api import YouTubeTranscriptApi, TranscriptsDisabled, NoTranscriptFound
+
+# Windows consoles default to a legacy codepage that cannot encode the emoji below,
+# or non-Latin transcript text. Force UTF-8 so output never dies on encoding.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, 'reconfigure'):
+        _stream.reconfigure(encoding='utf-8', errors='replace')
+
+# youtube-transcript-api 1.0 replaced the class methods get_transcript/list_transcripts
+# with an instance API (fetch/list). Support both so the skill works on either version.
+_IS_LEGACY_API = hasattr(YouTubeTranscriptApi, 'get_transcript')
+
+def parse_video_id(value):
+    """Accept a bare video ID or any common YouTube URL form"""
+    if not re.search(r'[/.]', value):
+        return value
+
+    patterns = [
+        r'(?:v=|/embed/|/shorts/|/live/|youtu\.be/)([A-Za-z0-9_-]{11})',
+        r'/v/([A-Za-z0-9_-]{11})',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, value)
+        if match:
+            return match.group(1)
+
+    print(f"❌ Could not find a video ID in: {value}", file=sys.stderr)
+    sys.exit(1)
 
 def extract_transcript(video_id, language='en'):
     """Extract transcript from YouTube video"""
     try:
         # Try to get transcript in specified language with fallback to English
-        transcript = YouTubeTranscriptApi.get_transcript(
-            video_id,
-            languages=[language, 'en']
-        )
-        
+        languages = [language, 'en'] if language != 'en' else ['en']
+
+        if _IS_LEGACY_API:
+            transcript = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+        else:
+            transcript = YouTubeTranscriptApi().fetch(video_id, languages=languages).to_raw_data()
+
         # Combine all transcript segments
         full_text = " ".join([entry['text'] for entry in transcript])
         return full_text
-        
+
     except TranscriptsDisabled:
         print(f"❌ Transcripts are disabled for video {video_id}", file=sys.stderr)
         sys.exit(1)
@@ -33,7 +63,10 @@ def extract_transcript(video_id, language='en'):
 def list_available_transcripts(video_id):
     """List all available transcripts for a video"""
     try:
-        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        if _IS_LEGACY_API:
+            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        else:
+            transcript_list = YouTubeTranscriptApi().list(video_id)
         print(f"✅ Available transcripts for {video_id}:")
         
         for transcript in transcript_list:
@@ -48,11 +81,11 @@ def list_available_transcripts(video_id):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: ./extract-transcript.py VIDEO_ID [LANGUAGE_CODE]")
-        print("       ./extract-transcript.py VIDEO_ID --list  (list available transcripts)")
+        print("Usage: ./extract-transcript.py VIDEO_ID_OR_URL [LANGUAGE_CODE]")
+        print("       ./extract-transcript.py VIDEO_ID_OR_URL --list  (list available transcripts)")
         sys.exit(1)
-    
-    video_id = sys.argv[1]
+
+    video_id = parse_video_id(sys.argv[1])
     
     # Check if user wants to list available transcripts
     if len(sys.argv) > 2 and sys.argv[2] == "--list":

--- a/skills/youtube-summarizer/SKILL.md
+++ b/skills/youtube-summarizer/SKILL.md
@@ -157,11 +157,18 @@ echo "[████████░░░░░░░░░░░░] 40% - Step 
 from youtube_transcript_api import YouTubeTranscriptApi, TranscriptsDisabled, NoTranscriptFound
 import sys
 
+# youtube-transcript-api 1.0 replaced the get_transcript/list_transcripts class
+# methods with an instance API. Support both versions.
+_legacy = hasattr(YouTubeTranscriptApi, 'get_transcript')
+
 video_id = sys.argv[1]
 
 try:
     # Get list of available transcripts
-    transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    if _legacy:
+        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    else:
+        transcript_list = YouTubeTranscriptApi().list(video_id)
     
     print(f"✅ Video accessible: {video_id}")
     print("📝 Available transcripts:")
@@ -207,22 +214,29 @@ echo "[████████████░░░░░░░░] 60% - Step 
 ```python
 from youtube_transcript_api import YouTubeTranscriptApi
 
+# youtube-transcript-api 1.0 replaced the get_transcript/list_transcripts class
+# methods with an instance API. Support both versions.
+_legacy = hasattr(YouTubeTranscriptApi, 'get_transcript')
+
 video_id = "VIDEO_ID"
 
 try:
     # Try to get transcript in user's preferred language first
     # Fall back to English if not available
-    transcript = YouTubeTranscriptApi.get_transcript(
-        video_id, 
-        languages=['pt', 'en']  # Prefer Portuguese, fallback to English
-    )
+    languages = ['pt', 'en']  # Prefer Portuguese, fallback to English
+    if _legacy:
+        transcript = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+    else:
+        transcript = YouTubeTranscriptApi().fetch(video_id, languages=languages).to_raw_data()
     
     # Combine transcript segments into full text
     full_text = " ".join([entry['text'] for entry in transcript])
     
     # Get video metadata
-    from youtube_transcript_api import YouTubeTranscriptApi
-    transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    if _legacy:
+        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+    else:
+        transcript_list = YouTubeTranscriptApi().list(video_id)
     
     print("✅ Transcript extracted successfully")
     print(f"📊 Transcript length: {len(full_text)} characters")

--- a/skills/youtube-summarizer/scripts/extract-transcript.py
+++ b/skills/youtube-summarizer/scripts/extract-transcript.py
@@ -1,25 +1,55 @@
 #!/usr/bin/env python3
 """
 Extract YouTube video transcript
-Usage: ./extract-transcript.py VIDEO_ID [LANGUAGE_CODE]
+Usage: ./extract-transcript.py VIDEO_ID_OR_URL [LANGUAGE_CODE]
 """
 
+import re
 import sys
 from youtube_transcript_api import YouTubeTranscriptApi, TranscriptsDisabled, NoTranscriptFound
+
+# Windows consoles default to a legacy codepage that cannot encode the emoji below,
+# or non-Latin transcript text. Force UTF-8 so output never dies on encoding.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, 'reconfigure'):
+        _stream.reconfigure(encoding='utf-8', errors='replace')
+
+# youtube-transcript-api 1.0 replaced the class methods get_transcript/list_transcripts
+# with an instance API (fetch/list). Support both so the skill works on either version.
+_IS_LEGACY_API = hasattr(YouTubeTranscriptApi, 'get_transcript')
+
+def parse_video_id(value):
+    """Accept a bare video ID or any common YouTube URL form"""
+    if not re.search(r'[/.]', value):
+        return value
+
+    patterns = [
+        r'(?:v=|/embed/|/shorts/|/live/|youtu\.be/)([A-Za-z0-9_-]{11})',
+        r'/v/([A-Za-z0-9_-]{11})',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, value)
+        if match:
+            return match.group(1)
+
+    print(f"❌ Could not find a video ID in: {value}", file=sys.stderr)
+    sys.exit(1)
 
 def extract_transcript(video_id, language='en'):
     """Extract transcript from YouTube video"""
     try:
         # Try to get transcript in specified language with fallback to English
-        transcript = YouTubeTranscriptApi.get_transcript(
-            video_id,
-            languages=[language, 'en']
-        )
-        
+        languages = [language, 'en'] if language != 'en' else ['en']
+
+        if _IS_LEGACY_API:
+            transcript = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+        else:
+            transcript = YouTubeTranscriptApi().fetch(video_id, languages=languages).to_raw_data()
+
         # Combine all transcript segments
         full_text = " ".join([entry['text'] for entry in transcript])
         return full_text
-        
+
     except TranscriptsDisabled:
         print(f"❌ Transcripts are disabled for video {video_id}", file=sys.stderr)
         sys.exit(1)
@@ -33,7 +63,10 @@ def extract_transcript(video_id, language='en'):
 def list_available_transcripts(video_id):
     """List all available transcripts for a video"""
     try:
-        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        if _IS_LEGACY_API:
+            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        else:
+            transcript_list = YouTubeTranscriptApi().list(video_id)
         print(f"✅ Available transcripts for {video_id}:")
         
         for transcript in transcript_list:
@@ -48,11 +81,11 @@ def list_available_transcripts(video_id):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: ./extract-transcript.py VIDEO_ID [LANGUAGE_CODE]")
-        print("       ./extract-transcript.py VIDEO_ID --list  (list available transcripts)")
+        print("Usage: ./extract-transcript.py VIDEO_ID_OR_URL [LANGUAGE_CODE]")
+        print("       ./extract-transcript.py VIDEO_ID_OR_URL --list  (list available transcripts)")
         sys.exit(1)
-    
-    video_id = sys.argv[1]
+
+    video_id = parse_video_id(sys.argv[1])
     
     # Check if user wants to list available transcripts
     if len(sys.argv) > 2 and sys.argv[2] == "--list":


### PR DESCRIPTION
## Problem

`youtube-summarizer` is broken on any fresh install.

The skill calls `YouTubeTranscriptApi.get_transcript()` and `YouTubeTranscriptApi.list_transcripts()` as class methods. Those were removed in **youtube-transcript-api 1.0**, which moved to an instance API (`.fetch()` / `.list()`). Because `scripts/install-dependencies.sh` installs the library unpinned, every new install resolves to 1.x, and the skill fails on **every** video with:

```
❌ Error: type object 'YouTubeTranscriptApi' has no attribute 'get_transcript'
```

### Reproduce

```bash
pip install youtube-transcript-api          # resolves to 1.2.4
python3 skills/youtube-summarizer/scripts/extract-transcript.py dQw4w9WgXcQ
```

The same dead calls also appear in the `SKILL.md` worked examples for Step 2 and Step 3. Since agents execute those inline rather than shelling out to the script, they fail independently of the script and needed the same fix.

## Fix

Detect which API is present and call the matching one:

```python
_IS_LEGACY_API = hasattr(YouTubeTranscriptApi, 'get_transcript')
```

This keeps the skill working on **both 0.6.x and 1.x**. I went this way rather than cutting over to 1.x and adding a `>=1.0` pin, because the skill currently declares no pin at all — a hard cutover would break anyone already sitting on an older installed copy.

Applied to all three vendored copies (`skills/`, `plugins/agentic-awesome-skills/skills/`, `plugins/agentic-awesome-skills-claude/skills/`), which are byte-identical before and after.

### Two smaller fixes in the same commit

**UTF-8 output.** The status emoji crashed on Windows consoles using a legacy codepage:

```
❌ Error listing transcripts: 'charmap' codec can't encode character '✅' in position 0
```

This hit `--list` on every run, and would equally have hit any transcript containing non-Latin text, so it isn't Windows-cosmetic — it's a data-dependent crash. `sys.stdout`/`sys.stderr` now reconfigure to UTF-8 with `errors='replace'`.

**Accept URLs.** The script only took a bare 11-character video ID, so the natural thing to paste — a YouTube URL — was rejected. It now accepts `/shorts/`, `watch?v=`, `youtu.be/`, `/embed/`, `/live/`, and `/v/` forms, or a bare ID as before. Happy to split this into its own PR if you'd rather keep this one strictly to the regression.

## Verification

Tested against a real video with auto-generated captions on youtube-transcript-api 1.2.4:

- Shorts URL, bare video ID, `watch?v=` with a trailing `&t=` param, and `youtu.be/` short link — all return the transcript
- `--list` prints the available tracks instead of crashing
- Unparseable input and a nonexistent video ID both exit 1 with a readable message
- The `SKILL.md` Step 2 and Step 3 examples were extracted from the patched file and executed directly: Step 2 lists the English auto-generated track, Step 3 returns 604 characters of transcript, both exit 0

## Notes

Source-only, per CONTRIBUTING — no `CATALOG.md`, `skills_index.json`, or `data/*.json` touched.
