### PR TITLE
Add AdMapix agent skill source

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ Key source families include:
 - [cloudflare/security-audit-skill](https://github.com/cloudflare/security-audit-skill) — Cloudflare Web Security Audit Skill (by Cloudflare)
 
 - **[gooseworks-ai/goose-skills](https://github.com/gooseworks-ai/goose-skills)**: Source for the `competitor-ad-intelligence` and `ad-campaign-analyzer` skills - evidence-labeled public ad research plus uncertainty-aware campaign diagnostics and bounded budget tests (MIT).
+- **[fly0pants/admapix](https://github.com/fly0pants/admapix)**: Source for the `admapix` skill - competitor ad creative and app market data research via [AdMapix](https://www.admapix.com/).
 
 - **[supernovae-st/nika-agents](https://github.com/supernovae-st/nika-agents)**: Official upstream source for the `nika` skill and its deterministic, budget-aware AI workflow runner (MIT skill content; AGPL-3.0 engine).
 - **[atdy/maoxuan-product-agent](https://github.com/atdy/maoxuan-product-agent)**: Source for the `product-decision-agent` skill - Chinese-first product judgment across prioritization, growth, operations, data, delivery, and cross-functional collaboration, with 36 tested scenarios (MIT).


### PR DESCRIPTION
Adds the public AdMapix agent skill to the Community Contributors and Source Repositories section.

- Source repo: https://github.com/fly0pants/admapix
- Skill documentation: https://github.com/fly0pants/admapix/blob/main/skill/SKILL.md
- Official website: https://www.admapix.com/
- The entry describes the documented competitor ad creative and app market data research workflow without adding generated catalog artifacts.