### PR TITLE
fix: harden multi-source evidence integrity

### DIFF
--- a/skills/multi-source-search/SKILL.md
+++ b/skills/multi-source-search/SKILL.md
@@ -64,7 +64,7 @@ separately.
 
 For every material claim:
 
-1. Link it to the source IDs that support or contradict it.
+1. Link it to every relevant source ID and classify each as supporting or contradicting.
 2. Mark it as `sourced` or `inference`.
 3. Count genuinely independent sources, not duplicated syndication.
 4. Assign `low`, `medium`, or `high` confidence.

--- a/skills/multi-source-search/references/report-schema.md
+++ b/skills/multi-source-search/references/report-schema.md
@@ -23,6 +23,8 @@ Save the research ledger as one UTF-8 JSON object:
       "kind": "sourced",
       "confidence": "low",
       "source_ids": ["s1"],
+      "supporting_source_ids": ["s1"],
+      "contradicting_source_ids": [],
       "independent_source_count": 1,
       "conflict": false
     }
@@ -34,10 +36,12 @@ Save the research ledger as one UTF-8 JSON object:
 Rules:
 
 - Record at least two unique capability names; repeated queries to one capability still count as one.
-- Source IDs and URLs must be unique. Source type is `primary`, `secondary`, or `aggregator`.
+- Source IDs and canonical URLs must be unique. URL fragments, host casing, and default ports do not create independent sources.
 - Claims reference existing source IDs and declare `kind` as `sourced` or `inference`.
+- `source_ids` is exactly the union of disjoint `supporting_source_ids` and `contradicting_source_ids` arrays.
+- `conflict: true` requires at least one contradicting source; `conflict: false` requires none.
 - High confidence requires at least three independent sources; medium requires two; low requires one.
 - A conflicting claim cannot be high confidence.
-- Every source must support at least one claim, and every evidence gap must be explicit.
+- Every source must support or contradict at least one claim, and every evidence gap must be explicit.
 
 The validator does not fetch URLs, judge credibility, detect hidden shared sources, or prove claims true.

--- a/skills/multi-source-search/scripts/validate_report.py
+++ b/skills/multi-source-search/scripts/validate_report.py
@@ -5,6 +5,7 @@ import json
 import sys
 from datetime import date
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 
 SOURCE_TYPES = {"primary", "secondary", "aggregator"}
@@ -16,13 +17,31 @@ def nonempty(value):
     return isinstance(value, str) and bool(value.strip())
 
 
-def valid_url(value):
-    if not nonempty(value) or not value.startswith(("https://", "http://")):
-        return False
-    authority = value.split("://", 1)[1].split("/", 1)[0]
-    return bool(authority) and "." in authority and not any(
-        character.isspace() for character in authority
+def canonical_url(value):
+    """Return a conservative identity for an HTTP(S) URL, or None if invalid."""
+    if not nonempty(value):
+        return None
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return None
+    if parsed.scheme.lower() not in {"http", "https"} or not hostname or "." not in hostname:
+        return None
+    if any(character.isspace() for character in parsed.netloc):
+        return None
+    if parsed.username is not None or parsed.password is not None:
+        return None
+    normalized_host = hostname.lower()
+    if ":" in normalized_host:
+        normalized_host = f"[{normalized_host}]"
+    default_port = (parsed.scheme.lower() == "http" and port == 80) or (
+        parsed.scheme.lower() == "https" and port == 443
     )
+    netloc = normalized_host if port is None or default_port else f"{normalized_host}:{port}"
+    path = parsed.path or "/"
+    return urlunsplit((parsed.scheme.lower(), netloc, path, parsed.query, ""))
 
 
 def validate(report):
@@ -70,12 +89,13 @@ def validate(report):
             errors.append(f"duplicate source id: {source_id}")
         else:
             source_ids.add(source_id)
-        if not valid_url(url):
+        normalized_url = canonical_url(url)
+        if normalized_url is None:
             errors.append(f"{label}.url must be an HTTP(S) URL")
-        elif url in source_urls:
-            errors.append(f"duplicate source URL: {url}")
+        elif normalized_url in source_urls:
+            errors.append(f"duplicate source URL after normalization: {url}")
         else:
-            source_urls.add(url)
+            source_urls.add(normalized_url)
         if not nonempty(source.get("publisher")):
             errors.append(f"{label}.publisher must be a non-empty string")
         if source.get("source_type") not in SOURCE_TYPES:
@@ -114,6 +134,30 @@ def validate(report):
             refs = []
         if len(set(refs)) != len(refs):
             errors.append(f"{label}.source_ids must not contain duplicates")
+
+        supporting_refs = claim.get("supporting_source_ids")
+        if not isinstance(supporting_refs, list) or not supporting_refs or not all(
+            nonempty(item) for item in supporting_refs
+        ):
+            errors.append(f"{label}.supporting_source_ids must be a non-empty string array")
+            supporting_refs = []
+        contradicting_refs = claim.get("contradicting_source_ids")
+        if not isinstance(contradicting_refs, list) or not all(
+            nonempty(item) for item in contradicting_refs
+        ):
+            errors.append(f"{label}.contradicting_source_ids must be a string array")
+            contradicting_refs = []
+        if len(set(supporting_refs)) != len(supporting_refs):
+            errors.append(f"{label}.supporting_source_ids must not contain duplicates")
+        if len(set(contradicting_refs)) != len(contradicting_refs):
+            errors.append(f"{label}.contradicting_source_ids must not contain duplicates")
+        overlap = set(supporting_refs) & set(contradicting_refs)
+        if overlap:
+            errors.append(f"{label} cannot classify the same source as supporting and contradicting")
+        if set(refs) != set(supporting_refs) | set(contradicting_refs):
+            errors.append(
+                f"{label}.source_ids must equal the union of supporting_source_ids and contradicting_source_ids"
+            )
         for source_id in refs:
             if source_id not in source_ids:
                 errors.append(f"{label} references unknown source id: {source_id}")
@@ -133,8 +177,13 @@ def validate(report):
                 )
         if not isinstance(claim.get("conflict"), bool):
             errors.append(f"{label}.conflict must be true or false")
-        elif claim.get("conflict") and confidence == "high":
-            errors.append(f"{label} cannot be high confidence while conflict is true")
+        elif claim.get("conflict"):
+            if confidence == "high":
+                errors.append(f"{label} cannot be high confidence while conflict is true")
+            if not contradicting_refs:
+                errors.append(f"{label} conflict true requires a contradicting source")
+        elif contradicting_refs:
+            errors.append(f"{label} conflict false cannot include contradicting sources")
 
     for source_id in sorted(source_ids - used_sources):
         errors.append(f"source is not referenced by any claim: {source_id}")

--- a/tools/scripts/tests/test_multi_source_search_report.py
+++ b/tools/scripts/tests/test_multi_source_search_report.py
@@ -31,6 +31,8 @@ def report():
             "kind": "sourced",
             "confidence": "high",
             "source_ids": ["s1", "s2", "s3"],
+            "supporting_source_ids": ["s1", "s2", "s3"],
+            "contradicting_source_ids": [],
             "independent_source_count": 3,
             "conflict": False,
         }],
@@ -65,6 +67,7 @@ class MultiSourceReportTests(unittest.TestCase):
     def test_rejects_unknown_and_unused_sources(self):
         payload = copy.deepcopy(report())
         payload["claims"][0]["source_ids"][2] = "missing"
+        payload["claims"][0]["supporting_source_ids"][2] = "missing"
         result = self.run_report(payload)
         self.assertIn("unknown source id: missing", result.stderr)
         self.assertIn("source is not referenced by any claim: s3", result.stderr)
@@ -75,11 +78,34 @@ class MultiSourceReportTests(unittest.TestCase):
         result = self.run_report(payload)
         self.assertIn("duplicate source URL", result.stderr)
 
+    def test_rejects_urls_that_only_differ_by_fragment_host_case_or_default_port(self):
+        payload = copy.deepcopy(report())
+        payload["sources"][0]["url"] = "https://EXAMPLE.org:443/a#first"
+        payload["sources"][2]["url"] = "https://example.org/a#second"
+        result = self.run_report(payload)
+        self.assertIn("duplicate source URL after normalization", result.stderr)
+
     def test_rejects_high_confidence_conflict(self):
         payload = report()
         payload["claims"][0]["conflict"] = True
+        payload["claims"][0]["supporting_source_ids"] = ["s1", "s2"]
+        payload["claims"][0]["contradicting_source_ids"] = ["s3"]
         result = self.run_report(payload)
         self.assertIn("cannot be high confidence", result.stderr)
+
+    def test_rejects_conflict_without_a_contradicting_source(self):
+        payload = report()
+        payload["claims"][0]["conflict"] = True
+        result = self.run_report(payload)
+        self.assertIn("conflict true requires a contradicting source", result.stderr)
+
+    def test_rejects_ambiguous_or_overlapping_evidence_stance(self):
+        payload = report()
+        payload["claims"][0]["supporting_source_ids"] = ["s1", "s2"]
+        payload["claims"][0]["contradicting_source_ids"] = ["s2"]
+        result = self.run_report(payload)
+        self.assertIn("cannot classify the same source", result.stderr)
+        self.assertIn("must equal the union", result.stderr)
 
     def test_rejects_non_date_search_metadata(self):
         payload = report()

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,13 @@
+# Multi-source evidence integrity repair - 2026-08-20
+
+- Ported the executable follow-up from community PR #1204 onto the protected
+  maintainer lane, preserving contributor credit while keeping fork code out of
+  the direct source-merge path.
+- Made every claim classify cited evidence as supporting or contradicting, and
+  made conflict state fail closed against that classification.
+- Canonicalized URL identity for fragment, host-case, and default-port variants
+  before duplicate-source checks, with focused offline regression coverage.
+
 # Multi-source research ledger import - 2026-08-20
 
 - Ported community PR #1200 from the Apache-2.0 SandBase source at immutable


### PR DESCRIPTION
Ports the executable follow-up from community PR #1204 onto the protected maintainer lane. Claims now classify every source as supporting or contradicting, conflict state is checked against that classification, and superficial URL variants cannot inflate source diversity.

Supersedes #1204 while preserving contributor credit.

Co-authored-by: liyb <lybing315@163.com>
Co-authored-by: denial123789 <269935157+denial123789@users.noreply.github.com>
Co-authored-by: sck_0 <188885273+sck000@users.noreply.github.com>

## Verification

- Focused validator tests: 9 passed
- npm run validate
- npm run validate:references
- npm run security:docs
- npm run chain
- npm run check:warning-budget
- npm run check:readme-credits -- --base origin/main --head HEAD
- git diff --check

## Quality Bar Checklist

- [x] Scope is bounded to the multi-source report contract and tests.
- [x] Canonical skill semantics, safety, provenance, limitations, and bundled files were reviewed.
- [x] Generated registries and plugin mirrors are excluded for protected canonical synchronization.
- [x] Contributor credit is retained in the commit and PR summary.