### PR TITLE
feat: add 2 review skills from amElnagdy/review-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-<!-- registry-sync: version=16.0.0; skills=2026; stars=45322; updated_at=2026-08-24T05:22:46+00:00 -->
+<!-- registry-sync: version=16.1.0; skills=2028; stars=45378; updated_at=2026-08-25T17:54:41+00:00 -->
 # AAS Core — Agentic Awesome Skills
 
 > **Local, agent-owned skill stacks for coding agents—from complete catalog access to a reproducible, reviewable plan.**
 
-**Current release: V16.0.0.** This release includes AAS Core for complete local catalog search, agent-owned selection, manifest validation, planning, and diagnosis. Apply and recovery remain experimental and outside the supported preview path.
+**Current release: V16.1.0.** This release includes AAS Core for complete local catalog search, agent-owned selection, manifest validation, planning, and diagnosis. Apply and recovery remain experimental and outside the supported preview path.
 
 Codex or Claude inspects your project and chooses exact skills from the complete local AAS catalog. AAS Core does not rank or recommend them: its read-only `compose_stack` tool validates the agent-owned selection in memory, and a client or the `aas` CLI can persist it as `aas-stack.json` and produce an immutable plan before any target change.
 
-**[Read the AAS Core preview guide →](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md)**
+**[Read the AAS Core preview guide →](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md)**
 
 ```text
 Project
@@ -67,7 +67,7 @@ AAS Core gives the repository one product model:
 | Apply and recovery | Experimental, explicit opt-in, outside the supported safety claim |
 | Semantic suitability certification | Not provided |
 
-Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md) for the exact trust boundaries, current preview status, Codex/Claude setup model, and CLI lifecycle.
+Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md) for the exact trust boundaries, current preview status, Codex/Claude setup model, and CLI lifecycle.
 
 ## Why This Repo
 
@@ -76,7 +76,7 @@ Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob
 - **Approval before writes**: the durable artifacts are an approved stack and immutable plan, not an opaque one-shot install.
 - **Installable, not just inspirational**: use the compatible legacy installer or plugin distributions when direct delivery is the right path.
 - **Built for major agent workflows**: Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, Kiro, OpenCode, Copilot, and more.
-- **Broad coverage with real utility**: 2,026+ skills across development, testing, security, infrastructure, product, and marketing.
+- **Broad coverage with real utility**: 2,028+ skills across development, testing, security, infrastructure, product, and marketing.
 - **Inspect before installing**: the hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) reviews agent-produced stack manifests and immutable plans without browser-side installation.
 - **Focused delivery remains available**: specialized plugins package proven sets for web, security, data, docs, DevOps, QA, OSS, or agent/MCP workflows.
 - **Useful whether you want breadth or curation**: install the full catalog, choose a specialized plugin, start with bundles, or compare alternatives before installing.
@@ -94,7 +94,7 @@ Direct file search can find candidate prose, but it leaves the result in the con
 - [Choose Your Tool](#choose-your-tool)
 - [Quick FAQ](#quick-faq)
 - [Bundles & Workflows](#bundles--workflows)
-- [Browse 2,026+ Skills](#browse-2026-skills)
+- [Browse 2,028+ Skills](#browse-2028-skills)
 - [Troubleshooting](#troubleshooting)
 - [Stable Skills Manifest v1](#stable-skills-manifest-v1)
 - [Support the Project](#support-the-project)
@@ -107,7 +107,7 @@ Direct file search can find candidate prose, but it leaves the result in the con
 
 ## Installation
 
-For Codex and Claude, start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md): configure the local MCP, ask the agent to inspect the project and choose exact IDs from the full catalog, review the proposed `aas-stack.json`, then run CLI validation and planning. The MCP and validation are read-only. Planning writes only the requested plan artifact; it does not materialize skill payloads or AAS managed state in the target.
+For Codex and Claude, start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md): configure the local MCP, ask the agent to inspect the project and choose exact IDs from the full catalog, review the proposed `aas-stack.json`, then run CLI validation and planning. The MCP and validation are read-only. Planning writes only the requested plan artifact; it does not materialize skill payloads or AAS managed state in the target.
 
 Use direct installation when your host does not yet have a native AAS Core adapter, when you already know the exact skill IDs, or when you deliberately prefer manual selection:
 
@@ -261,7 +261,7 @@ The supported path covers complete local catalog search and inspection, agent-ow
 
 ### How do I install it?
 
-For AAS Core, follow the [preview guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md) and use only a package release whose notes explicitly state that it includes Core. Release 14.6.0 predates Core; Core-capable releases begin with the 15.x line.
+For AAS Core, follow the [preview guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md) and use only a package release whose notes explicitly state that it includes Core. Release 14.6.0 predates Core; Core-capable releases begin with the 15.x line.
 
 For direct skill distribution, use a tool-specific flag such as `--codex`,
 `--cursor`, `--gemini`, or `--claude` to place skills in the directory your
@@ -339,7 +339,7 @@ Remove `--dry-run` only after reviewing the install, update, and removal plan. U
 
 The hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) imports and reviews AAS Core stack manifests and immutable plans in browser memory. It does not access the filesystem, generate an approved plan, or install skills.
 
-## Browse 2,026+ Skills
+## Browse 2,028+ Skills
 
 Use the root repo as a landing page, then jump into the deeper surface that matches your intent.
 
@@ -377,7 +377,7 @@ Use the root repo as a landing page, then jump into the deeper surface that matc
 Keep the root README short; use the dedicated docs for recovery and platform-specific guidance.
 
 - If you are confused after installation, start with the [Usage Guide](docs/users/usage.md).
-- For Core setup, trust boundaries, stack manifests, and preview status, use the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md).
+- For Core setup, trust boundaries, stack manifests, and preview status, use the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md).
 - On native Windows, `AAS_ADAPTER_WINDOWS_ACL_FAILED` refers to the configuration path checked with PowerShell `Get-Acl`, not the cache and not `icacls`; do not approve until preview returns an approval digest.
 - If you integrate agentic-awesome-skills into a host, read the discovery contract first: [Stable Skills Manifest v1](docs/users/discovery-manifest.md).
 - For Windows truncation or context crash loops, use [docs/users/windows-truncation-recovery.md](docs/users/windows-truncation-recovery.md).
@@ -388,7 +388,7 @@ Keep the root README short; use the dedicated docs for recovery and platform-spe
 
 ## Stable Skills Manifest v1
 
-This is the stable **direct-host discovery manifest** for integrations that load individual `SKILL.md` files. It is not `aas-stack.json`, the verified AAS Core catalog, or the Core composition contract. Core users should start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md); custom host integrations can continue using the manifest below.
+This is the stable **direct-host discovery manifest** for integrations that load individual `SKILL.md` files. It is not `aas-stack.json`, the verified AAS Core catalog, or the Core composition contract. Core users should start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md); custom host integrations can continue using the manifest below.
 
 Host integrations should use:
 
@@ -513,6 +513,7 @@ Key source families include:
 - **[Phelan164/codex-howto](https://github.com/Phelan164/codex-howto)**: Source for the `maintain-codex-wiki` skill - review-first engineering knowledge with provenance, explicit capture and promotion, and deterministic structural checks (MIT).
 - **[0xsarwagya/ontoly](https://github.com/0xsarwagya/ontoly)**: Source for the `ontoly-software-graph` skill - deterministic TypeScript software graphs, MCP-backed architecture review, request tracing, impact analysis, and dependency analysis (MIT).
 - [amElnagdy/guard-skills](https://github.com/amElnagdy/guard-skills) — Code Quality & Testing Guard Skills (by amElnagdy)
+- **[amElnagdy/review-skills](https://github.com/amElnagdy/review-skills)**: Source for the `debate-review` and `babysit-pr` skills - two-model debate review of PRs/MRs with inline comments and automated babysitting of review rounds for GitHub and GitLab (MIT).
 
 - [cloudflare/security-audit-skill](https://github.com/cloudflare/security-audit-skill) — Cloudflare Web Security Audit Skill (by Cloudflare)
 
@@ -554,6 +555,7 @@ Key source families include:
 - **[JunsW/feature-track](https://github.com/JunsW/feature-track)**: Source for the `feature-tracking` skill - lightweight repository-native feature memory for current status, source-of-truth documents, decisions, risks, and cross-session handoff (MIT).
 - **[JularDepick/user-thoughts.SKILL](https://github.com/JularDepick/user-thoughts.SKILL)**: Source for the `user-thoughts` skill - persistent project idea repository workflows for capturing decisions, tech stack notes, UI/UX rationale, and MDBASE-backed project memory (MIT).
 - **[TheaDust/lore](https://github.com/TheaDust/lore)**: Source for the `lore` skill - Markdown-only, zero-dependency long-term project memory for AI coding agents, with monorepo scopes, two-section platform mirrors, and stdlib Python helpers (MIT).
+- **[rainmanjam/poka-yoke](https://github.com/rainmanjam/poka-yoke)**: Source for the `poka-yoke` skill - software mistake-proofing through control, warning, detection, and source-inspection guardrails (MIT).
 - **[ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills)**: Source for the `youtube-full` skill - TranscriptAPI-backed YouTube transcripts, search, channel browsing, playlists, and cloud-safe video research workflows (MIT).
 - **[ZeroPointRepo/zillow-skills](https://github.com/ZeroPointRepo/zillow-skills)**: Source for the `us-property-data` skill - U.S. property lookup, valuation, listing, tax, school, photo, and price-history guidance through the independent Zillapi API (MIT-0).
 - **[Antheurus/anywrite](https://github.com/Antheurus/anywrite)**: Source for the `anywrite` skill - low-context CLI access to Anytype's local API for objects, properties, files, search, chat, and other workspace operations (MIT).

--- a/docs/sources/sources.md
+++ b/docs/sources/sources.md
@@ -158,6 +158,7 @@ The following skills were added during the March 2026 skills update:
 | Skill | Source | License | Notes |
 |-------|--------|---------|-------|
 | `clarity-gate` | [frmoretto/clarity-gate](https://github.com/frmoretto/clarity-gate) | Compatible | RAG quality verification |
+| `debate-review`, `babysit-pr` | [amElnagdy/review-skills](https://github.com/amElnagdy/review-skills) | MIT | Two-model debate review + automated PR babysitting for GitHub/GitLab (requires delegate-skills) |
 
 **Total: 80+ new skills added**
 

--- a/skills/babysit-pr/SKILL.md
+++ b/skills/babysit-pr/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: babysit-pr
+description: 'Babysit a pull request through its bot review rounds: verify, fix, reply,
+  resolve. Use for any babysit or watch-the-PR ask.'
+risk: safe
+category: code-quality
+source: https://github.com/amElnagdy/review-skills
+source_repo: amElnagdy/review-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/review-skills/blob/master/LICENSE
+compatibility: Requires `gh` (GitHub) or `glab` (GitLab) authenticated, plus `jq`
+  and bash for the thread harvester.
+metadata:
+  version: 0.1.0
+---
+# Babysit a PR
+
+## When to Use
+
+- A PR/MR has accumulated bot review threads (debate-review, Codex, Greptile, etc.) that need verification, fixes, replies, and resolution.
+- You want to drive a PR from 'just opened' to 'nothing left unanswered' across multiple review rounds.
+
+Goal: carry a pull request (GitHub) or merge request (GitLab) from "just opened" to "nothing left
+unanswered," without the human having to sit and refresh the page. "PR" below means either.
+
+Review bots are diff-anchored samplers. Every push mints a fresh round, and a fix in one place can
+light up commentary somewhere adjacent. Left alone, a PR accumulates half-answered threads that
+nobody resolves, and the real bug in round three gets buried under nitpicks from rounds one and two.
+Your job is to be the person who reads every finding, decides what is actually true, fixes what
+blocks, and closes every loop in writing.
+
+You know how to drive `gh` (GitHub), `glab` (GitLab), and git. What follows is only the judgment this
+loop needs and the few API calls that are easy to get wrong. The harvest script picks the forge from
+the cwd's git origin; everything it returns has the same shape on both, with a `capabilities` block
+naming what that forge cannot tell you.
+
+## The three rules that matter most
+
+Verify before you believe. A bot's severity badge is a guess made without running anything. Treat
+every finding, including the P1s, as a claim to check against the code. Bots are frequently right
+(that is why this loop is worth running), and they are also confidently wrong often enough that
+shipping their suggestions unexamined will introduce bugs. Read the actual code path before you
+agree or disagree.
+
+Every thread gets an answer. A finding you fixed, rejected, or deferred is only closed once you have
+said so in that thread and resolved it. Silence reads as "ignored" to the next human who opens the
+PR, and it is how a real bug gets lost.
+
+Publish before you answer. A "fixed" reply is only true once the remote branch carries the fix.
+Never post a confirmed reply, or resolve its thread, while the fix exists only locally. Rejections
+need no push. Reply with evidence and resolve immediately.
+
+## Harvest the round
+
+Findings arrive on two different surfaces, and a round that reads only one silently misses half of
+them. This is the single most common way a babysit loop goes wrong:
+
+- Inline review threads. This is where debate-review and Codex post their findings (Codex attaches
+  P1/P2-badged inline comments to an otherwise boilerplate review body; an empty-looking body proves
+  nothing). Each thread carries a `thread_id` (to resolve) and a `reply_to` (to reply inside the
+  thread). On GitHub these are GraphQL review threads; on GitLab they are discussions.
+- Top-level review bodies. This is where Greptile summarizes, Codex sometimes posts a numbered list,
+  and debate-review posts its round summary. These have no thread to resolve; answer them with one PR
+  comment per round. On GitHub they are review objects; on GitLab they are plain notes.
+
+The bundled script returns both in one call, already correlated (`<skill-dir>` is the folder that
+holds this SKILL.md):
+
+```bash
+"<skill-dir>/scripts/threads.sh" <N> > /tmp/pr-<N>-round-<k>.json
+```
+
+Never trust a filtered count without its unfiltered twin. Before applying any jq filter to the
+harvest, print the raw totals (`jq '{threads: (.threads|length), reviews: (.reviews|length)}'`) and
+compare. A filter that eliminates 100% of items is presumed broken until the field names are
+verified against the actual schema (`jq '.threads[0] | keys'`). jq selects on a misspelled field
+fail silently-empty, and a "clean round" built on one is how a P1 gets a merge-gate mention posted
+over it. That has happened. GitHub tooling fails by returning less data, not by erroring; pair this with the
+pagination rule.
+
+Never describe an object you did not fetch. If a query for a specific id returns empty, that is a
+stop signal. Say "I can't see it" and fetch it another way (`gh api .../reviews/<id>`), never narrate
+its presumed content. Related trap: every inline thread reply arrives wrapped in a zero-byte
+`COMMENTED` review object, so a watcher's "new review" event may be just a reply wrapper, not a new
+round. threads.sh's `.reviews` does not include these wrappers, so a review id from an event that is
+missing from the harvest means "wrapper", not "gone".
+
+Diff it against the previous round's file to see what is genuinely new. `outdated: true` on a thread
+means the line moved underneath it. The finding may already be fixed, so check it against current
+code before spending the round on it. A `comment_count` bump on a thread you already handled means a
+bot followed up inside it.
+
+Has this reviewer seen the current push? Only trust a field that names a sha. On GitHub each review
+carries `commit_id`; compare it to `head`. For debate-review on either forge, the round body's
+`debate_head` is the sha it reviewed. On GitLab other reviewers' notes carry no sha (`capabilities.
+review_commit_id: false`); a note's timestamp being later than your push does not prove it reviewed
+that push, so say "coverage unknown" rather than guessing.
+
+Two kinds of author count as a reviewer. First, a bot: `author_bot: true` in the harvest. On GitHub
+that comes from the API's own author type and is reliable (`chatgpt-codex-connector` and
+`greptile-apps` are the usual ones; don't hardcode a whitelist). On GitLab the API only sometimes
+says, so `author_bot` can be `null`; treat `null` as unknown, look at the thread, and say in your
+report that you could not confirm it. Second, any thread whose first comment carries a
+`<!-- debate-review:... -->` marker. debate-review posts from the user's own account, so the author
+is the PR author (`author_is_pr_author: true`), but the thread is a reviewer thread. The harvest
+flags these as `debate_review: true` with `debate_id`, `debate_status`, and `debate_severity` parsed
+from the marker; its round body shows up in `.reviews` with `debate_head` (the sha it reviewed) and
+`debate_agreed` / `debate_contested`. Treat them like any other bot thread. Anything else from the PR
+author, and any human's comment without that marker, is never in scope for autonomous fixing.
+Surface it to the user instead.
+
+Bots post 5 to 10 minutes after a push, longer on a big diff. Don't poll tightly; background the wait
+and review the diff yourself meanwhile. A round is "in" once every reviewer you expect has either
+posted against the current head SHA or been marked unavailable after its own wait budget. An
+unavailable reviewer never blocks harvesting or acting on the ones that did post. Disclose the gap
+instead of reporting the PR clean.
+
+## Classify by real impact, not by badge
+
+After verifying a finding, sort it by consequence rather than by the label the bot attached.
+
+Blocking, meaning it would ship a defect or stop the merge:
+- a real bug, wrong behavior, or broken edge case in the changed code
+- security, authorization, data-integrity, or data-loss exposure
+- a violation of the change's own stated contract, acceptance criteria, or spec
+- a migration or schema hazard
+- a failing or newly-flaky check
+
+Non-blocking, meaning real but ships nothing broken: naming, structure, docs, test nitpicks, micro
+performance, "consider extracting this", style preference.
+
+When a finding is genuinely ambiguous, hold it as blocking until you have read enough code to demote
+it. The asymmetry is deliberate. An over-cautious fix costs minutes, a missed P1 costs a production
+bug.
+
+A debate-review thread with `debate_status: contested` means two models looked and disagreed. The
+main reviewer held the finding against a refutation, and the italic last line of the comment says
+what the challenge was. That is a claim with a known counter-argument, not a weaker claim. Verify it
+the same way, and say in your reply which side the code supports and why.
+
+## Fix the blockers, autonomously
+
+Don't stop to ask about blockers. Verify, fix, push, keep watching, report what you did.
+
+- Reproduce first where you can. A probe that fails before the fix and passes after is what separates
+  a real fix from a plausible edit. This matters most on findings you initially disagreed with. Those
+  are the ones where being wrong is expensive.
+- One push per round, not one per finding. Every push mints a new bot round, so per-finding pushes
+  multiply the rounds you have to sit through.
+- Run the repo's own gate before pushing. A fix that breaks the suite costs a whole extra round.
+- If a matching guard skill is installed (clean-code-guard, test-guard, wp-guard, woo-guard from
+  guard-skills), run it on your fix before pushing. The guards catch the failure modes a quick fix
+  under review pressure tends to produce.
+- When you disagree, prove it. Rejecting a finding is legitimate and common, but the reply has to
+  carry the evidence: the code path, the guard that already handles it, or the test that pins the
+  behavior. "This is fine" is not a rejection.
+
+## Publish, then reply, then resolve
+
+Work the round in one pass, not per finding: verify everything, reproduce confirmed blockers where
+practical, fix them all, run the gate, then commit and push once and confirm the remote SHA. Only
+then close the loops:
+
+- Confirmed: reply naming the fix commit, then resolve.
+- Rejected: reply with concrete evidence, then resolve. No push needed; these can close anytime.
+- Deferred: create the agreed issue, reply with its link, then resolve.
+
+Non-blocker fixes the user approves ride the next consolidated push, never a dedicated push of their
+own. There is no re-review-exempt push: every push, including a final docs-only or nit-only one, must
+be covered by a clean round from the merge-gate reviewer before merge (see "Before merge"). If
+publication or verification fails, leave the thread open and report the blocker.
+
+Answer inside the thread the finding came from. A fresh top-level comment leaves the original thread
+open and forces the reader to correlate by hand. Use the harvest's `reply_to` to reply and `thread_id`
+to resolve. On GitHub those are two different identifiers (REST comment id, GraphQL thread id); on
+GitLab both are the discussion id.
+
+GitHub:
+
+```bash
+gh api --method POST "repos/<owner>/<repo>/pulls/<N>/comments/<reply_to>/replies" \
+  -f body="$(cat /tmp/reply.md)"
+
+gh api graphql -f query='mutation($t:ID!){
+  resolveReviewThread(input:{threadId:$t}){ thread{ isResolved } } }' -F t="<thread_id>"
+```
+
+GitLab (`<project>` is the URL-encoded `group/path`, `--hostname` your instance):
+
+```bash
+glab api --hostname <host> --method POST "projects/<project>/merge_requests/<N>/discussions/<reply_to>/notes" \
+  --raw-field "body=$(cat /tmp/reply.md)"
+
+glab api --hostname <host> --method PUT "projects/<project>/merge_requests/<N>/discussions/<thread_id>" \
+  -F resolved=true
+```
+
+The GitLab reply and resolve calls are taken from the GitLab API docs and have not yet been exercised
+against a live instance from this skill. The first time you use them, check the response, and if
+either fails, stop and report rather than retrying variations.
+
+Attribution. Open every reply by naming the model writing it and the person it writes for, so a
+reader never has to guess whether a human weighed in. Sign your own model name; this skill is
+model-neutral. The person is whoever owns the account the reply posts from. Get the name once per
+session, `gh api user -q '.name // .login'` on GitHub or `glab api user --hostname <host> | jq -r
+'.name // .username'` on GitLab, and reuse it:
+
+> I am \<model-slug\> writing on behalf of \<user\>.
+
+Then the verdict, then the evidence, briefly:
+
+```
+I am <model-slug> writing on behalf of <user>.
+
+Confirmed and fixed in `a1b2c3d`. You were right that `occurrence_time` was never
+compared against `evidence.event_time`, so a mapping could bind proof from a
+different occurrence. Reproduced with a failing test first
+(`test_binds_proof_to_mapped_occurrence`), then fixed the composition check.
+```
+
+```
+I am <model-slug> writing on behalf of <user>.
+
+Declining this one. The nil case you describe is already unreachable. `resolve()`
+returns early at `handlers.py:88` whenever the session is unset, which is the only
+path that reaches this line. Leaving the behavior as-is.
+```
+
+Resolve only what is actually closed: fixed and pushed, rejected with evidence, or deferred with an
+issue filed. Never resolve a thread whose question you have not answered. Resolution claims the loop
+is closed, and a false claim is worse than an open thread.
+
+## Non-blockers: one batched ask per round
+
+Don't interrupt per finding, and don't silently decide. Once per round, after the blockers are
+handled, bring the non-blocking findings as one list with a recommendation each (fix now, open an
+issue, or reject) and let the user choose:
+
+> Round 2 on PR #123. 1 blocker fixed and pushed (`a1b2c3d`). Three non-blocking findings left:
+> 1. debate-review: extract the duplicated fixture in `test_foo.py`. Recommend issue, touches
+>    files outside this change
+> 2. Codex: `Counter` comparison could use `==` directly. Recommend fix now, one line
+> 3. Greptile: docstring missing on the new helper. Recommend fix now, trivial
+> Fix 2 and 3 in the next push, issue for 1?
+
+Whatever they decide, close each thread the same way as any other finding. Anything deferred gets a
+real issue with enough context to act on months later: a link back to the thread, the file, and why
+it was deferred. Not just a title.
+
+## Re-trigger within a fixed budget
+
+One invocation gets the initial harvest plus at most two consolidated repair pushes and two
+re-review cycles unless the user explicitly asks to continue. After each push you start the next
+round yourself. How depends on the reviewer, because they are triggered in three different ways:
+
+- debate-review is a local script, not a bot, and it works on both forges. You run it, it does the
+  whole review while you wait, and it exits once the review is posted. Nothing to mention, nothing
+  to poll:
+
+  ```bash
+  node "<debate-review skill-dir>/scripts/review-pr.mjs" <pr-url>
+  ```
+
+  (`<debate-review skill-dir>` is wherever that skill is installed, `~/.agents/skills/debate-review`
+  on a standard install.) Run it in the background, keep working, and harvest the moment the command
+  exits. It prints the review URL; exit code 3 means this head was already reviewed. It reviews
+  exactly one head sha per run, so a run after a push always produces a fresh round. A run takes
+  10 to 20 minutes.
+- Codex is a GitHub app (there is no GitLab equivalent). Mention `@codex review` in a PR comment,
+  then wait. It answers 8 to 15 minutes later, against whatever head was current when it ran. Check
+  `commit_id` on its review before believing it covers your push.
+- Greptile and similar bots re-review every push on their own. Don't summon them; handle their
+  findings when they show up.
+
+For a bot you are waiting on, wait at most 10 minutes past its usual window. If it is silent or
+rate-limited, mark that reviewer unavailable; do not wait out a cooldown. The one exception is the
+merge-gate reviewer at the merge gate, which has no timeout (see "Before merge"). Even a final
+test-only, documentation-only, or nit-only push gets a round. The merge gate below is meaningless if
+the last push went unreviewed.
+
+Run the repository's required gate once per consolidated repair push; never rerun an already-passing
+gate for the same SHA. If the user says "stop", "enough", or "push whatever you have", cancel active
+polls and long gates, run the smallest relevant check that can finish promptly, publish the safe
+work, disclose any incomplete gate, and do not trigger another review round.
+
+Rounds should shrink. If round three is as large as round one, something systematic is wrong. Say
+so rather than grinding. Findings that recur in the same shape usually mean the fix addressed a
+symptom instead of the cause, which is worth surfacing.
+
+At the budget boundary, stop and hand off the exact remaining findings, unresolved threads, last
+reviewed SHA, and unavailable reviewers. Never describe an unreviewed head as clean.
+
+## Before merge
+
+The merge gate is an explicit clean round from the repo's primary reviewer on the exact merge
+candidate, the final head sha. Which reviewer that is depends on the repo.
+
+Where Codex is installed, mention `@codex review` after the final push and wait for its reply. A
+clean round is Codex saying so in plain words ("no findings", "good job") against the final head. No
+reply yet is not a pass. Codex answers 8 to 15 minutes after a push, and merging inside that window
+is how a real finding lands minutes after the merge.
+
+Where debate-review is the reviewer (on GitLab it is usually the only one), run it on the final head.
+A clean round is all three of: its round body present in `.reviews` with `debate_head` equal to the
+final head sha, `debate_agreed` and `debate_contested` both zero, and no unresolved reviewer threads.
+If the body is missing (a run can fail after posting inline comments), the gate has not been met;
+re-run it, don't infer.
+
+Either way, a finding is a new round, not a merge. Silence well past the usual window is something
+to report to the user, not approval.
+
+Re-harvest and re-read the PR's most recent comments before proposing a merge. A watcher settled
+into a quiet interval can miss a late round, and a comment posted after your last check is exactly
+the one that gets merged over.
+
+Then ask the user whether to merge. Never merge on your own initiative. Report: rounds run,
+blockers fixed with their SHAs, findings rejected and why, issues filed, unresolved threads
+remaining (ideally zero), and CI state. The merge decision is theirs; everything leading to it was
+yours.
+
+## When to stop and speak up
+
+Some situations are not yours to grind through:
+
+- A bot finding that is right but demands a change well beyond this PR's scope.
+- Two bots contradicting each other on the same line, when code, tests, and the stated contract
+  cannot settle it.
+- The same finding recurring after a retry. The first recurrence gets a re-verified root cause and
+  one more attempt inside the repair budget; a second means your model of the bug is wrong.
+- A human reviewer's comment, always.
+- CI failing for infrastructure reasons rather than code.
+- The two-repair-cycle budget is exhausted.
+- The user asks to stop, push the current work, or end the babysit loop.
+
+
+## Limitations
+
+- Requires authenticated `gh`/`glab`, `jq` and bash; harvests both inline threads and top-level review bodies.
+- Fixes and pushes blockers to the PR branch but never merges — human still controls merge gate.
+
+> Adapted from [amElnagdy/review-skills](https://github.com/amElnagdy/review-skills) (MIT).

--- a/skills/babysit-pr/scripts/threads.sh
+++ b/skills/babysit-pr/scripts/threads.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Harvest a pull request's (GitHub) or merge request's (GitLab) reviewer threads and top-level
+# review bodies in one shot, in one JSON shape.
+#
+# Usage:  threads.sh <number> [owner/repo] [--github | --gitlab] [--hostname <host>]
+#         threads.sh 123                       # forge and repo from the cwd's git origin
+#         threads.sh 123 owner/repo --github
+#         threads.sh 45 group/sub/proj --gitlab --hostname gitlab.example.com
+#
+# Emits JSON on stdout:
+#   .forge        "github" | "gitlab"
+#   .host         the forge host
+#   .repo, .pr    owner/repo (or group/path on GitLab) and the number
+#   .head         current head sha
+#   .pr_author    login of the PR/MR author. Their own notes are never reviewer findings.
+#   .capabilities what this forge can tell you:
+#       outdated          GitHub says when the line under a thread moved. GitLab does not.
+#       review_commit_id  GitHub reviews carry the sha they reviewed. GitLab notes do not.
+#       author_bot_flag   GitHub types every author (Bot vs User), so author_bot is reliable.
+#                         GitLab only sometimes exposes author.bot; it is null when absent.
+#   .threads[]    inline reviewer threads, each with:
+#       thread_id      use to RESOLVE (GitHub GraphQL node id / GitLab discussion id)
+#       reply_to       use to REPLY inside the thread (GitHub REST comment id / GitLab discussion id)
+#       resolved, resolvable
+#       outdated       GitHub only; null on GitLab
+#       author, author_bot (true/false/null), author_is_pr_author
+#       path, line, original_line, line_side ("RIGHT"/"LEFT" on GitHub, "new"/"old" on GitLab)
+#       position_head  GitLab: the head sha the note was placed against; null on GitHub
+#       comment_count  a bump since the previous round means someone followed up inside the thread
+#       body           the thread's first comment, the finding itself
+#       last_author, last_body
+#       source         "thread" (GitHub) | "discussion" (GitLab)
+#       debate_review, debate_id, debate_status, debate_severity, debate_level (P0/P1/P2)
+#                      parsed from a debate-review marker in the first comment; debate-review posts
+#                      from the user's own account, so these threads are reviewer threads even though
+#                      the author is not a bot
+#   .reviews[]    top-level bodies with no thread to resolve (Codex/Greptile summaries,
+#                 the debate-review round body). Answer these with one PR comment.
+#       id, author, author_bot, state (GitHub), commit_id (GitHub), submitted_at, body
+#       source         "review" (GitHub) | "note" (GitLab)
+#       debate_review, debate_head, debate_agreed, debate_contested
+#   .unresolved   count of unresolved threads
+#
+# Threads and top-level bodies are different objects on both forges. A round that reads only one
+# misses half the findings.
+#
+# GitLab: a "discussion" with individual_note:true is a plain comment, not a thread, so it is
+# excluded from .threads. System notes ("changed the description") are excluded everywhere. Root
+# notes of real discussions are excluded from .reviews so nothing appears twice.
+
+set -euo pipefail
+
+NUMBER=""; REPO=""; FORGE=""; HOST=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --github) FORGE=github; shift ;;
+    --gitlab) FORGE=gitlab; shift ;;
+    --hostname) HOST="$2"; shift 2 ;;
+    -h|--help) sed -n '2,50p' "$0"; exit 0 ;;
+    *) if [ -z "$NUMBER" ]; then NUMBER="$1"; elif [ -z "$REPO" ]; then REPO="$1"; else echo "unexpected argument: $1" >&2; exit 2; fi; shift ;;
+  esac
+done
+[ -n "$NUMBER" ] || { echo "usage: threads.sh <number> [owner/repo] [--github|--gitlab] [--hostname <host>]" >&2; exit 2; }
+
+# ---------- detect forge and repo from git origin when not given ----------
+if [ -z "$FORGE" ] || [ -z "$REPO" ]; then
+  ORIGIN=$(git remote get-url origin 2>/dev/null || true)
+  [ -n "$ORIGIN" ] || { echo "no --github/--gitlab + owner/repo given and no git origin in cwd" >&2; exit 2; }
+  # https://host/path.git  |  git@host:path.git  |  ssh://git@host/path.git
+  ORIGIN_HOST=$(printf '%s' "$ORIGIN" | sed -E 's#^(https?://|ssh://git@|git@)([^/:]+)[/:].*#\2#')
+  ORIGIN_PATH=$(printf '%s' "$ORIGIN" | sed -E 's#^(https?://|ssh://git@|git@)[^/:]+[/:]##; s#/$##; s#\.git$##')
+  [ -z "$FORGE" ] && { if [ "$ORIGIN_HOST" = "github.com" ]; then FORGE=github; else FORGE=gitlab; fi; }
+  [ -z "$REPO" ] && REPO="$ORIGIN_PATH"
+  [ -z "$HOST" ] && HOST="$ORIGIN_HOST"
+fi
+[ -n "$HOST" ] || { if [ "$FORGE" = github ]; then HOST=github.com; else HOST=gitlab.com; fi; }
+
+# jq: parse the two debate-review markers. Shared by both forges.
+JQ_MARKERS='
+  def thread_marker:
+    . + ((.body // "") | capture("<!-- debate-review:(?<debate_id>[FD][0-9]+) status=(?<debate_status>[a-z-]+) severity=(?<debate_severity>[a-z-]+)(?: level=(?<debate_level>P[0-9]))?[^>]*-->")
+          // {debate_id:null, debate_status:null, debate_severity:null, debate_level:null})
+    | . + {debate_review: (.debate_id != null)};
+  def review_marker:
+    . + ((.body // "") | capture("<!-- debate-review head=(?<debate_head>[0-9a-f]+)(?: [^>]*?agreed=(?<debate_agreed>[0-9]+) contested=(?<debate_contested>[0-9]+))?[^>]*-->")
+          // {debate_head:null, debate_agreed:null, debate_contested:null})
+    | .debate_agreed |= (if . == null then null else tonumber end)
+    | .debate_contested |= (if . == null then null else tonumber end)
+    | . + {debate_review: (.debate_head != null)};
+'
+
+# ============================================================ GitHub
+harvest_github() {
+  local owner="${REPO%%/*}" name="${REPO##*/}"
+
+  local pr_author
+  pr_author=$(gh api "repos/$REPO/pulls/$NUMBER" -q '.user.login')
+
+  # --paginate follows pageInfo until exhausted; --slurp wraps the pages in one array.
+  local pages
+  pages=$(gh api graphql --paginate --slurp -f query='
+query($owner:String!,$repo:String!,$pr:Int!,$endCursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$pr){
+      headRefOid
+      reviewThreads(first:100, after:$endCursor){
+        pageInfo{ hasNextPage endCursor }
+        nodes{
+          id isResolved isOutdated path line originalLine diffSide viewerCanResolve
+          first: comments(first:1){ totalCount nodes{ databaseId author{login __typename} body } }
+          last:  comments(last:1){ nodes{ author{login} body } }
+        }
+      }
+    }
+  }
+}' -F owner="$owner" -F repo="$name" -F pr="$NUMBER")
+
+  local head threads reviews
+  head=$(jq -r '.[0].data.repository.pullRequest.headRefOid' <<<"$pages")
+
+  threads=$(jq --arg pr_author "$pr_author" "$JQ_MARKERS"'
+    [.[].data.repository.pullRequest.reviewThreads.nodes[] | {
+        thread_id:     .id,
+        reply_to:      .first.nodes[0].databaseId,
+        resolved:      .isResolved,
+        resolvable:    .viewerCanResolve,
+        outdated:      .isOutdated,
+        author:        .first.nodes[0].author.login,
+        author_bot:    (.first.nodes[0].author.__typename == "Bot"),
+        author_is_pr_author: (.first.nodes[0].author.login == $pr_author),
+        path:          .path,
+        line:          (.line // .originalLine),
+        original_line: .originalLine,
+        line_side:     .diffSide,
+        position_head: null,
+        comment_count: .first.totalCount,
+        body:          .first.nodes[0].body,
+        last_author:   .last.nodes[0].author.login,
+        last_body:     .last.nodes[0].body,
+        source:        "thread"
+      } | thread_marker ]' <<<"$pages")
+
+  # --slurp here too: past one page, bare --paginate emits back-to-back arrays.
+  reviews=$(gh api "repos/$REPO/pulls/$NUMBER/reviews" --paginate --slurp \
+    | jq "$JQ_MARKERS"'
+      [.[][] | {id, author: .user.login, author_bot: (.user.type == "Bot"),
+                state, commit_id, submitted_at, body, source: "review"}
+       | select(.body != "") | review_marker ]')
+
+  emit "$head" "$pr_author" "$threads" "$reviews" \
+    '{"outdated":true,"review_commit_id":true,"author_bot_flag":true}'
+}
+
+# ============================================================ GitLab
+harvest_gitlab() {
+  local pid base mr head pr_author discussions notes threads reviews
+  pid=$(jq -rn --arg v "$REPO" '$v|@uri')
+  base="projects/$pid/merge_requests/$NUMBER"
+
+  mr=$(glab api "$base" --hostname "$HOST")
+  head=$(jq -r '.sha' <<<"$mr")
+  pr_author=$(jq -r '.author.username' <<<"$mr")
+
+  discussions=$(glab api "$base/discussions?per_page=100" --hostname "$HOST" --paginate --output ndjson | jq -s '.')
+  notes=$(glab api "$base/notes?per_page=100&order_by=created_at&sort=asc" --hostname "$HOST" --paginate --output ndjson | jq -s '.')
+
+  # A real thread: individual_note false, root note not a system note.
+  threads=$(jq --arg pr_author "$pr_author" "$JQ_MARKERS"'
+    [ .[] | select(.individual_note == false) | select(.notes[0].system != true)
+      | .notes[0] as $root | .notes[-1] as $last | {
+        thread_id:     .id,
+        reply_to:      .id,
+        resolved:      ($root.resolved // false),
+        resolvable:    ($root.resolvable // false),
+        outdated:      null,
+        author:        $root.author.username,
+        author_bot:    ($root.author.bot // null),
+        author_is_pr_author: ($root.author.username == $pr_author),
+        path:          ($root.position.new_path // $root.position.old_path // null),
+        line:          ($root.position.new_line // $root.position.old_line // null),
+        original_line: null,
+        line_side:     (if $root.position.new_line != null then "new" elif $root.position.old_line != null then "old" else null end),
+        position_head: ($root.position.head_sha // null),
+        comment_count: (.notes | length),
+        body:          $root.body,
+        last_author:   $last.author.username,
+        last_body:     $last.body,
+        source:        "discussion",
+        note_type:     $root.type
+      } | thread_marker ]' <<<"$discussions")
+
+  # Top-level bodies: non-system notes without a diff position that are not the root of a thread.
+  reviews=$(jq --argjson threads "$threads" --argjson discussions "$discussions" "$JQ_MARKERS"'
+    ([ $discussions[] | select(.individual_note == false) | .notes[0].id ]) as $roots
+    | [ .[] | select(.system != true) | select(.position == null) | select((.id as $i | $roots | index($i)) == null)
+        | {id, author: .author.username, author_bot: (.author.bot // null),
+           state: null, commit_id: null, submitted_at: .created_at, body, source: "note"}
+        | review_marker ]' <<<"$notes")
+
+  emit "$head" "$pr_author" "$threads" "$reviews" \
+    '{"outdated":false,"review_commit_id":false,"author_bot_flag":false}'
+}
+
+# ============================================================ output
+emit() {
+  local head="$1" pr_author="$2" threads="$3" reviews="$4" caps="$5"
+  jq -n --arg forge "$FORGE" --arg host "$HOST" --arg repo "$REPO" --arg pr "$NUMBER" \
+        --arg head "$head" --arg pr_author "$pr_author" \
+        --argjson t "$threads" --argjson r "$reviews" --argjson caps "$caps" \
+    '{forge:$forge, host:$host, repo:$repo, pr:($pr|tonumber), head:$head, pr_author:$pr_author,
+      capabilities:$caps, threads:$t, reviews:$r,
+      unresolved:[$t[]|select(.resolved==false)]|length}'
+}
+
+case "$FORGE" in
+  github) harvest_github ;;
+  gitlab) harvest_gitlab ;;
+  *) echo "unknown forge: $FORGE" >&2; exit 2 ;;
+esac

--- a/skills/debate-review/SKILL.md
+++ b/skills/debate-review/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: debate-review
+description: Two-model debate review of a GitHub PR or GitLab MR, posted as inline
+  comments. Use for any PR/MR review request.
+risk: safe
+category: code-quality
+source: https://github.com/amElnagdy/review-skills
+source_repo: amElnagdy/review-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/review-skills/blob/master/LICENSE
+compatibility: Requires Node 18+, `gh` (GitHub) or `glab` (GitLab) authenticated,
+  and delegate-skills installed for the main/debate lanes.
+metadata:
+  version: 0.1.0
+---
+# debate-review
+
+## When to Use
+
+- You have a GitHub PR or GitLab MR that needs a thorough pre-merge review.
+- You want a two-model debate (main reviewer vs. debate reviewer) to catch blind spots before posting inline comments.
+
+Two models argue before anything is posted. A main reviewer finds issues. A debate reviewer tries to
+knock them down and may add its own. The main reviewer then makes the final call, and one review with
+inline comments lands on the PR or MR. It posts from the user's own `gh` or `glab` account as a
+`COMMENT` review. It never approves and never requests changes.
+
+You are the orchestrator. You run one command and relay the result. You do not review the diff
+yourself, and you do not touch the PR.
+
+## Run it
+
+```bash
+node "<skill-dir>/scripts/review-pr.mjs" <pr-url | number> [--dry-run]
+```
+
+- `<pr-url>` is a GitHub `/pull/N` or GitLab `/-/merge_requests/N` URL. A bare number resolves against
+  the cwd's `origin`.
+- The reviewers are two delegate-skills lanes, `review-main` and `review-debate`. If either is missing
+  the script says so. Add them with `delegate-setup`. Pick two different implementers, since the debate
+  is only worth something when the second model doesn't share the first one's blind spots (main
+  `claude` or `grok`, debate `codex` at high effort is a good pair). For a one-off, pass
+  `--main <implementer>` or `--debate <implementer>`. Only implementers whose relay has `--read-only`
+  are accepted. These two lanes belong to the reviewer. Don't point them at a lane you use for other
+  work, such as a plan-debate lane.
+- `--dry-run` prints the review instead of posting it. Use it when the user wants to see the review
+  before it lands.
+- Exit code `3` means this head sha already has a debate-review. Re-run with `--force` to post again.
+- A run takes minutes, since it is two or three implementer sessions back to back. Run it in the
+  background and report the printed URL when it finishes. Don't poll tightly.
+
+All flags: `--help`. Contracts: [references/schema.md](references/schema.md). What gets posted:
+[references/comment-format.md](references/comment-format.md). The reviewer briefs live in `assets/prompts/`
+and the script fills them in; you don't need to read them.
+
+## After it posts
+
+Each posted comment carries a `<!-- debate-review:<id> status=... -->` marker. `babysit-pr` recognises
+the marker and handles the round like any other bot round (verify, fix blockers, reply in the thread,
+resolve). Don't act on the findings yourself unless the user asks.
+
+## Artifacts
+
+`~/.cache/debate-review/<owner>__<repo>/<N>/<head>/` holds `run.json` (all three documents, timings,
+what was posted) plus `main/`, `debate/`, and `final/`, each with the brief sent and the relay's
+`result.json`.
+
+
+## Limitations
+
+- Requires `delegate-skills` with `review-main` and `review-debate` lanes (two different implementers) and authenticated `gh`/`glab`.
+- Posts a single `COMMENT` review with inline comments — never approves or requests changes; re-run with `--force` if the same head was already reviewed.
+
+> Adapted from [amElnagdy/review-skills](https://github.com/amElnagdy/review-skills) (MIT).

--- a/skills/debate-review/assets/prompts/review-debate.md
+++ b/skills/debate-review/assets/prompts/review-debate.md
@@ -1,0 +1,51 @@
+You are the debate reviewer. A prior review pass produced the findings below. Judge them on the code,
+not on who wrote them. Treat every claim as unattributed. Your job is to break confidence in those
+findings and in the change itself, not to validate either. You review; you never edit. Return exactly
+one fenced ```json block matching `debate-review.debate.v1` and nothing after it.
+
+## Input
+- Repository checked out at the PR head. Base: `{{BASE}}`. Head: `{{HEAD}}`.
+- Diff: `git diff {{BASE}}...{{HEAD}}`.
+- Findings under review:
+{{FINDINGS_JSON}}
+
+## Stance
+Default to skepticism in both directions. The three verdicts are not symmetric. `refute` has the
+highest bar.
+
+- `refute` only when the refutation is constructible from the code. The claim is factually wrong
+  (quote the actual line). It is provably impossible (show the type, constant, or invariant). It is
+  already guarded in this diff (cite the guard). Or it has no observable effect.
+- `downgrade` when the defect is real but severity or confidence is overstated. That includes realistic
+  but unverified state (a race, nil on a rare but reachable path, a cold cache, an absent optional
+  field) when the finding was written as always-on or blocking.
+- `confirm` when you traced the path yourself and it holds. Realistic runtime state you cannot disprove
+  from the code is not grounds to refute.
+
+Do not refute a finding for being speculative or "dependent on runtime state" when that state is
+realistic. Re-read the code. Do not treat the finding's quoted evidence as proof that the line says
+what it claims.
+
+Then attack the change where the first pass did not look. `new_findings` is a gap sweep, not a second
+review. Add one only when it is `blocking`, you can name the trigger and the wrong result, and it is
+one of: auth or trust boundaries, data loss or duplication, idempotency or partial failure, races and
+ordering, schema drift or migrations. Do not relabel a non-blocking issue as blocking to get it
+through. Zero new findings is the expected outcome on most PRs. Do not pad.
+
+## Bar
+- Every verdict and every new finding carries evidence: `file:line` or quoted code. Where a grep or a
+  test settles it, run it and quote the command and output. A refutation without evidence is a
+  downgrade.
+- Do not invent files, lines, or runtime behaviour. If a conclusion rests on an inference, say so and
+  keep the confidence honest.
+- Material only. No style, naming, or cleanup.
+- New finding ids are `D1`, `D2`, and so on. Same shape as the findings under review.
+
+## Before you emit
+Check each verdict and each new finding. Is it adversarial rather than stylistic? Tied to a location
+you actually read? Plausible under a failure scenario you can state? Actionable? Drop anything that
+fails one. Every `F*` id still needs exactly one verdict. A verdict on an `F*` does not suppress a `D*`
+at the same location for a different failure. Record both.
+
+## Schema
+{{SCHEMA_DEBATE}}

--- a/skills/debate-review/assets/prompts/review-main.md
+++ b/skills/debate-review/assets/prompts/review-main.md
@@ -1,0 +1,64 @@
+You are the main reviewer of a pull request. You review; you never edit. Return exactly one fenced
+```json block matching `debate-review.findings.v1` (schema below) and nothing after it.
+
+## Input
+- Repository checked out at the PR head. Base ref: `{{BASE}}`. Head: `{{HEAD}}`.
+- Diff to review: `git diff {{BASE}}...{{HEAD}}`. Commits: `git log {{BASE}}..{{HEAD}} --oneline`.
+- PR title and body: {{PR_TITLE}}. {{PR_BODY}}
+- Spec source (issue or PRD), if any: {{SPEC}}
+- Standards sources found in the repo (CONTRIBUTING, CODING_STANDARDS, CLAUDE.md, AGENTS.md): {{STANDARDS}}
+
+## Review on these axes
+1. Correctness and security. Bugs, broken edge cases, auth, data, and idempotency hazards in the
+   changed code. Run three passes in order, and don't let one pass suppress another:
+   - Every hunk line by line, then its enclosing function. A defect on an unchanged line of a function
+     this PR touches is in scope. For each line ask what input, state, timing, or config makes it wrong.
+   - Every deleted or replaced line. Name the invariant it enforced, then find where the new code
+     re-establishes it. If you cannot find it, that is a finding.
+   - Every changed signature or contract. Grep the callers. Check each for a new precondition, a changed
+     return shape, a new exception, or an ordering dependency.
+2. Spec. Requirements asked for but missing or partial. Behaviour nobody asked for. Implemented but
+   wrong. Quote the spec line. If there is no spec, skip the axis and say so in `summary`.
+3. Standards. Violations of the repo's documented rules. Quote the exact rule text and the exact line
+   that breaks it. No "spirit of the doc". Do not invent a finding because a standards file exists.
+   Skip anything tooling enforces.
+4. Tests and docs, only when the diff touches them. Tests that don't pin behaviour. Docs that drift
+   from code.
+
+## Bar
+You are reviewing for precision. The passes above find candidates. Only candidates that clear this
+bar become findings.
+
+- Report a finding only if all of these hold:
+  1. It materially affects one of the axes above.
+  2. It is one discrete, actionable defect at one location.
+  3. Fixing it does not demand more rigour than the rest of this codebase already shows.
+  4. This diff introduced it, or it sits on an unchanged line of a function this PR touches, or it is
+     an unchanged caller broken by a contract this PR changed. Other pre-existing defects are out of
+     scope even when real.
+  5. If you claim it breaks code elsewhere, you identified that code and can cite it. "May affect" is
+     not a finding.
+  6. It does not rest on an unstated assumption about intent. A behaviour change stated in the PR body
+     is not a bug.
+- Never report what CI already catches (type errors, lint, formatting, missing imports, failing tests).
+  Never report naming, style, or "consider extracting".
+- `evidence` names the trigger (input, state, timing, or config) and the wrong result (output, crash,
+  or violated invariant). Where a grep or a test settles it, run it and quote the command and output.
+  If you cannot name the trigger, you do not have a finding.
+- `confidence`. Findings below the pipeline's `min_confidence` (default 0.5) are dropped before debate.
+  - `0.9` to `1.0`: you traced the trigger through to the wrong result.
+  - `0.7` to `0.9`: mechanism quoted, trigger realistic but unverified (concurrency, cold cache, absent
+    optional field, timeout).
+  - `0.5` to `0.7`: plausible, but a guard elsewhere was not ruled out. Say which guard you looked for.
+  - below `0.5`: do not emit it.
+- Anchor `line_start` and `line_end` to the new side of the diff. Pick the one to three lines that show
+  the defect, never more than ten. If the defect is outside the diff, anchor the nearest changed line
+  and say so in `evidence`.
+- `claim`, `evidence`, and `recommendation` are posted as an inline comment on a colleague's PR. One
+  short paragraph each. At most three lines of quoted code. Matter-of-fact, plain punctuation (no em
+  dashes). No flattery. No severity inflation. Say which inputs the bug depends on.
+- Do not stop at the first qualifying finding, and do not pad. Zero findings with `verdict: approve`
+  is the correct answer for a clean diff. Under 15 findings. `summary` under 300 words.
+
+## Schema
+{{SCHEMA_FINDINGS}}

--- a/skills/debate-review/assets/prompts/review-rebuttal.md
+++ b/skills/debate-review/assets/prompts/review-rebuttal.md
@@ -1,0 +1,42 @@
+You are the main reviewer again, making the final call. Two positions about this pull request are
+below. Treat both as unattributed arguments about the code. Not yours, not a peer's verdict. Decide
+each one from the repository. You review; you never edit. Return exactly one fenced ```json block
+matching `debate-review.final.v1` and nothing after it.
+
+## Input
+- Repository checked out at the PR head. Base: `{{BASE}}`. Head: `{{HEAD}}`.
+- Position A, the original findings (`F*`):
+{{FINDINGS_JSON}}
+- Position B, verdicts on each `F*` plus any additional findings (`D*`):
+{{DEBATE_JSON}}
+
+## Rules
+- Re-read the code for every `refute` and `downgrade` before deciding.
+  - `withdrawn` requires a positive reason of your own. Name the line, guard, type, invariant, or spec
+    clause that makes the original claim wrong, and put it in `debate_note`. "Position B disagreed" is
+    not a reason. Neither is the absence of a counter-argument.
+  - If the challenge is wrong and you can show why, use `contested`, with the why in `debate_note`.
+  - Accept a valid `downgrade` by changing `severity` and marking `agreed`.
+  - If every challenge really does collapse, withdraw them all. Do not keep a finding in order to
+    have kept one.
+- For each `D*`, apply the same bar as any finding. This diff introduced it (or it sits on an unchanged
+  line of a function this PR touches, or an unchanged caller broken by a changed contract). It is
+  discrete. `evidence` names a trigger and a wrong result. CI would not already catch it.
+  - Holds: `agreed`.
+  - Does not hold: `withdrawn`, with your evidence in `debate_note`. A rejected `D*` is never posted.
+    `contested` is reserved for `F*` findings you hold against a refutation.
+  - Restates an `F*` at the same location for the same failure: `withdrawn` with `debate_note`
+    "duplicate of F<n>". Keep the `F*`.
+- Carry every finding through with its final `status`. Drop nothing silently.
+- `claim`, `evidence`, `recommendation`, `debate_note`, and `summary` are posted on the PR for a
+  reader who never saw this exchange. Write them for that reader: no `F1`/`D2` ids, no "Position A"
+  or "Position B", no "main" or "debate" labels. Say "the second pass" or "the challenge" if you must
+  refer to it. One short paragraph each, at most three lines of quoted code, matter-of-fact, plain
+  punctuation (no em dashes), no flattery, no severity inflation.
+- `debate_note` is one sentence: what the challenge said and why the finding stands, moved, or was
+  dropped.
+- `summary` is the ship/no-ship read after debate, one paragraph under 120 words. Name what is still
+  blocking. Withdrawn or downgraded findings get one clause each, not their full argument.
+
+## Schema
+{{SCHEMA_FINAL}}

--- a/skills/debate-review/references/comment-format.md
+++ b/skills/debate-review/references/comment-format.md
@@ -1,0 +1,58 @@
+# What gets posted
+
+One review per head sha, never one per finding. The review event is `COMMENT`, so it cannot approve
+or request changes on the author's behalf. Inline comments anchor to `line_start` through `line_end`
+on the new side of the diff.
+
+## Levels
+
+Severity is shown on the PR as a level, computed by the script from the contract's fields:
+
+| Level | Meaning | Alert |
+| --- | --- | --- |
+| P0 | blocking on the security axis | `[!CAUTION]` (red) |
+| P1 | any other blocking finding | `[!WARNING]` (yellow) |
+| P2 | non-blocking | `[!NOTE]` (blue) |
+
+GitHub and GitLab (17.10+) render those alert blockquotes with colour; anything else shows a plain
+quote, which still reads.
+
+## Review body
+
+```
+<!-- debate-review head=<sha> main=<implementer> debate=<implementer> agreed=<n> contested=<m> p0=<a> p1=<b> p2=<c> -->
+| Level | Count |
+| --- | ---: |
+| P0 | <a> |
+| P1 | <b> |
+| P2 | <c> |
+| contested | <m> |
+
+**debate-review** on `<sha7>`, main `<implementer>`, second `<implementer>`.
+
+<final.summary>
+```
+
+## Inline comment
+
+```
+<!-- debate-review:<id> status=<agreed|contested> severity=<blocking|non-blocking> level=<P0|P1|P2> -->
+> [!CAUTION | WARNING | NOTE]
+> **<level>, agreed by both reviewers.** <claim>
+
+<evidence>
+
+Suggested: <recommendation>
+
+_<debate_note>_
+```
+
+A contested finding's first line reads `**<level>, contested. The second reviewer disagreed; the
+main reviewer holds it, reasons below.** <claim>`.
+
+## Why the HTML markers
+
+- `babysit-pr` finds these threads by the `<!-- debate-review` marker, not by a `[bot]` author. The
+  review is posted from the user's own account, so there is no bot author to match on.
+- `head=<sha>` lets a re-run detect that this push already has a review and skip it (or `--force`).
+- Replies inside a thread keep babysit-pr's attribution line: `I am <model-slug> writing on behalf of <user>.`

--- a/skills/debate-review/references/schema.md
+++ b/skills/debate-review/references/schema.md
@@ -1,0 +1,95 @@
+# debate-review JSON contracts
+
+Three documents flow through one run. Each implementer returns its document as the only fenced
+```json block in its final message. The script extracts it and checks it against the contract below.
+Anything that fails the check stops the run. Nothing gets posted.
+
+The script reads sections 1, 2, and 3 below by heading order and pastes them into the briefs. Don't
+reorder them or add a `##` heading above section 3.
+
+## 1. `debate-review.findings.v1`, main reviewer to script
+
+```json
+{
+  "schema": "debate-review.findings.v1",
+  "head": "<head sha reviewed>",
+  "verdict": "approve | needs-attention",
+  "summary": "one-paragraph ship/no-ship read",
+  "findings": [
+    {
+      "id": "F1",
+      "file": "src/foo.py",
+      "line_start": 42,
+      "line_end": 48,
+      "severity": "blocking | non-blocking",
+      "axis": "correctness | security | spec | standards | tests | docs",
+      "claim": "what is wrong, one sentence",
+      "evidence": "why: the code path, the quoted line, the spec line",
+      "recommendation": "concrete change",
+      "confidence": 0.0
+    }
+  ]
+}
+```
+
+- `id` is `F<n>` for the main reviewer and `D<n>` for findings the debate reviewer adds.
+- `line_start` and `line_end` must be lines on the new side of the PR diff, because GitHub and GitLab
+  can only anchor comments there. If the problem is outside the diff, anchor the nearest changed line
+  and say so in `evidence`.
+- `severity` follows babysit-pr. Blocking means it ships a defect, a security or data exposure, a spec
+  violation, a migration hazard, or a failing check. Everything else is non-blocking.
+- `confidence` is 0 to 1. Findings under `min_confidence` (default 0.5) are dropped before debate.
+
+## 2. `debate-review.debate.v1`, debate reviewer to script
+
+```json
+{
+  "schema": "debate-review.debate.v1",
+  "head": "<same sha>",
+  "verdicts": [
+    { "id": "F1", "verdict": "confirm | refute | downgrade", "reason": "one sentence", "evidence": "file:line or quoted code" }
+  ],
+  "new_findings": [ /* same shape as findings[], ids D1, D2, ... */ ]
+}
+```
+
+- Every `F*` id gets exactly one verdict. A missing id counts as `confirm` with reason "no objection".
+- `downgrade` means the defect is real but severity or confidence was overstated.
+- `refute` must carry evidence. A bare "I disagree" is recorded but weighted as `downgrade`.
+- `new_findings` is a gap sweep, not a second review. Blocking only, with a named trigger. Entries
+  below `min_confidence` are dropped the same way the main findings are. Zero new findings is the
+  expected outcome on most PRs.
+
+## 3. `debate-review.final.v1`, main reviewer (rebuttal pass) to script, then to the PR
+
+```json
+{
+  "schema": "debate-review.final.v1",
+  "head": "<same sha>",
+  "summary": "final ship/no-ship read after debate",
+  "findings": [
+    {
+      "id": "F1",
+      "status": "agreed | contested | withdrawn",
+      "severity": "blocking | non-blocking",
+      "file": "...", "line_start": 0, "line_end": 0,
+      "claim": "...", "evidence": "...", "recommendation": "...",
+      "debate_note": "one line: what the challenge said and why the finding was kept, dropped, or changed"
+    }
+  ]
+}
+```
+
+- `agreed`: both models stand behind it. Posted.
+- `contested`: the debate reviewer refuted it and the main reviewer holds, with evidence. Posted with a
+  `contested` tag, or dropped with `--contested drop`.
+- `withdrawn`: the main reviewer accepts the refutation. Never posted, kept in the run log.
+- `D*` findings can only end as `agreed` or `withdrawn`. A `D*` the main reviewer rejects with evidence
+  is `withdrawn` with the objection in `debate_note`. It is never `contested`, so a rejected claim from
+  the second model is never posted. A `D*` that duplicates an `F*` is `withdrawn` with `debate_note`
+  "duplicate of F<n>".
+
+## Run log
+
+`<out-dir>/run.json` keeps all three documents plus timings, implementers, lanes, and the posted
+comment ids, keyed by `owner/repo#N@head`. Re-running on the same head does nothing unless `--force`.

--- a/skills/debate-review/scripts/lib/diff.mjs
+++ b/skills/debate-review/scripts/lib/diff.mjs
@@ -1,0 +1,60 @@
+// Map the PR diff so findings can be anchored to lines the forge will accept an inline comment on.
+
+/**
+ * Parse a unified diff. Returns Map<path, Set<lineNumber>> of new-side lines that appear in the
+ * diff (added lines and context lines). Removed lines and deleted files are not commentable.
+ */
+export function diffLineMap(diffText) {
+  const map = new Map();
+  let file = null;
+  let line = 0;
+
+  for (const raw of diffText.split('\n')) {
+    if (raw.startsWith('diff --git ')) { file = null; continue; }
+    if (raw.startsWith('--- ')) continue;
+
+    if (raw.startsWith('+++ ')) {
+      const name = raw.slice(4).replace(/^b\//, '');
+      file = name === '/dev/null' ? null : name;
+      if (file) map.set(file, new Set());
+      continue;
+    }
+
+    const hunk = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+    if (hunk) { line = Number(hunk[1]); continue; }
+
+    if (!file) continue;
+    if (raw.startsWith('-')) continue;       // removed line: no new-side number
+    if (raw.startsWith('\\')) continue;      // "\ No newline at end of file"
+
+    // '+' (added) or ' ' (context): both have a new-side line number
+    map.get(file).add(line);
+    line += 1;
+  }
+  return map;
+}
+
+/**
+ * Pick a commentable anchor for a finding: { path, line, start_line?, snapped }.
+ * Returns null when the file is not in the diff at all.
+ */
+export function anchor(map, finding) {
+  const lines = map.get(finding.file);
+  if (!lines || lines.size === 0) return null;
+
+  const nearest = (n) => [...lines].reduce((best, x) => (Math.abs(x - n) < Math.abs(best - n) ? x : best));
+  const wantedEnd = finding.line_end || finding.line_start;
+  const end = lines.has(wantedEnd) ? wantedEnd : nearest(wantedEnd);
+
+  let start = lines.has(finding.line_start) ? finding.line_start : undefined;
+  if (start !== undefined && start >= end) start = undefined;
+
+  // A multi-line comment needs every line in between to be in the diff too.
+  if (start !== undefined) {
+    for (let i = start; i <= end; i++) {
+      if (!lines.has(i)) { start = undefined; break; }
+    }
+  }
+
+  return { path: finding.file, line: end, start_line: start, snapped: end !== wantedEnd };
+}

--- a/skills/debate-review/scripts/lib/dispatch.mjs
+++ b/skills/debate-review/scripts/lib/dispatch.mjs
@@ -1,0 +1,121 @@
+// Send a brief to an implementer through its delegate-skills relay, read-only, and get the JSON back.
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { json, log } from './shell.mjs';
+
+// ---------- locate delegate-skills ----------
+
+function skillRoots() {
+  const candidates = [
+    process.env.DELEGATE_SKILLS_DIR,
+    path.join(os.homedir(), '.agents', 'skills'),
+    path.join(os.homedir(), '.claude', 'skills'),
+    path.join(os.homedir(), '.codex', 'skills'),
+  ];
+  return candidates.filter(Boolean).filter(dir => fs.existsSync(dir));
+}
+
+function findScript(skill, script) {
+  for (const root of skillRoots()) {
+    const candidate = path.join(root, skill, 'scripts', script);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error(`cannot find ${skill}/scripts/${script}. Install delegate-skills (looked in: ${skillRoots().join(', ') || 'no skills dir'})`);
+}
+
+// ---------- lanes ----------
+
+/**
+ * Decide who plays a role. An explicit implementer wins; otherwise read the lane from the fleet config.
+ * Returns { implementer, lane }. lane is null when the implementer was given explicitly.
+ */
+export function resolveRole(role, { explicit, lane, cwd }) {
+  if (explicit) return { implementer: explicit, lane: null };
+
+  const config = json('node', [findScript('delegate-setup', 'config.mjs'), 'load', '--cwd', cwd]);
+  const entry = config.lanes && config.lanes[lane];
+  if (!entry) {
+    throw new Error(`lane "${lane}" is not configured. Run delegate-setup, or pass --${role} <implementer>`);
+  }
+  return { implementer: entry.implementer, lane };
+}
+
+// ---------- read-only capability ----------
+
+const probeCache = new Map();
+
+/** Ask the relay itself whether it has a --read-only mode (so new relays work without a code change). */
+function supportsReadOnly(relayPath) {
+  if (!probeCache.has(relayPath)) {
+    const help = spawnSync('node', [relayPath, '--help'], { encoding: 'utf8' });
+    const combined = `${help.stdout || ''}${help.stderr || ''}`;
+    probeCache.set(relayPath, /--read-only/.test(combined));
+  }
+  return probeCache.get(relayPath);
+}
+
+// ---------- dispatch ----------
+
+/**
+ * Run one implementer on a brief, read-only, inside `cwd`. Artifacts land in `<outDir>/<role>/`.
+ * Returns { text, seconds } where text is the implementer's final message.
+ */
+export function dispatch({ role, who, brief, cwd, outDir, timeout }) {
+  const relay = findScript(`${who.implementer}-delegate`, 'relay.mjs');
+  if (!supportsReadOnly(relay)) {
+    throw new Error(`${who.implementer}-delegate has no --read-only mode; choose another ${role} implementer`);
+  }
+
+  const dir = path.join(outDir, role);
+  fs.mkdirSync(dir, { recursive: true });
+  const briefPath = path.join(dir, 'brief.md');
+  fs.writeFileSync(briefPath, brief);
+
+  const args = [relay, '--brief', briefPath, '--cd', cwd, '--read-only', '--out-dir', dir, '--timeout', timeout];
+  if (who.lane) args.push('--lane', who.lane);
+
+  log(`${role}: ${who.implementer}${who.lane ? ` (lane ${who.lane})` : ''} …`);
+  const started = Date.now();
+  const proc = spawnSync('node', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, stdio: ['ignore', 'pipe', 'inherit'] });
+  const seconds = Math.round((Date.now() - started) / 1000);
+
+  const resultPath = path.join(dir, 'result.json');
+  if (!fs.existsSync(resultPath)) {
+    throw new Error(`${role}: relay exited ${proc.status} without writing result.json`);
+  }
+  const result = JSON.parse(fs.readFileSync(resultPath, 'utf8'));
+  if (result.status !== 'completed') {
+    throw new Error(`${role}: relay finished with status "${result.status}" (see ${dir})`);
+  }
+  if (result.readOnlyViolation === true) {
+    log(`WARNING ${role}: relay reported a read-only violation. Inspect ${dir}`);
+  }
+
+  log(`${role}: done in ${seconds}s`);
+  return { text: result.finalMessage || '', seconds };
+}
+
+// ---------- parse the answer ----------
+
+/** Pull the JSON document out of an implementer's final message (last ```json block wins). */
+export function extractJson(message) {
+  const blocks = [...message.matchAll(/```json\s*([\s\S]*?)```/g)].map(m => m[1]);
+  const candidates = blocks.length > 0
+    ? blocks.reverse()
+    : [message.slice(message.indexOf('{'), message.lastIndexOf('}') + 1)];
+
+  for (const candidate of candidates) {
+    try { return JSON.parse(candidate); } catch { /* try the next block */ }
+  }
+  throw new Error('implementer returned no parseable JSON block');
+}
+
+/** Throw unless the document carries the schema id we asked for. */
+export function expectSchema(doc, schema, role) {
+  if (!doc || doc.schema !== schema) {
+    throw new Error(`${role}: expected schema ${schema}, got ${doc && doc.schema}`);
+  }
+  return doc;
+}

--- a/skills/debate-review/scripts/lib/forge.mjs
+++ b/skills/debate-review/scripts/lib/forge.mjs
@@ -1,0 +1,178 @@
+// Everything that talks to GitHub (gh) or GitLab (glab): identify the PR, read it, post the review.
+import { text, json } from './shell.mjs';
+
+// ---------- identify the target ----------
+
+/** Turn a PR URL or a bare number (+ git origin) into { host, origin, owner, repo, number }. */
+export function parseTarget(target, originUrl) {
+  const github = target.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/pull\/(\d+)/);
+  if (github) {
+    return { host: 'github', origin: 'github.com', owner: github[1], repo: github[2], number: Number(github[3]) };
+  }
+
+  const gitlab = target.match(/^https?:\/\/([^/]+)\/(.+?)\/-\/merge_requests\/(\d+)/);
+  if (gitlab) {
+    const segments = gitlab[2].split('/');
+    return { host: 'gitlab', origin: gitlab[1], owner: segments.slice(0, -1).join('/'), repo: segments.at(-1), number: Number(gitlab[3]) };
+  }
+
+  if (/^\d+$/.test(target)) {
+    if (!originUrl) throw new Error('a bare PR number needs a git remote to resolve against');
+    const origin = parseOrigin(originUrl);
+    if (!origin) throw new Error(`cannot parse git origin: ${originUrl}`);
+    return { ...origin, number: Number(target) };
+  }
+
+  throw new Error(`unrecognised target: ${target}`);
+}
+
+/** Parse a git remote URL (https or ssh) into { host, origin, owner, repo }. */
+export function parseOrigin(url) {
+  const m = url.match(/^(?:https?:\/\/|git@|ssh:\/\/git@)([^/:]+)[/:](.+?)(?:\.git)?\/?$/);
+  if (!m) return null;
+  const origin = m[1].toLowerCase();
+  const segments = m[2].split('/');
+  return {
+    host: origin === 'github.com' ? 'github' : 'gitlab',
+    origin,
+    owner: segments.slice(0, -1).join('/'),
+    repo: segments.at(-1),
+  };
+}
+
+export function projectPath(t) {
+  return `${t.owner}/${t.repo}`;
+}
+
+function glabProject(t) {
+  return encodeURIComponent(projectPath(t));
+}
+
+function glabEnv(t) {
+  return { ...process.env, GITLAB_HOST: t.origin };
+}
+
+// ---------- read the PR ----------
+
+/** Fetch what we need about the PR/MR: title, body, head/base shas, branch names, fetch ref. */
+export function fetchPR(t) {
+  if (t.host === 'github') {
+    const pr = json('gh', ['pr', 'view', String(t.number), '--repo', projectPath(t),
+      '--json', 'title,body,url,headRefOid,headRefName,baseRefName']);
+    const baseSha = text('gh', ['api', `repos/${projectPath(t)}/pulls/${t.number}`, '-q', '.base.sha']);
+    return {
+      title: pr.title,
+      body: pr.body || '',
+      url: pr.url,
+      head: pr.headRefOid,
+      headRef: pr.headRefName,
+      baseRef: pr.baseRefName,
+      baseSha,
+      fetchRef: `pull/${t.number}/head`,
+    };
+  }
+
+  const mr = json('glab', ['api', `projects/${glabProject(t)}/merge_requests/${t.number}`], { env: glabEnv(t) });
+  return {
+    title: mr.title,
+    body: mr.description || '',
+    url: mr.web_url,
+    head: mr.diff_refs.head_sha,
+    headRef: mr.source_branch,
+    baseRef: mr.target_branch,
+    baseSha: mr.diff_refs.base_sha,
+    startSha: mr.diff_refs.start_sha,
+    fetchRef: `merge-requests/${t.number}/head`,
+  };
+}
+
+/** True if a debate-review for this head sha is already on the PR. */
+export function alreadyReviewed(t, pr) {
+  const marker = `<!-- debate-review head=${pr.head}`;
+  if (t.host === 'github') {
+    const bodies = text('gh', ['api', `repos/${projectPath(t)}/pulls/${t.number}/reviews`, '--paginate', '-q', '.[].body']);
+    return bodies.includes(marker);
+  }
+  const notes = text('glab', ['api', `projects/${glabProject(t)}/merge_requests/${t.number}/notes?per_page=100`, '--paginate'], { env: glabEnv(t) });
+  return notes.includes(marker);
+}
+
+/** Collect up to two referenced issues (#123) as the Spec source. */
+export function fetchSpec(t, pr, commitsText) {
+  const haystack = `${pr.title}\n${pr.body}\n${commitsText}`;
+  const numbers = [...new Set([...haystack.matchAll(/(?:^|[^\w/])#(\d+)\b/g)].map(m => m[1]))].slice(0, 2);
+
+  const parts = [];
+  for (const n of numbers) {
+    try {
+      if (t.host === 'github') {
+        const issue = json('gh', ['issue', 'view', n, '--repo', projectPath(t), '--json', 'title,body,url']);
+        parts.push(`Issue #${n}: ${issue.title}\n${issue.url}\n${issue.body || ''}`);
+      } else {
+        const issue = json('glab', ['api', `projects/${glabProject(t)}/issues/${n}`], { env: glabEnv(t) });
+        parts.push(`Issue #${n}: ${issue.title}\n${issue.web_url}\n${issue.description || ''}`);
+      }
+    } catch {
+      // "#12" was not an issue (PR number, plain text). skip it
+    }
+  }
+  if (parts.length === 0) return 'none found, skip the Spec axis';
+  return parts.join('\n\n---\n\n').slice(0, 8000);
+}
+
+// ---------- post the review ----------
+
+/**
+ * Post one review with inline comments. `comments` items: { path, line, start_line?, body }.
+ * Event is always COMMENT. never approve/request-changes on the author's behalf.
+ */
+export function postReview(t, pr, body, comments) {
+  if (t.host === 'github') return postGithub(t, pr, body, comments);
+  return postGitlab(t, pr, body, comments);
+}
+
+function postGithub(t, pr, body, comments) {
+  const payload = {
+    commit_id: pr.head,
+    event: 'COMMENT',
+    body,
+    comments: comments.map(c => ({
+      path: c.path,
+      line: c.line,
+      side: 'RIGHT',
+      body: c.body,
+      ...(c.start_line ? { start_line: c.start_line, start_side: 'RIGHT' } : {}),
+    })),
+  };
+  const review = json('gh', ['api', '--method', 'POST', `repos/${projectPath(t)}/pulls/${t.number}/reviews`, '--input', '-'],
+    { input: JSON.stringify(payload) });
+  return { reviewId: review.id, url: review.html_url };
+}
+
+function postGitlab(t, pr, body, comments) {
+  const base = `projects/${glabProject(t)}/merge_requests/${t.number}`;
+  const env = glabEnv(t);
+  const discussionIds = [];
+
+  for (const c of comments) {
+    const payload = {
+      body: c.body,
+      position: {
+        position_type: 'text',
+        base_sha: pr.baseSha,
+        start_sha: pr.startSha,
+        head_sha: pr.head,
+        new_path: c.path,
+        old_path: c.path,
+        new_line: c.line,
+      },
+    };
+    const discussion = json('glab', ['api', '--method', 'POST', `${base}/discussions`, '--input', '-'],
+      { input: JSON.stringify(payload), env });
+    discussionIds.push(discussion.id);
+  }
+
+  const note = json('glab', ['api', '--method', 'POST', `${base}/notes`, '--input', '-'],
+    { input: JSON.stringify({ body }), env });
+  return { noteId: note.id, discussionIds, url: pr.url };
+}

--- a/skills/debate-review/scripts/lib/render.mjs
+++ b/skills/debate-review/scripts/lib/render.mjs
@@ -1,0 +1,53 @@
+// What gets posted: the round body and each inline comment, as Markdown both forges render.
+// Severity on the PR is shown as a P-level inside a forge alert (CAUTION / WARNING / NOTE), so the
+// reader sees a colour before a word. The JSON contract stays blocking / non-blocking; the level is
+// computed here.
+
+/** P0: blocking on the security axis. P1: any other blocking. P2: non-blocking. */
+export function levelOf(finding) {
+  if (finding.severity === 'blocking') return finding.axis === 'security' ? 'P0' : 'P1';
+  return 'P2';
+}
+
+const ALERT = { P0: 'CAUTION', P1: 'WARNING', P2: 'NOTE' };
+
+function statusPhrase(f) {
+  if (f.status === 'contested') return 'contested. The second reviewer disagreed; the main reviewer holds it, reasons below.';
+  return 'agreed by both reviewers.';
+}
+
+/** One inline comment. The HTML marker stays first so babysit-pr and the re-run check find it. */
+export function renderInline(f) {
+  const level = levelOf(f);
+  const quote = (text) => text.split('\n').map(l => `> ${l}`.trimEnd()).join('\n');
+  let body = `<!-- debate-review:${f.id} status=${f.status} severity=${f.severity} level=${level} -->\n`;
+  body += `> [!${ALERT[level]}]\n`;
+  body += quote(`**${level}, ${statusPhrase(f)}** ${f.claim}`) + '\n\n';
+  if (f.evidence) body += `${f.evidence}\n\n`;
+  if (f.recommendation) body += `Suggested: ${f.recommendation}\n\n`;
+  if (f.debate_note) body += `_${f.debate_note}_\n`;
+  return body;
+}
+
+/** The one review body per head sha: marker, a count per level, who reviewed, the summary. */
+export function renderBody({ who, finalDoc, posted, unanchored }) {
+  const counts = { P0: 0, P1: 0, P2: 0 };
+  let contested = 0;
+  for (const f of posted) { counts[levelOf(f)] += 1; if (f.status === 'contested') contested += 1; }
+  const agreed = posted.length - contested;
+
+  let body = `<!-- debate-review head=${finalDoc.head} main=${who.main.implementer} debate=${who.debate.implementer} agreed=${agreed} contested=${contested} p0=${counts.P0} p1=${counts.P1} p2=${counts.P2} -->\n`;
+  body += `| Level | Count |\n| --- | ---: |\n`;
+  body += `| P0 | ${counts.P0} |\n| P1 | ${counts.P1} |\n| P2 | ${counts.P2} |\n| contested | ${contested} |\n\n`;
+  body += `**debate-review** on \`${finalDoc.head.slice(0, 7)}\`, main \`${who.main.implementer}\`, second \`${who.debate.implementer}\`.\n\n`;
+  body += `${finalDoc.summary || ''}\n`;
+
+  if (unanchored.length > 0) {
+    body += `\nFindings outside the diff (could not be anchored inline):\n`;
+    for (const f of unanchored) {
+      body += `\n- **${levelOf(f)}, ${f.status}.** \`${f.file}:${f.line_start}\` ${f.claim}`;
+    }
+    body += '\n';
+  }
+  return body;
+}

--- a/skills/debate-review/scripts/lib/shell.mjs
+++ b/skills/debate-review/scripts/lib/shell.mjs
@@ -1,0 +1,31 @@
+// Small wrappers around child_process so the rest of the code reads as plain steps.
+import { spawnSync } from 'node:child_process';
+
+const BIG = 64 * 1024 * 1024;
+
+/** Run a command. Throws on non-zero exit unless opts.allowFail. Returns the spawnSync result. */
+export function run(cmd, args, opts = {}) {
+  const result = spawnSync(cmd, args, { encoding: 'utf8', maxBuffer: BIG, ...opts });
+  if (result.error) {
+    throw new Error(`${cmd}: ${result.error.message}`);
+  }
+  if (result.status !== 0 && !opts.allowFail) {
+    throw new Error(`${cmd} ${args.join(' ')} → exit ${result.status}\n${result.stderr}`);
+  }
+  return result;
+}
+
+/** Run and return trimmed stdout. */
+export function text(cmd, args, opts) {
+  return run(cmd, args, opts).stdout.trim();
+}
+
+/** Run and parse stdout as JSON. */
+export function json(cmd, args, opts) {
+  return JSON.parse(text(cmd, args, opts));
+}
+
+/** Progress line on stderr (stdout is reserved for the result). */
+export function log(message) {
+  process.stderr.write(`[debate-review] ${message}\n`);
+}

--- a/skills/debate-review/scripts/lib/validate.mjs
+++ b/skills/debate-review/scripts/lib/validate.mjs
@@ -1,0 +1,104 @@
+// Contract checks for the three documents. The pipeline fails closed on any violation: a malformed
+// document is never posted as if it were a review.
+
+const SEVERITIES = new Set(['blocking', 'non-blocking']);
+const AXES = new Set(['correctness', 'security', 'spec', 'standards', 'tests', 'docs']);
+const VERDICTS = new Set(['confirm', 'refute', 'downgrade']);
+const STATUSES = new Set(['agreed', 'contested', 'withdrawn']);
+
+function problem(role, message) {
+  return new Error(`${role}: ${message}`);
+}
+
+function isInt(n) {
+  return Number.isInteger(n);
+}
+
+/** One finding object, shared by findings.v1 (F*), debate.v1 new_findings (D*), and final.v1. */
+function checkFinding(role, f, index, { idPrefix, needStatus }) {
+  const where = `finding[${index}]${f && f.id ? ` (${f.id})` : ''}`;
+  if (!f || typeof f !== 'object') throw problem(role, `${where} is not an object`);
+  if (typeof f.id !== 'string' || !new RegExp(`^${idPrefix}\\d+$`).test(f.id)) {
+    throw problem(role, `${where} id must look like ${idPrefix}<n>`);
+  }
+  if (typeof f.file !== 'string' || f.file.length === 0) throw problem(role, `${where} has no file`);
+  if (!isInt(f.line_start) || !isInt(f.line_end) || f.line_start < 1 || f.line_end < f.line_start) {
+    throw problem(role, `${where} has bad line_start/line_end`);
+  }
+  if (!SEVERITIES.has(f.severity)) throw problem(role, `${where} severity must be blocking|non-blocking`);
+  if (typeof f.claim !== 'string' || f.claim.length === 0) throw problem(role, `${where} has no claim`);
+  if (needStatus) {
+    if (!STATUSES.has(f.status)) throw problem(role, `${where} status must be agreed|contested|withdrawn`);
+  } else {
+    if (f.axis !== undefined && !AXES.has(f.axis)) throw problem(role, `${where} axis is not one of ${[...AXES].join('|')}`);
+    if (f.confidence !== undefined && !(typeof f.confidence === 'number' && f.confidence >= 0 && f.confidence <= 1)) {
+      throw problem(role, `${where} confidence must be a number in 0..1`);
+    }
+  }
+}
+
+function checkUniqueIds(role, list, label) {
+  const seen = new Set();
+  for (const item of list) {
+    if (seen.has(item.id)) throw problem(role, `duplicate ${label} id ${item.id}`);
+    seen.add(item.id);
+  }
+}
+
+/** debate-review.findings.v1 */
+export function validateFindings(doc, role = 'main') {
+  if (!doc || doc.schema !== 'debate-review.findings.v1') throw problem(role, 'expected schema debate-review.findings.v1');
+  if (!['approve', 'needs-attention'].includes(doc.verdict)) throw problem(role, 'verdict must be approve|needs-attention');
+  if (!Array.isArray(doc.findings)) throw problem(role, 'findings must be an array');
+  doc.findings.forEach((f, i) => checkFinding(role, f, i, { idPrefix: 'F', needStatus: false }));
+  checkUniqueIds(role, doc.findings, 'finding');
+  return doc;
+}
+
+/**
+ * debate-review.debate.v1. checked against the findings it answers.
+ * Missing verdicts are filled as confirm ("no objection"), as schema.md promises; duplicates are errors.
+ */
+export function validateDebate(doc, findings, role = 'debate') {
+  if (!doc || doc.schema !== 'debate-review.debate.v1') throw problem(role, 'expected schema debate-review.debate.v1');
+  if (!Array.isArray(doc.verdicts)) throw problem(role, 'verdicts must be an array');
+  doc.new_findings = Array.isArray(doc.new_findings) ? doc.new_findings : [];
+
+  const known = new Set(findings.findings.map(f => f.id));
+  const answered = new Set();
+  doc.verdicts.forEach((v, i) => {
+    if (!v || typeof v.id !== 'string') throw problem(role, `verdict[${i}] has no id`);
+    if (!known.has(v.id)) throw problem(role, `verdict[${i}] answers unknown finding ${v.id}`);
+    if (answered.has(v.id)) throw problem(role, `finding ${v.id} has more than one verdict`);
+    if (!VERDICTS.has(v.verdict)) throw problem(role, `verdict for ${v.id} must be confirm|refute|downgrade`);
+    answered.add(v.id);
+  });
+  for (const id of known) {
+    if (!answered.has(id)) doc.verdicts.push({ id, verdict: 'confirm', reason: 'no objection', evidence: '' });
+  }
+
+  doc.new_findings.forEach((f, i) => checkFinding(role, f, i, { idPrefix: 'D', needStatus: false }));
+  checkUniqueIds(role, doc.new_findings, 'new finding');
+  return doc;
+}
+
+/** debate-review.final.v1. every F* and D* must come back with a status; nothing may appear from nowhere. */
+export function validateFinal(doc, findings, debate, role = 'final') {
+  if (!doc || doc.schema !== 'debate-review.final.v1') throw problem(role, 'expected schema debate-review.final.v1');
+  if (!Array.isArray(doc.findings)) throw problem(role, 'findings must be an array');
+
+  doc.findings.forEach((f, i) => checkFinding(role, f, i, { idPrefix: '[FD]', needStatus: true }));
+  checkUniqueIds(role, doc.findings, 'final finding');
+
+  const expected = new Set([...findings.findings.map(f => f.id), ...debate.new_findings.map(f => f.id)]);
+  const returned = new Set(doc.findings.map(f => f.id));
+  for (const id of expected) if (!returned.has(id)) throw problem(role, `finding ${id} was dropped silently`);
+  for (const id of returned) if (!expected.has(id)) throw problem(role, `finding ${id} appeared from nowhere`);
+
+  for (const f of doc.findings) {
+    if (f.id.startsWith('D') && f.status === 'contested') {
+      throw problem(role, `${f.id}: a D* finding cannot be contested, only agreed or withdrawn`);
+    }
+  }
+  return doc;
+}

--- a/skills/debate-review/scripts/review-pr.mjs
+++ b/skills/debate-review/scripts/review-pr.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+// debate-review · review-pr.mjs
+//
+// Review a GitHub PR / GitLab MR with two implementers that debate, then post one review.
+//
+//   1. main reviewer   → findings
+//   2. debate reviewer → confirm / refute / downgrade each finding, add its own
+//   3. main reviewer   → final call (agreed / contested / withdrawn)
+//   4. post one review with inline comments (or print it with --dry-run)
+//
+// Shells out to git, gh|glab, and delegate-skills relays in --read-only. Never commits, never
+// edits the PR branch, never approves or requests changes.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { run, text, log } from './lib/shell.mjs';
+import { parseTarget, parseOrigin, projectPath, fetchPR, alreadyReviewed, fetchSpec, postReview } from './lib/forge.mjs';
+import { diffLineMap, anchor } from './lib/diff.mjs';
+import { resolveRole, dispatch, extractJson } from './lib/dispatch.mjs';
+import { validateFindings, validateDebate, validateFinal } from './lib/validate.mjs';
+import { renderInline, renderBody } from './lib/render.mjs';
+
+const SKILL_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const HELP = `debate-review · review-pr.mjs
+
+Usage:
+  node review-pr.mjs <pr-url | number> [options]
+
+Options:
+  --main <implementer>      Main reviewer (claude|codex|cursor|grok|opencode|pi…). Default: the lane.
+  --debate <implementer>    Debate reviewer. Default: the lane.
+  --main-lane <name>        Fleet lane for main (default: review-main).
+  --debate-lane <name>      Fleet lane for debate (default: review-debate).
+  --contested post|drop     Findings debate refuted but main kept (default: post, tagged).
+  --min-confidence <0-1>    Drop findings (main F* and debate D*) below this confidence (default: 0.5).
+  --base <ref>              Base override (default: the PR's base sha from the forge).
+  --repo-dir <dir>          Local clone to use (default: cwd if its origin matches, else a cache clone).
+  --out-dir <dir>           Artifacts (default: ~/.cache/debate-review/<owner>__<repo>/<N>/<head>).
+  --timeout <dur>           Per-implementer relay watchdog (default: 30m).
+  --dry-run                 Print the review instead of posting.
+  --force                   Post even if this head sha already has a debate-review.
+  --keep                    Keep the temporary worktree.
+  --help
+
+Exit codes: 0 posted/dry-run · 1 failure · 2 usage · 3 head already reviewed (use --force)
+`;
+
+// ============================================================ args
+
+function parseArgs(argv) {
+  const opts = {
+    mainLane: 'review-main',
+    debateLane: 'review-debate',
+    contested: 'post',
+    minConfidence: 0.5,
+    timeout: '30m',
+  };
+  const positional = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const value = () => {
+      if (i + 1 >= argv.length) fail(2, `missing value for ${arg}`);
+      return argv[++i];
+    };
+
+    if (arg === '--help' || arg === '-h') { process.stdout.write(HELP); process.exit(0); }
+    else if (arg === '--main') opts.main = value();
+    else if (arg === '--debate') opts.debate = value();
+    else if (arg === '--main-lane') opts.mainLane = value();
+    else if (arg === '--debate-lane') opts.debateLane = value();
+    else if (arg === '--contested') opts.contested = value();
+    else if (arg === '--min-confidence') opts.minConfidence = Number(value());
+    else if (arg === '--base') opts.base = value();
+    else if (arg === '--repo-dir') opts.repoDir = value();
+    else if (arg === '--out-dir') opts.outDir = value();
+    else if (arg === '--timeout') opts.timeout = value();
+    else if (arg === '--dry-run') opts.dryRun = true;
+    else if (arg === '--force') opts.force = true;
+    else if (arg === '--keep') opts.keep = true;
+    else if (arg.startsWith('--')) fail(2, `unknown option ${arg}`);
+    else positional.push(arg);
+  }
+
+  if (positional.length !== 1) fail(2, HELP);
+  if (!['post', 'drop'].includes(opts.contested)) fail(2, '--contested must be post or drop');
+  if (!(opts.minConfidence >= 0 && opts.minConfidence <= 1)) fail(2, '--min-confidence must be 0..1');
+
+  opts.target = positional[0];
+  return opts;
+}
+
+function fail(code, message) {
+  process.stderr.write(`review-pr: ${message}\n`);
+  process.exit(code);
+}
+
+// ============================================================ local checkout
+
+function currentOrigin() {
+  const r = run('git', ['remote', 'get-url', 'origin'], { allowFail: true });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+function cloneMatches(dir, target) {
+  const r = run('git', ['-C', dir, 'remote', 'get-url', 'origin'], { allowFail: true });
+  if (r.status !== 0) return false;
+  const origin = parseOrigin(r.stdout.trim());
+  return origin
+    && origin.owner.toLowerCase() === target.owner.toLowerCase()
+    && origin.repo.toLowerCase() === target.repo.toLowerCase();
+}
+
+/** Find a local clone of the PR's repo: --repo-dir, else cwd, else a cache clone. */
+function findClone(target, opts) {
+  if (opts.repoDir) {
+    if (!cloneMatches(opts.repoDir, target)) throw new Error(`--repo-dir origin does not match ${projectPath(target)}`);
+    return path.resolve(opts.repoDir);
+  }
+
+  const top = run('git', ['rev-parse', '--show-toplevel'], { allowFail: true });
+  if (top.status === 0 && cloneMatches(top.stdout.trim(), target)) return top.stdout.trim();
+
+  const cache = path.join(os.homedir(), '.cache', 'debate-review', 'clones', `${target.owner.replace(/\//g, '__')}__${target.repo}`);
+  if (!fs.existsSync(cache)) {
+    log(`cloning ${projectPath(target)} into ${cache}`);
+    const url = `https://${target.origin}/${projectPath(target)}.git`;
+    run('git', ['clone', '--filter=blob:none', url, cache], { stdio: ['ignore', 'ignore', 'inherit'] });
+  }
+  return cache;
+}
+
+/** Fetch the PR head + base and check the head out in a throwaway worktree. */
+function makeWorktree(clone, pr, baseBranch) {
+  run('git', ['-C', clone, 'fetch', '--quiet', 'origin', pr.fetchRef]);
+  run('git', ['-C', clone, 'fetch', '--quiet', 'origin', baseBranch]);
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debate-review-'));
+  fs.rmSync(dir, { recursive: true, force: true }); // git wants to create it
+  run('git', ['-C', clone, 'worktree', 'add', '--detach', '--quiet', dir, pr.head]);
+  return dir;
+}
+
+function removeWorktree(clone, dir) {
+  run('git', ['-C', clone, 'worktree', 'remove', '--force', dir], { allowFail: true });
+}
+
+// ============================================================ briefs
+
+function prompt(name, vars) {
+  let body = fs.readFileSync(path.join(SKILL_DIR, 'assets', 'prompts', name), 'utf8');
+  for (const [key, value] of Object.entries(vars)) {
+    body = body.split(`{{${key}}}`).join(value);
+  }
+  return body;
+}
+
+/** Section n of references/schema.md ("## 1.", "## 2.", "## 3."), the schema text the implementer sees. */
+function schemaSection(n) {
+  const md = fs.readFileSync(path.join(SKILL_DIR, 'references', 'schema.md'), 'utf8');
+  return '## ' + md.split(/^## /m)[n];
+}
+
+/** Files that document how code should be written in this repo (the Standards axis). */
+function findStandards(worktree) {
+  const candidates = ['CONTRIBUTING.md', 'CODING_STANDARDS.md', 'CLAUDE.md', 'AGENTS.md', '.github/PULL_REQUEST_TEMPLATE.md', 'docs/agents'];
+  const found = [];
+  for (const rel of candidates) {
+    const abs = path.join(worktree, rel);
+    if (!fs.existsSync(abs)) continue;
+    if (fs.statSync(abs).isDirectory()) {
+      for (const f of fs.readdirSync(abs)) found.push(path.join(rel, f));
+    } else {
+      found.push(rel);
+    }
+  }
+  return found.length ? found.join(', ') : 'none found, skip the Standards axis';
+}
+
+// ============================================================ flow
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  // --- what are we reviewing?
+  const target = parseTarget(opts.target, currentOrigin());
+  const pr = fetchPR(target);
+  log(`${projectPath(target)}#${target.number} @ ${pr.head.slice(0, 10)} (${pr.headRef} → ${pr.baseRef})`);
+
+  if (!opts.force && !opts.dryRun && alreadyReviewed(target, pr)) {
+    log('this head already has a debate-review; use --force to post another');
+    process.exit(3);
+  }
+
+  // --- check it out
+  const clone = findClone(target, opts);
+  const worktree = makeWorktree(clone, pr, pr.baseRef);
+  const baseRef = opts.base || pr.baseSha; // the forge's own base sha: still valid after merge
+
+  const outDir = opts.outDir || path.join(os.homedir(), '.cache', 'debate-review',
+    `${target.owner.replace(/\//g, '__')}__${target.repo}`, String(target.number), pr.head.slice(0, 12));
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const runLog = { schema: 'debate-review.run.v1', target, pr, outDir, startedAt: new Date().toISOString(), stages: {} };
+  const save = () => fs.writeFileSync(path.join(outDir, 'run.json'), JSON.stringify(runLog, null, 2));
+
+  try {
+    const diff = text('git', ['-C', worktree, 'diff', `${baseRef}...HEAD`]);
+    if (!diff.trim()) throw new Error('empty diff, nothing to review');
+    const commits = text('git', ['-C', worktree, 'log', `${baseRef}..HEAD`, '--oneline']);
+    const lineMap = diffLineMap(diff);
+
+    const who = {
+      main: resolveRole('main', { explicit: opts.main, lane: opts.mainLane, cwd: clone }),
+      debate: resolveRole('debate', { explicit: opts.debate, lane: opts.debateLane, cwd: clone }),
+    };
+    runLog.who = who;
+    save();
+
+    const common = {
+      BASE: baseRef,
+      HEAD: pr.head,
+      PR_TITLE: pr.title,
+      PR_BODY: pr.body.slice(0, 6000) || '(empty)',
+    };
+    const send = (role, implementer, brief) => dispatch({ role, who: implementer, brief, cwd: worktree, outDir, timeout: opts.timeout });
+
+    // --- 1. main review
+    const mainBrief = prompt('review-main.md', {
+      ...common,
+      SPEC: fetchSpec(target, pr, commits),
+      STANDARDS: findStandards(worktree),
+      SCHEMA_FINDINGS: schemaSection(1),
+    });
+    const mainRun = send('main', who.main, mainBrief);
+    const findings = validateFindings(extractJson(mainRun.text));
+    findings.findings = findings.findings.filter(f => (f.confidence ?? 1) >= opts.minConfidence);
+    runLog.stages.main = { seconds: mainRun.seconds, doc: findings };
+    save();
+    log(`main: ${findings.findings.length} finding(s) after the confidence filter`);
+
+    // --- 2. debate
+    const debateBrief = prompt('review-debate.md', {
+      ...common,
+      FINDINGS_JSON: JSON.stringify(findings, null, 2),
+      SCHEMA_DEBATE: schemaSection(2),
+    });
+    const debateRun = send('debate', who.debate, debateBrief);
+    const debate = validateDebate(extractJson(debateRun.text), findings);
+    debate.new_findings = debate.new_findings.filter(f => (f.confidence ?? 1) >= opts.minConfidence);
+    runLog.stages.debate = { seconds: debateRun.seconds, doc: debate };
+    save();
+    log(`debate: ${debate.verdicts.length} verdict(s), ${debate.new_findings.length} new finding(s) after the confidence filter`);
+
+    // --- 3. final call (skipped when there is nothing to argue about)
+    let finalDoc;
+    const nothingToDebate = findings.findings.length === 0 && debate.new_findings.length === 0;
+    if (nothingToDebate) {
+      finalDoc = {
+        schema: 'debate-review.final.v1',
+        head: pr.head,
+        summary: findings.summary || 'No material findings from either reviewer.',
+        findings: [],
+      };
+    } else {
+      const finalBrief = prompt('review-rebuttal.md', {
+        ...common,
+        FINDINGS_JSON: JSON.stringify(findings, null, 2),
+        DEBATE_JSON: JSON.stringify(debate, null, 2),
+        SCHEMA_FINAL: schemaSection(3),
+      });
+      const finalRun = send('final', who.main, finalBrief);
+      finalDoc = validateFinal(extractJson(finalRun.text), findings, debate);
+      runLog.stages.final = { seconds: finalRun.seconds, doc: finalDoc };
+    }
+    finalDoc.head = pr.head;
+    const axisOf = new Map([...findings.findings, ...debate.new_findings].map(f => [f.id, f.axis]));
+    for (const f of finalDoc.findings || []) if (!f.axis) f.axis = axisOf.get(f.id);
+    save();
+
+    // --- 4. choose what to post and anchor it to the diff
+    const toPost = (finalDoc.findings || []).filter(f =>
+      f.status === 'agreed' || (f.status === 'contested' && opts.contested === 'post'));
+
+    const comments = [];
+    const unanchored = [];
+    for (const f of toPost) {
+      const a = anchor(lineMap, f);
+      if (!a) { unanchored.push(f); continue; }
+      let body = renderInline(f);
+      if (a.snapped) body += `\n_(anchored to the nearest diff line; the finding named ${f.line_start}-${f.line_end})_\n`;
+      comments.push({ ...a, body });
+    }
+    const body = renderBody({ who, finalDoc, posted: toPost, unanchored });
+
+    runLog.posted = {
+      body,
+      comments,
+      withdrawn: (finalDoc.findings || []).filter(f => f.status === 'withdrawn').map(f => f.id),
+    };
+    save();
+
+    // --- 5. post or print
+    if (opts.dryRun) {
+      process.stdout.write(`\n===== REVIEW BODY =====\n${body}\n`);
+      for (const c of comments) {
+        const range = c.start_line ? `${c.start_line}-${c.line}` : String(c.line);
+        process.stdout.write(`\n===== ${c.path}:${range} =====\n${c.body}\n`);
+      }
+      process.stdout.write(`\n(dry-run: nothing posted; artifacts in ${outDir})\n`);
+    } else {
+      const result = postReview(target, pr, body, comments);
+      runLog.postResult = result;
+      save();
+      log(`posted ${comments.length} inline comment(s): ${result.url}`);
+      process.stdout.write(`${result.url}\n`);
+    }
+  } finally {
+    if (!opts.keep) removeWorktree(clone, worktree);
+    runLog.finishedAt = new Date().toISOString();
+    save();
+  }
+}
+
+main().catch(error => {
+  process.stderr.write(`review-pr: ${error.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds 2 skills from [amElnagdy/review-skills](https://github.com/amElnagdy/review-skills) (MIT, 45 stars) — two-model debate review and automated PR babysitting. Closes https://github.com/FrancoStino/opencode-skills-collection/issues/115.

**Skills:**
- `debate-review` — Two-model debate review of a GitHub PR or GitLab MR, posted as inline comments. Main reviewer finds issues, debate reviewer challenges them, main makes final call. Posts one `COMMENT` review with inline comments. Requires `delegate-skills` lanes `review-main`/`review-debate`.
- `babysit-pr` — Babysits a PR/MR through bot review rounds: harvests threads from debate-review/Codex/Greptile, verifies each finding, fixes blockers, replies in-thread, resolves, and re-triggers review.

**Source:** `amElnagdy/review-skills` (master), MIT. `delegate-skills` is an external runtime dependency (same author, 1.3k stars) — documented in `compatibility` and PR description, not bundled.

### Quality Bar Checklist

- [x] Standards read (CONTRIBUTING.md, `docs/policies/*`, `docs/guides/*`)
- [x] Metadata valid (`name`/`description`/`license`/`compatibility`/`risk`/`source`/`source_repo`/`source_type`/`date_added`/`license_source` plus `category: code-quality`)
- [x] Risk labels correct (`safe` — review/babysit, no offensive actions; babysit fixes are to PR branch only)
- [x] Triggers clear (`## When to Use` added to both skills)
- [x] Limitations documented (`## Limitations` with delegate-skills/gh+glab requirements and `> Adapted from` provenance)
- [x] Security review: `validate_skills --strict` ✅, `audit_skills --strict` ✅ (within budget), `security_scanner` ✅ (0 flags), `docs_security_content` ✅, `validate_references` ✅, `check_readme_credits` (README + `docs/sources/sources.md` updated)
- [x] Manual logic review completed
- [x] `npm run validate` / `scripts` tests not applicable (skills only)
- [x] Source-only PR (no generated `data/*`, `CATALOG.md`, `skills_index.json`)
- [x] Credits: `docs/sources/sources.md` (Quality & Verification) and `README.md` Community Contributors updated
- [x] License provenance: `license: MIT` + `license_source: https://github.com/amElnagdy/review-skills/blob/master/LICENSE` declared

> **Note on `pr-policy` fork safety:** These skills bundle executable helpers (`scripts/review-pr.mjs` + `scripts/threads.sh` and `scripts/lib/*.mjs`). They live under `skills/<name>/scripts/` and use extensions `.mjs`/`.sh` which are intentionally flagged as `unknown_extension`/`unapproved_path` by `workflow-contract` and require human maintainer review. This is expected for skills with executable code — the scripts are the skill's core runtime (see `skills/007` precedent). No `curl|bash` or other high-risk patterns are present.
