### PR TITLE
fix: remove trailing space after opening --- in 8 skills

### DIFF
--- a/skills/animejs-animation/SKILL.md
+++ b/skills/animejs-animation/SKILL.md
@@ -1,4 +1,4 @@
---- 
+---
 name: animejs-animation
 description: Advanced JavaScript animation library skill for creating complex, high-performance web animations.
 risk: safe

--- a/skills/antigravity-design-expert/SKILL.md
+++ b/skills/antigravity-design-expert/SKILL.md
@@ -1,4 +1,4 @@
---- 
+---
 name: antigravity-design-expert
 description: Core UI/UX engineering skill for building highly interactive, spatial, weightless, and glassmorphism-based web interfaces using GSAP and 3D CSS.
 risk: safe

--- a/skills/design-spells/SKILL.md
+++ b/skills/design-spells/SKILL.md
@@ -1,4 +1,4 @@
---- 
+---
 name: design-spells
 description: Curated micro-interactions and design details that add "magic" and personality to websites and apps.
 risk: safe

--- a/skills/iconsax-library/SKILL.md
+++ b/skills/iconsax-library/SKILL.md
@@ -1,4 +1,4 @@
---- 
+---
 name: iconsax-library
 description: Extensive icon library and AI-driven icon generation skill for premium UI/UX design.
 risk: safe

--- a/skills/magic-animator/SKILL.md
+++ b/skills/magic-animator/SKILL.md
@@ -1,4 +1,4 @@
---- 
+---
 name: magic-animator
 description: AI-powered animation tool for creating motion in logos, UI, icons, and social media assets.
 risk: safe

--- a/skills/magic-ui-generator/SKILL.md
+++ b/skills/magic-ui-generator/SKILL.md
@@ -1,4 +1,4 @@
---- 
+---
 name: magic-ui-generator
 description: Utilizes Magic by 21st.dev to generate, compare, and integrate multiple production-ready UI component variations.
 risk: safe

--- a/skills/unsplash-integration/SKILL.md
+++ b/skills/unsplash-integration/SKILL.md
@@ -1,4 +1,4 @@
---- 
+---
 name: unsplash-integration
 description: Integration skill for searching and fetching high-quality, free-to-use professional photography from Unsplash.
 risk: safe

--- a/skills/vizcom/SKILL.md
+++ b/skills/vizcom/SKILL.md
@@ -1,4 +1,4 @@
---- 
+---
 name: vizcom
 description: AI-powered product design tool for transforming sketches into full-fidelity 3D renders.
 risk: safe


### PR DESCRIPTION
Eight skills open their frontmatter with `--- ` (three dashes and a trailing space) instead of `---`:

`animejs-animation`, `antigravity-design-expert`, `design-spells`, `iconsax-library`, `magic-animator`, `magic-ui-generator`, `unsplash-integration`, `vizcom`

`tools/scripts/validate_skills.py` accepts this because its regex is `^---\s*\n`, so `npm run validate` passes. The skills CLI matches `^---\r?\n` exactly, so these eight are silently skipped on install:

```
$ npx skills add sickn33/agentic-awesome-skills --list 2>&1 | grep Skipped
⚠ Skipped skills/animejs-animation/SKILL.md — missing required frontmatter field(s): name, description
⚠ Skipped skills/antigravity-design-expert/SKILL.md — missing required frontmatter field(s): name, description
⚠ Skipped skills/design-spells/SKILL.md — missing required frontmatter field(s): name, description
⚠ Skipped skills/iconsax-library/SKILL.md — missing required frontmatter field(s): name, description
⚠ Skipped skills/magic-animator/SKILL.md — missing required frontmatter field(s): name, description
⚠ Skipped skills/magic-ui-generator/SKILL.md — missing required frontmatter field(s): name, description
⚠ Skipped skills/unsplash-integration/SKILL.md — missing required frontmatter field(s): name, description
⚠ Skipped skills/vizcom/SKILL.md — missing required frontmatter field(s): name, description
```

This PR removes the trailing space in the eight `skills/*/SKILL.md` sources. Source-only, no generated artifacts. The `plugins/` copies carry the same byte and will pick up the fix when main regenerates them.

After the change, `npx skills add ./skills --list` reports 0 skipped (was 8). `npm run validate` passes before and after.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Quality Bar Checklist ✅

- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`, plus `npx skills add ./skills --list` shows 0 skipped).
- [x] **Source-Only PR**: I did not include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`).
- [x] **Maintainer Edits**: Allow edits from maintainers is enabled.
- Other checklist items are not applicable: no skill content, commands, triggers, or `risk:` labels changed. Only the opening delimiter line of eight files.
