### PR TITLE
feat: add 18 delegate skills from amElnagdy/delegate-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-<!-- registry-sync: version=16.0.0; skills=2026; stars=45322; updated_at=2026-08-24T05:22:46+00:00 -->
+<!-- registry-sync: version=16.1.0; skills=2028; stars=45378; updated_at=2026-08-25T17:54:41+00:00 -->
 # AAS Core — Agentic Awesome Skills
 
 > **Local, agent-owned skill stacks for coding agents—from complete catalog access to a reproducible, reviewable plan.**
 
-**Current release: V16.0.0.** This release includes AAS Core for complete local catalog search, agent-owned selection, manifest validation, planning, and diagnosis. Apply and recovery remain experimental and outside the supported preview path.
+**Current release: V16.1.0.** This release includes AAS Core for complete local catalog search, agent-owned selection, manifest validation, planning, and diagnosis. Apply and recovery remain experimental and outside the supported preview path.
 
 Codex or Claude inspects your project and chooses exact skills from the complete local AAS catalog. AAS Core does not rank or recommend them: its read-only `compose_stack` tool validates the agent-owned selection in memory, and a client or the `aas` CLI can persist it as `aas-stack.json` and produce an immutable plan before any target change.
 
-**[Read the AAS Core preview guide →](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md)**
+**[Read the AAS Core preview guide →](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md)**
 
 ```text
 Project
@@ -67,7 +67,7 @@ AAS Core gives the repository one product model:
 | Apply and recovery | Experimental, explicit opt-in, outside the supported safety claim |
 | Semantic suitability certification | Not provided |
 
-Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md) for the exact trust boundaries, current preview status, Codex/Claude setup model, and CLI lifecycle.
+Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md) for the exact trust boundaries, current preview status, Codex/Claude setup model, and CLI lifecycle.
 
 ## Why This Repo
 
@@ -76,7 +76,7 @@ Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob
 - **Approval before writes**: the durable artifacts are an approved stack and immutable plan, not an opaque one-shot install.
 - **Installable, not just inspirational**: use the compatible legacy installer or plugin distributions when direct delivery is the right path.
 - **Built for major agent workflows**: Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, Kiro, OpenCode, Copilot, and more.
-- **Broad coverage with real utility**: 2,026+ skills across development, testing, security, infrastructure, product, and marketing.
+- **Broad coverage with real utility**: 2,028+ skills across development, testing, security, infrastructure, product, and marketing.
 - **Inspect before installing**: the hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) reviews agent-produced stack manifests and immutable plans without browser-side installation.
 - **Focused delivery remains available**: specialized plugins package proven sets for web, security, data, docs, DevOps, QA, OSS, or agent/MCP workflows.
 - **Useful whether you want breadth or curation**: install the full catalog, choose a specialized plugin, start with bundles, or compare alternatives before installing.
@@ -94,7 +94,7 @@ Direct file search can find candidate prose, but it leaves the result in the con
 - [Choose Your Tool](#choose-your-tool)
 - [Quick FAQ](#quick-faq)
 - [Bundles & Workflows](#bundles--workflows)
-- [Browse 2,026+ Skills](#browse-2026-skills)
+- [Browse 2,028+ Skills](#browse-2028-skills)
 - [Troubleshooting](#troubleshooting)
 - [Stable Skills Manifest v1](#stable-skills-manifest-v1)
 - [Support the Project](#support-the-project)
@@ -107,7 +107,7 @@ Direct file search can find candidate prose, but it leaves the result in the con
 
 ## Installation
 
-For Codex and Claude, start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md): configure the local MCP, ask the agent to inspect the project and choose exact IDs from the full catalog, review the proposed `aas-stack.json`, then run CLI validation and planning. The MCP and validation are read-only. Planning writes only the requested plan artifact; it does not materialize skill payloads or AAS managed state in the target.
+For Codex and Claude, start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md): configure the local MCP, ask the agent to inspect the project and choose exact IDs from the full catalog, review the proposed `aas-stack.json`, then run CLI validation and planning. The MCP and validation are read-only. Planning writes only the requested plan artifact; it does not materialize skill payloads or AAS managed state in the target.
 
 Use direct installation when your host does not yet have a native AAS Core adapter, when you already know the exact skill IDs, or when you deliberately prefer manual selection:
 
@@ -261,7 +261,7 @@ The supported path covers complete local catalog search and inspection, agent-ow
 
 ### How do I install it?
 
-For AAS Core, follow the [preview guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md) and use only a package release whose notes explicitly state that it includes Core. Release 14.6.0 predates Core; Core-capable releases begin with the 15.x line.
+For AAS Core, follow the [preview guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md) and use only a package release whose notes explicitly state that it includes Core. Release 14.6.0 predates Core; Core-capable releases begin with the 15.x line.
 
 For direct skill distribution, use a tool-specific flag such as `--codex`,
 `--cursor`, `--gemini`, or `--claude` to place skills in the directory your
@@ -339,7 +339,7 @@ Remove `--dry-run` only after reviewing the install, update, and removal plan. U
 
 The hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) imports and reviews AAS Core stack manifests and immutable plans in browser memory. It does not access the filesystem, generate an approved plan, or install skills.
 
-## Browse 2,026+ Skills
+## Browse 2,028+ Skills
 
 Use the root repo as a landing page, then jump into the deeper surface that matches your intent.
 
@@ -377,7 +377,7 @@ Use the root repo as a landing page, then jump into the deeper surface that matc
 Keep the root README short; use the dedicated docs for recovery and platform-specific guidance.
 
 - If you are confused after installation, start with the [Usage Guide](docs/users/usage.md).
-- For Core setup, trust boundaries, stack manifests, and preview status, use the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md).
+- For Core setup, trust boundaries, stack manifests, and preview status, use the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md).
 - On native Windows, `AAS_ADAPTER_WINDOWS_ACL_FAILED` refers to the configuration path checked with PowerShell `Get-Acl`, not the cache and not `icacls`; do not approve until preview returns an approval digest.
 - If you integrate agentic-awesome-skills into a host, read the discovery contract first: [Stable Skills Manifest v1](docs/users/discovery-manifest.md).
 - For Windows truncation or context crash loops, use [docs/users/windows-truncation-recovery.md](docs/users/windows-truncation-recovery.md).
@@ -388,7 +388,7 @@ Keep the root README short; use the dedicated docs for recovery and platform-spe
 
 ## Stable Skills Manifest v1
 
-This is the stable **direct-host discovery manifest** for integrations that load individual `SKILL.md` files. It is not `aas-stack.json`, the verified AAS Core catalog, or the Core composition contract. Core users should start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md); custom host integrations can continue using the manifest below.
+This is the stable **direct-host discovery manifest** for integrations that load individual `SKILL.md` files. It is not `aas-stack.json`, the verified AAS Core catalog, or the Core composition contract. Core users should start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.1.0/docs/users/aas-core.md); custom host integrations can continue using the manifest below.
 
 Host integrations should use:
 
@@ -513,6 +513,7 @@ Key source families include:
 - **[Phelan164/codex-howto](https://github.com/Phelan164/codex-howto)**: Source for the `maintain-codex-wiki` skill - review-first engineering knowledge with provenance, explicit capture and promotion, and deterministic structural checks (MIT).
 - **[0xsarwagya/ontoly](https://github.com/0xsarwagya/ontoly)**: Source for the `ontoly-software-graph` skill - deterministic TypeScript software graphs, MCP-backed architecture review, request tracing, impact analysis, and dependency analysis (MIT).
 - [amElnagdy/guard-skills](https://github.com/amElnagdy/guard-skills) — Code Quality & Testing Guard Skills (by amElnagdy)
+- **[amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills)**: Source for 18 delegation skills (`delegate-setup` + 17 implementer relays for Claude/Codex/Cursor/OpenCode and 13 more) — multi-agent delegation and fleet orchestration with Node built-ins only, relay never commits (MIT).
 
 - [cloudflare/security-audit-skill](https://github.com/cloudflare/security-audit-skill) — Cloudflare Web Security Audit Skill (by Cloudflare)
 
@@ -554,6 +555,7 @@ Key source families include:
 - **[JunsW/feature-track](https://github.com/JunsW/feature-track)**: Source for the `feature-tracking` skill - lightweight repository-native feature memory for current status, source-of-truth documents, decisions, risks, and cross-session handoff (MIT).
 - **[JularDepick/user-thoughts.SKILL](https://github.com/JularDepick/user-thoughts.SKILL)**: Source for the `user-thoughts` skill - persistent project idea repository workflows for capturing decisions, tech stack notes, UI/UX rationale, and MDBASE-backed project memory (MIT).
 - **[TheaDust/lore](https://github.com/TheaDust/lore)**: Source for the `lore` skill - Markdown-only, zero-dependency long-term project memory for AI coding agents, with monorepo scopes, two-section platform mirrors, and stdlib Python helpers (MIT).
+- **[rainmanjam/poka-yoke](https://github.com/rainmanjam/poka-yoke)**: Source for the `poka-yoke` skill - software mistake-proofing through control, warning, detection, and source-inspection guardrails (MIT).
 - **[ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills)**: Source for the `youtube-full` skill - TranscriptAPI-backed YouTube transcripts, search, channel browsing, playlists, and cloud-safe video research workflows (MIT).
 - **[ZeroPointRepo/zillow-skills](https://github.com/ZeroPointRepo/zillow-skills)**: Source for the `us-property-data` skill - U.S. property lookup, valuation, listing, tax, school, photo, and price-history guidance through the independent Zillapi API (MIT-0).
 - **[Antheurus/anywrite](https://github.com/Antheurus/anywrite)**: Source for the `anywrite` skill - low-context CLI access to Anytype's local API for objects, properties, files, search, chat, and other workspace operations (MIT).

--- a/docs/sources/sources.md
+++ b/docs/sources/sources.md
@@ -130,6 +130,11 @@ The following skills were added during the March 2026 skills update:
 | `rails-upgrade` | [robzolkos](https://github.com/robzolkos/skill-rails-upgrade) | Compatible | Rails upgrade assistant |
 | `vexor-cli` | [scarletkc/vexor](https://github.com/scarletkc/vexor) | Compatible | Semantic file discovery |
 
+### Agent Orchestration & Delegation
+| Skill | Source | License | Notes |
+|-------|--------|---------|-------|
+| `delegate-setup`, `agy-delegate`, `aider-delegate`, `claude-delegate`, `cline-delegate`, `codex-delegate`, `commandcode-delegate`, `copilot-delegate`, `cursor-delegate`, `grok-delegate`, `kimi-delegate`, `omp-delegate`, `opencode-delegate`, `pi-delegate`, `qoder-delegate`, `vibe-delegate`, `warp-delegate`, `zcode-delegate` | [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) | MIT | Multi-agent delegation to 17 implementer CLIs with fleet lanes (Node built-ins only, relay never commits) |
+
 ### Machine Learning & Data
 | Skill | Source | License | Notes |
 |-------|--------|---------|-------|

--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: agy-delegate
+description: Delegate a coding task to the Google Antigravity CLI (`agy`) as a background
+  implementer, then review its diff and land it yourself. Use this whenever the user
+  wants to hand implementation work to Antigravity or agy - phrasings like "have Antigravity
+  do X", "delegate this to...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `agy` CLI installed and authenticated, Node.js, and git.
+  The orchestrator must be able to run shell commands and read files. Shell examples
+  assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+# Antigravity Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `agy` implementer (`Google Antigravity`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** - the Google Antigravity CLI (`agy`) - then review what it produced and land it
+yourself. You write the brief and own the judgment; Antigravity does the typing in its own
+conversation; you verify and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so any comparable agent can drive it. It is designed for and run on Claude
+Code; treat other orchestrators as designed-for, not yet proven.
+
+## When NOT to use this
+
+- The task is small enough to just do inline - delegation overhead is not worth it.
+- The `agy` CLI is not installed or not authenticated. Install it from Antigravity's CLI docs and run
+  the first-launch setup.
+- You want to write the code yourself, or you only need Antigravity's opinion on code you wrote (a
+  `--read-only` dispatch covers review without edits, but a plain review may not need delegation at all).
+
+## Prerequisites (check once)
+
+1. `agy help` succeeds. If not, install the Antigravity CLI and complete first-launch setup.
+2. `agy models` succeeds. That proves the CLI can authenticate and list the available model labels.
+3. You are in (or will point `--cd` at) the target git repository.
+
+These checks do not prove that a headless write will be approved. In `--print` mode, Antigravity
+cannot prompt for a write permission and may auto-deny it. The relay detects that denial instead of
+reporting completion.
+
+## Choose the implementer model
+
+`agy` has a configured default model, so `--model` is optional. Use it when the human has a preferred
+Antigravity model label for the task. Otherwise let Antigravity use its own current default rather than
+guessing.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Antigravity sees only the text you send plus what it can inspect in the workspace - no chat history, no
+shared context. Everything the task needs goes in the brief: the goal, the current state, what to
+change, what to leave untouched, the project's **actual** gate commands, and a report contract. Tell
+Antigravity it will **not** commit (you will). Keep one task per brief. Full guidance and a template:
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to Antigravity with the bundled helper. It wraps `agy --print`, captures the run, and
+writes a structured `result.json` - so your only job is "run a command, read a file." (`<skill-dir>`
+below is this skill's installed directory - the folder containing this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a model label:                 add --model "<label from agy models>"
+# reasoning effort (low, medium, high): add --effort high
+# read-only (plan mode — no edits):     add --read-only
+# enable Antigravity terminal sandbox:  add --sandbox
+# resume the most recent conversation:  add --resume-last  (delta brief only)
+# see all options:                      node .../relay.mjs --help
+```
+
+The helper starts a fresh Antigravity project by default and passes `--add-dir <repo>` (the `--cd`
+path, absolute) so `agy` has an explicit workspace. It does **not** pass `--dangerously-skip-permissions` by default.
+Mechanics, flags, and the `result.json` shape: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Antigravity finishes, so back it with whatever your orchestrator offers and
+resume when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file.
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line. The implementer's full report is
+the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
+
+### 4. Review - do not trust the self-report
+
+Antigravity's `result.json` includes its own final message and any gate claims. **Re-verify, don't
+accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1).
+- **Read the diff** against the brief: did Antigravity do what was asked, nothing more and nothing less?
+  `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Only after the gates pass and the
+diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--resume-last` and review again.
+
+## Permission model
+
+Antigravity owns its own permission policy. The relay does not bypass it by default. Use
+`--dangerously-skip-permissions` only when the human explicitly accepts that Antigravity may
+auto-approve tool permission requests. `--read-only` runs `agy` in plan mode (`--mode plan`),
+removing write and edit paths, and is mutually exclusive with `--dangerously-skip-permissions`.
+Use `--sandbox` when you want Antigravity's terminal sandbox enabled for the run.
+Antigravity's own help says `--dangerously-skip-permissions` auto-approves all tool permission
+requests without prompting, including a request to act outside the sandbox. Do not treat
+`--sandbox` as an enforced boundary when the flags are combined; treat the run as full access.
+If headless `--print` auto-denies a write, the relay reports `status: "failed"` and exits non-zero.
+The relay fingerprints the working tree before and after a `--read-only` run to report
+`readOnlyViolation` in `result.json`. Settings allow-rules are not documented here as a fix
+because they have not been demonstrated to apply to this headless path. Do not add the bypass
+flag without explicit human approval.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract. Two limits on that mandate: **surface, don't
+absorb** (report Antigravity's design decisions, defensible-but-unasked turns, and non-blocking
+nitpicks rather than silently keeping them) and **stop for scope changes** (if correct completion needs
+going beyond the brief, ask - don't expand the mandate yourself). The full treatment is in
+[references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - how to write a brief Antigravity
+  can execute blind: structure, XML blocks, the report contract, and real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) - the review checklist, the commit
+  boundary, and the rework cycle via `--resume-last`.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.
+
+
+## Limitations
+
+- Requires the `agy` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/agy-delegate/references/dispatch-and-poll.md
+++ b/skills/agy-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,140 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `agy --print`, runs the brief in Antigravity,
+captures the final response, and writes a structured `result.json`. Your job collapses to: run one
+command, then read one file.
+
+## Before the first run: check the binary
+
+```bash
+command -v agy
+agy help
+agy models
+```
+
+`agy models` proves the CLI can authenticate and list available model labels. The relay records the
+version it can infer from `agy changelog` into `result.json`. Neither command proves that a headless
+write will be approved.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed - the folder containing its `SKILL.md`.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin before passing it to `agy --print`. |
+| `--cd <dir>` | Working root for Antigravity (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Antigravity model label. Optional; a fresh run can use Antigravity's configured default. |
+| `--effort <level>` | Reasoning effort: `low`, `medium`, or `high` (passed as agy's own `--effort`). |
+| `--project <id>` | Use an existing Antigravity project. |
+| `--new-project` | Force a fresh Antigravity project. This is the default for fresh dispatches. |
+| `--resume-last` | Continue the most recent Antigravity conversation; send only the delta brief. |
+| `--conversation <id>` | Continue a specific Antigravity conversation; send only the delta brief. |
+| `--sandbox` | Enable Antigravity's terminal sandbox for the run. |
+| `--read-only` | Run in plan mode (`--mode plan`), removing write and edit paths; mutually exclusive with `--dangerously-skip-permissions`. |
+| `--dangerously-skip-permissions` | Pass Antigravity's permission-bypass flag; mutually exclusive with `--read-only`. Never use this unless the human explicitly accepts it. |
+| `--print-timeout <duration>` | Timeout agy itself applies to print mode (default: `30m`). |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`); overrides the default of `--print-timeout` plus a 60s grace. On expiry the agy process tree is killed and `result.json` gets `status: "timeout"`. Set it explicitly when agy may hang past its own print timeout. Malformed, zero, and out-of-range durations are rejected; the maximum is `596h31m23s`. |
+| `--add-dir <dir>` | Add an extra workspace directory. Repeatable; relative paths resolve against `--cd`. Fresh runs always add the `--cd` repo (absolute path) as a workspace dir. Edits inside extra workspaces are not reported in `touchedFiles`. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only Antigravity's edits and nothing of the helper's own.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` - the result-format version (currently `delegate-relay.result.v1`)
+- `tool` - `agy`
+- `status` - `completed` | `failed` | `timeout` | `aborted` | `agy_unavailable`
+- `exitCode` - mirrors Antigravity's exit code; `128` plus the signal number if the child was killed; `127` if `agy` is not on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
+- `signal` - the signal that killed the child, otherwise `null`
+- `agyVersion` - inferred from `agy changelog` when available
+- `projectId` / `conversationId` - parsed from the Antigravity log when present
+- `finalMessage` - Antigravity's stdout response
+- `touchedFiles` - `git status --porcelain` lines in the working root: your review starting point.
+  `null` (not `[]`) when git cannot report; `[]` means git ran and the tree is clean
+- `readOnlyViolation` - `true` when fingerprints prove a working-tree change, `false` when coverage is complete and proves none, and `null` when fingerprinting was incomplete or the run was not `--read-only`
+- `briefPath` / `finalPath` / `logPath` / `stderrPath` - the exact brief, final message, Antigravity
+  log, and stderr capture
+- `workdir`, `model`, `effort`, `project` (the `--project` you passed, vs `projectId` parsed from the log),
+  `sandbox`, `readOnly`, `dangerouslySkipPermissions`, `resumed` (true for a `--resume-last` or `--conversation`
+  run), `startedAt`, `finishedAt`
+- `stderrTail` - last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`; also present when `finalMessage` is empty so diagnostics are not discarded
+- `error` - present on a launch failure, `timeout`, `aborted`, headless permission denial, or silent no-op
+
+The helper also prints a summary to stdout and normally exits with Antigravity's exit code. It forces
+exit 1 when Antigravity exits 0 after a detected headless permission denial or with neither a final
+message nor observable working-tree changes, so a wrapping script can branch on success/failure directly.
+
+## Waiting for completion
+
+The helper blocks until Antigravity finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll. A run is done
+  when `result.json` exists with a `status`. A pre-run usage error exits with code 2 before writing any
+  file, so check the exit code too. A missing `agy` binary exits 127 and writes `result.json` with
+  `status: agy_unavailable`.
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written.
+
+## When a run misbehaves
+
+- **`status: agy_unavailable` (exit 127):** `agy` is not on PATH. Install the Antigravity CLI and run
+  its first-launch setup, then re-dispatch.
+- **`status: timeout`:** the relay watchdog killed the run. Inspect `error` to see whether the selected
+  limit was explicit `--timeout` or the derived `--print-timeout` plus 60s grace. The working tree may
+  hold a half-applied change — inspect it before changing that limit, reducing the brief, or resuming.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to agy. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child - commonly the OOM killer
+  or a supervisor timeout, not an implementer error. Free up host memory or split the task into
+  smaller briefs, then re-dispatch.
+- **`status: failed`:** read `result.json`'s `stderrTail`, `stderrPath`, and `logPath` for the cause.
+  Common causes: auth lapse, an unknown model label, timeout, or a permission the run needed.
+- **Headless write permission denied:** the relay detects Antigravity's `no output produced ...
+  auto-denied` stderr sentinel, reports `status: failed`, preserves `stderrTail`, and exits 1. Settings
+  allow-rules are not recommended here because they have not been demonstrated to apply in
+  `--print` mode. Ask the human before re-dispatching with `--dangerously-skip-permissions`; that flag
+  auto-approves every tool permission request and the run must be treated as full access.
+- **Empty `finalMessage`:** a run with edits may still be correct - check `touchedFiles`, the diff, and
+  the preserved `stderrTail`. With no observable edits, the relay reports `status: failed` rather than
+  claiming completion. To get a report next time, add a `<structured_output_contract>` block (see
+  [writing-the-brief.md](writing-the-brief.md)).
+
+## What the helper is doing
+
+Under the hood the helper runs roughly:
+
+```bash
+agy --new-project --add-dir <repo> --print-timeout 30m --print=<brief>
+agy --continue --print-timeout 30m --print=<delta brief>
+agy --conversation <id> --print-timeout 30m --print=<delta brief>
+```
+
+`agy --print` requires the prompt as a flag argument, so keep briefs focused. The relay still accepts
+stdin or `--brief <file>` for your convenience; it reads the text first, then passes it to `agy` as
+`--print=<brief>` (the `=` form so a brief that begins with a bare flag like `--help` still runs).
+Two consequences of the brief riding the command line: it is visible in the host process list (`ps`),
+so on a shared machine keep secrets out of it; and a brief over ~120 KB is rejected up front (the OS
+caps a single argument), so have `agy` read large context from the workspace instead of inlining it.
+
+## The commit boundary
+
+The helper never commits - by design, not omission. The robust contract is: Antigravity edits the
+working tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/agy-delegate/references/multi-task-queues.md
+++ b/skills/agy-delegate/references/multi-task-queues.md
@@ -1,0 +1,59 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that is where delegation pays off most - a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each (review + gates + commit) before
+dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential.
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan did not have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, fold it into that
+task's brief as an explicit line. A fresh Antigravity conversation has no memory of the earlier run, so
+a constraint that emerged in task 2 must be restated in task 5's brief or it will not hold.
+
+## Keep a progress file
+
+For anything longer than two or three tasks - especially a run the human steps away from - maintain a
+single progress file alongside the work:
+
+- **Status table** - each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** - what landed, what you verified, the gate outcome.
+- **Needs your eyes** - design decisions Antigravity made, non-blocking nitpicks, anything you want the
+  human to overrule or confirm.
+- **End-of-run checklist** - what happens after the last task.
+
+Update it as each task lands, not in a batch at the end.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it does not prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree.
+- Do a repo-wide check for the thing the queue was about.
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief's scope.
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already done.
+
+Then report where you are, what is committed, and what the open question is - and wait.

--- a/skills/agy-delegate/references/review-and-land.md
+++ b/skills/agy-delegate/references/review-and-land.md
@@ -1,0 +1,103 @@
+# Review and land
+
+Antigravity did the typing; you own the judgment. Verify against reality, never against the self-report
+- and read the diff as generated code, which fails in ways a green gate cannot see.
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* - before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** Flag them, don't
+  absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as
+  failing until proven otherwise.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened,
+  tolerance widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries Antigravity's own claims. Treat them as claims, not evidence - re-run the
+project's actual test/lint/build commands in the working tree and read the output. Passing is necessary,
+not sufficient.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them and check for drift.
+- **Removals / renames:** grep the codebase for dangling references.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Scope creep** - did Antigravity change things the brief said to leave untouched?
+- **Scope shortfall** - did it do the whole task, including edge cases and cleanup?
+- **Quiet judgment calls** - did it make a defensible but unasked decision you need to understand?
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to. Walk these against every
+diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work.
+- **Catch-all error handling that returns a default** instead of propagating or recovering explicitly.
+- **Unverified imports and API calls** - confirm new dependencies, methods, and signatures exist in the
+  installed version.
+- **Dead weight** - unused imports, helpers nothing calls, unreachable branches, scaffolding comments.
+- **A second way to do what the file already does** - new client, error idiom, or logging style beside
+  an existing one.
+- **New tests that assert internals** instead of behavior.
+- **Near-duplicate test bodies** differing by one value.
+- **Speculative surface** - optional parameters, config flags, or abstractions with no caller.
+- **Guards for impossible cases** that bury validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to Antigravity as a delta brief or gets fixed in the tree before
+commit - and either way is reported to the user.
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** - the orchestrator, never the implementer. Write
+a clear message describing what landed. If your project attributes co-authorship, that is the place for
+it.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same Antigravity
+conversation with just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+`--resume-last` keeps Antigravity's conversation context from the first run, so a short delta is enough.
+Then review again - rework gets the same gate-rerun, test check, diff-read, and sweep as the original,
+no shortcuts.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract. But
+keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** Antigravity made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past - see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/agy-delegate/references/writing-the-brief.md
+++ b/skills/agy-delegate/references/writing-the-brief.md
@@ -1,0 +1,124 @@
+# Writing the brief
+
+A brief is the entire task as Antigravity will see it. It runs in a separate conversation with **no
+memory of your conversation, no access to your prior notes, and no shared context** - only the text you
+send and whatever it can inspect in the workspace. If a constraint is not in the brief or discoverable
+in the repo, it does not exist for Antigravity.
+
+## Model choice
+
+`agy` has a configured default model, so a fresh dispatch does not require `--model`. Pass `--model`
+only when the human has named a preferred Antigravity model label for this task. `agy models` shows the
+available labels.
+
+A resumed run keeps the conversation context. Send only the delta brief.
+
+## The shape that works
+
+Antigravity responds well to compact, block-structured prompts with XML tags rather than long prose.
+State the task, what "done" looks like, how to behave by default, and the few constraints that actually
+matter. Add a block only when the task needs it.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps Antigravity
+from wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for extra blocks when the task profile
+calls for them:
+
+- **Debugging / open-ended fixes** - add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Research / recommendations** - add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Always ask for the report explicitly
+
+The relay captures `agy --print` stdout as `finalMessage`. If Antigravity finishes without a closing
+summary, the result is not useful to review. The `<structured_output_contract>` block is what guarantees
+a report you can read.
+
+## Discover the real gates
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`AGENTS.md` / `CLAUDE.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you an implementer that guesses - or skips.
+
+## Honor the repo's conventions
+
+If the project has house rules in `AGENTS.md`, `CLAUDE.md`, or a similar file, restate the load-bearing
+ones in the brief. Antigravity can inspect the workspace, but compliance is more reliable when the
+important rules are directly in front of it.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and suggest
+a roadmap" produces a muddled run; split it into separate dispatches. One brief -> one Antigravity run
+-> one commit keeps review and rollback clean.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/agy-delegate/scripts/relay.mjs
+++ b/skills/agy-delegate/scripts/relay.mjs
@@ -1,0 +1,772 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · agy-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Google Antigravity CLI (`agy --print`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON -
+ * every Antigravity-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `agy` and `git`. The `agy` process it launches
+ * does authenticate - exactly as you do at the terminal. Read this file before
+ * you run it.
+ *
+ * Note: `agy --print` takes the prompt as a command-line argument, so the brief is
+ * visible in the host process list (`ps`, /proc). On a shared machine keep secrets
+ * out of the brief - reference them by a path or env var the workspace can read.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job -
+ * after it reviews the diff and re-runs the project gates.
+ *
+ * Antigravity owns its own permission policy. This helper does not pass
+ * --dangerously-skip-permissions by default; opt into that flag only when the
+ * human explicitly accepts it. Pass --sandbox to enable Antigravity's terminal
+ * sandbox for the run. Combining both flags must be treated as full access because
+ * permission requests to act outside the sandbox may be auto-approved.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for Antigravity (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Antigravity model label (default: agy's configured default).
+ *   --effort <level>        Reasoning effort: low, medium, or high (passed as agy's own --effort).
+ *   --project <id>          Use an existing Antigravity project.
+ *   --new-project           Force a fresh Antigravity project (default for fresh runs).
+ *   --resume-last           Continue the most recent Antigravity conversation; send only the delta brief.
+ *   --conversation <id>     Continue a specific Antigravity conversation; send only the delta brief.
+ *   --sandbox               Enable Antigravity's terminal sandbox for this run.
+ *   --read-only             Run in plan mode (`--mode plan`), removing write and edit paths.
+ *                           Mutually exclusive with --dangerously-skip-permissions.
+ *   --dangerously-skip-permissions
+ *                           Auto-approve Antigravity tool permission requests. Use only with human approval.
+ *                           Mutually exclusive with --read-only.
+ *   --print-timeout <dur>   Timeout agy itself applies to print mode (default: 30m).
+ *   --timeout <dur>         Relay-side watchdog, h/m/s like 30m (default: --print-timeout
+ *                           plus a 60s grace). On expiry the agy process tree is killed and
+ *                           result.json gets status "timeout". Set it explicitly when agy
+ *                           may hang past its own print timeout.
+ *   --add-dir <dir>         Add an extra workspace directory. Repeatable.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout -
+ *   status, exitCode, agyVersion, projectId, conversationId, finalMessage
+ *   (Antigravity's own report), touchedFiles (git porcelain, null if git can't report),
+ *   readOnlyViolation (on --read-only), and the paths to brief.txt, final.txt, agy.log, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `agy` binary exits 127;
+ * otherwise the exit code mirrors Antigravity's own, except that an exit-zero
+ * permission denial or silent write-dispatch no-op is forced to exit 1.
+ * If the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
+ * Once the brief validates, `result.json` is written on every outcome -
+ * completed, failed, timeout (the relay watchdog fired after explicit --timeout,
+ * or after --print-timeout plus 60s grace), aborted (the relay itself was killed
+ * and forwarded the kill to agy), or agy_unavailable. An orchestrator that polls for the
+ * file must therefore also treat a non-zero exit with no file as a usage error.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, readlinkSync, lstatSync, existsSync, appendFileSync, realpathSync } from "node:fs";
+import {join, resolve, basename, dirname, relative, isAbsolute } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+
+const DEFAULT_PRINT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const MAX_TIMER_DURATION = "596h31m23s";
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+
+const IMPLEMENTER_KEY = "agy";
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && (flagged.has("readOnly") || flagged.has("dangerouslySkipPermissions"))) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    effort: null,
+    project: null,
+    newProject: false,
+    resumeLast: false,
+    conversation: null,
+    sandbox: false,
+    readOnly: false,
+    dangerouslySkipPermissions: false,
+    printTimeout: DEFAULT_PRINT_TIMEOUT,
+    timeout: null,
+    addDirs: [],
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--effort": opts.effort = next(); flagged.add("effort"); break;
+      case "--project": opts.project = next(); break;
+      case "--new-project": opts.newProject = true; break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--conversation": opts.conversation = next(); break;
+      case "--sandbox": opts.sandbox = true; flagged.add("sandbox"); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--dangerously-skip-permissions":
+        opts.dangerouslySkipPermissions = true;
+        flagged.add("dangerouslySkipPermissions");
+        break;
+      case "--print-timeout": opts.printTimeout = next(); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--add-dir": opts.addDirs.push(next()); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.effort !== null && !["low", "medium", "high"].includes(opts.effort)) {
+    fail(`invalid --effort "${opts.effort}" (expected: low, medium, high)`);
+  }
+  if (opts.readOnly && opts.dangerouslySkipPermissions) {
+    fail("--read-only and --dangerously-skip-permissions are mutually exclusive; pass only one");
+  }
+  if (opts.resumeLast && opts.conversation) {
+    fail("--resume-last and --conversation are mutually exclusive; pass only one");
+  }
+  // A malformed --timeout must fail loudly: parseDuration returns null for it, and a null
+  // delay makes setTimeout fire on the next tick - a silent instant "timeout", the worst
+  // failure mode a watchdog has. Zero is rejected for the same reason.
+  if (opts.timeout !== null) {
+    const milliseconds = parseDuration(opts.timeout);
+    if (milliseconds === null || milliseconds <= 0 || milliseconds > MAX_TIMER_MS) {
+      fail(`--timeout "${opts.timeout}" must be an h/m/s duration from 1s through ${MAX_TIMER_DURATION}`);
+    }
+  }
+  const printTimeoutMs = parseDuration(opts.printTimeout);
+  if (printTimeoutMs === null || printTimeoutMs <= 0 || printTimeoutMs + 60_000 > MAX_TIMER_MS) {
+    fail(`--print-timeout "${opts.printTimeout}" must be an h/m/s duration from 1s through 596h30m23s so its 60s grace fits the relay watchdog limit`);
+  }
+  if (opts.project && (opts.resumeLast || opts.conversation)) {
+    fail("--project cannot be combined with --resume-last or --conversation");
+  }
+  if (opts.project && opts.newProject) {
+    fail("--project and --new-project are mutually exclusive");
+  }
+  if (opts.newProject && (opts.resumeLast || opts.conversation)) {
+    fail("--new-project cannot be combined with --resume-last or --conversation");
+  }
+  // agy requires absolute --add-dir paths; resolve a relative one against --cd
+  // (not the relay's own cwd) - and only after the loop, since --add-dir may
+  // appear before --cd on the command line. resolve() passes absolutes through.
+  opts.addDirs = opts.addDirs.map((dir) => resolve(opts.cd, dir));
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to agy --print\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function agyVersion(timeoutMs) {
+  try {
+    const out = execFileSync("agy", ["changelog"], {
+      encoding: "utf8",
+      timeout: Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS),
+      killSignal: "SIGKILL",
+    }).trim();
+    const firstLine = out.split("\n").find(Boolean) || "";
+    const match = firstLine.match(/^([^:\s]+):/);
+    return match ? match[1] : firstLine || null;
+  } catch (err) {
+    // Only a missing binary means "unavailable"; any other changelog failure
+    // (permissions, a broken subcommand) must not masquerade as exit 127.
+    if (err && err.code === "ENOENT") return null;
+    if (err && err.code === "ETIMEDOUT") throw err;
+    return "unknown";
+  }
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function gitWorktreeFingerprint(cwd, excludedPaths = []) {
+  try {
+    const git = (args) => execFileSync("git", args, {
+      cwd,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const root = realpathSync.native(git(["rev-parse", "--show-toplevel"]).toString("utf8").replace(/\r?\n$/, ""));
+    const exclusions = excludedPaths
+      .map((path) => {
+        const absolute = resolve(path);
+        try { return relative(root, realpathSync.native(absolute)); }
+        catch { return relative(root, join(realpathSync.native(dirname(absolute)), basename(absolute))); }
+      })
+      .filter((path) => path && path !== ".." && !path.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) && !isAbsolute(path))
+      .map((path) => `:(exclude,top,literal)${path.replaceAll("\\", "/")}`);
+    const pathspec = [":(top)", ...exclusions];
+    const status = git(["status", "--porcelain=v1", "-z", "--untracked-files=all", "--no-renames", "--", ...pathspec]);
+    const fingerprint = createHash("sha256").update("status\0").update(status);
+    fingerprint.update("\0index\0").update(git(["diff", "--cached", "--raw", "--full-index", "--no-renames", "-z", "--", ...pathspec]));
+    fingerprint.update("\0worktree\0").update(git(["diff", "--raw", "--full-index", "--no-renames", "-z", "--", ...pathspec]));
+
+    const paths = [...new Set(status.toString("utf8").split("\0").filter(Boolean).map((entry) => entry.slice(3)))].sort();
+    for (const path of paths) {
+      const fullPath = join(cwd, path);
+      fingerprint.update("\0path\0").update(path).update("\0");
+      let stat;
+      try {
+        stat = lstatSync(fullPath);
+      } catch (error) {
+        if (error?.code !== "ENOENT") throw error;
+        fingerprint.update("missing");
+        continue;
+      }
+      fingerprint.update(String(stat.mode)).update("\0");
+      if (stat.isSymbolicLink()) fingerprint.update(readlinkSync(fullPath));
+      else if (stat.isFile()) fingerprint.update(git(["hash-object", "--no-filters", "--", path]));
+      else if (stat.isDirectory()) {
+        const nestedState = gitWorktreeFingerprint(fullPath, excludedPaths);
+        if (nestedState === null) return null;
+        let headState;
+        try {
+          headState = git(["-C", fullPath, "rev-parse", "--verify", "HEAD"]);
+        } catch {
+          const symbolicHead = git(["-C", fullPath, "symbolic-ref", "--quiet", "HEAD"]).toString("utf8").trim();
+          const target = spawnSync("git", ["-C", fullPath, "show-ref", "--verify", "--quiet", symbolicHead], { cwd, timeout: 10_000, killSignal: "SIGKILL", stdio: "ignore" });
+          if (target.status !== 1) return null;
+          headState = Buffer.from(`unborn\0${symbolicHead}`);
+        }
+        fingerprint.update("submodule\0").update(headState).update(nestedState);
+      } else return null;
+    }
+    return fingerprint.digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+function readOnlyVerdict(opts, beforeState, afterState) {
+  // Three-valued on purpose: true when fingerprints prove a change, false when coverage
+  // is complete and proves none, null when the fingerprint could not be taken or the run
+  // was not read-only.
+  if (!opts.readOnly) return null;
+  if (beforeState === null || afterState === null) return null;
+  return beforeState !== afterState;
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    logPath: join(outDir, "agy.log"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function buildArgv(opts, brief, run) {
+  const argv = [];
+  if (opts.project) {
+    argv.push("--project", opts.project);
+  } else if (opts.conversation) {
+    argv.push("--conversation", opts.conversation);
+  } else if (opts.resumeLast) {
+    argv.push("--continue");
+  } else {
+    argv.push("--new-project");
+  }
+
+  if (!opts.resumeLast && !opts.conversation) {
+    // The disposable smoke showed that relying on cwd alone can produce a false
+    // "I created the file" response, so pin the workspace explicitly. agy requires
+    // an absolute path here (it rejects "." as non-absolute); opts.cd is already
+    // resolve()d, and an argv-array element carries spaces fine without a shell.
+    argv.push("--add-dir", opts.cd);
+    for (const dir of opts.addDirs) argv.push("--add-dir", dir);
+  }
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.effort) argv.push("--effort", opts.effort);
+  if (opts.readOnly) argv.push("--mode", "plan");
+  if (opts.sandbox) argv.push("--sandbox");
+  if (opts.dangerouslySkipPermissions) argv.push("--dangerously-skip-permissions");
+  if (opts.printTimeout) argv.push("--print-timeout", opts.printTimeout);
+  argv.push("--log-file", run.logPath);
+  // Use the --print=<brief> form, not a separate ["--print", brief] pair: agy's flag
+  // parser intercepts a value that is exactly a bare flag (a brief consisting only of
+  // "--help" or "-h" prints usage instead of running). The = form always binds the value.
+  argv.push(`--print=${brief}`);
+  return argv;
+}
+
+function parseIdsFromLog(logPath) {
+  if (!existsSync(logPath)) return { projectId: null, conversationId: null };
+  const text = readFileSync(logPath, "utf8");
+  const projectMatches = [
+    /project: created project "[^"]*" \(id=([0-9a-f-]+)\)/i,
+    /Conversation using project ID: ([0-9a-f-]+)/i,
+    /Backend project ID updated dynamically to: ([0-9a-f-]+)/i,
+  ];
+  const conversationMatches = [
+    /Print mode: conversation=([0-9a-f-]+)/i,
+    /Created conversation ([0-9a-f-]+)/i,
+  ];
+  const firstMatch = (patterns) => {
+    for (const pattern of patterns) {
+      const match = text.match(pattern);
+      if (match) return match[1];
+    }
+    return null;
+  };
+  return {
+    projectId: firstMatch(projectMatches),
+    conversationId: firstMatch(conversationMatches),
+  };
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const ids = parseIdsFromLog(run.logPath);
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "agy",
+      workdir: opts.cd,
+      model: opts.model,
+      effort: opts.effort,
+      project: opts.project,
+      sandbox: opts.sandbox,
+      readOnly: opts.readOnly,
+      readOnlyViolation: null,
+      dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
+      resumed: Boolean(opts.resumeLast || opts.conversation),
+      agyVersion: version,
+      projectId: ids.projectId,
+      conversationId: ids.conversationId,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      logPath: existsSync(run.logPath) ? run.logPath : null,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "agy_unavailable", exitCode: 127, signal: null, finalMessage: "", touchedFiles: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `agy` not found on PATH. Install the Antigravity CLI and complete first-launch setup.\n");
+  process.exit(127);
+}
+
+function reportVersionTimeout(writeResult, run, timeoutMs, error) {
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = `agy changelog version preflight timed out after ${Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS)}ms; agy was not dispatched`;
+  const result = writeResult({
+    status: "timeout",
+    exitCode: 124,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: null,
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToAgy(opts, brief, run, writeResult, watchdogMs) {
+  const relayArtifacts = [run.briefPath, run.finalPath, run.logPath, run.stderrPath, run.resultPath];
+  const beforeState = gitWorktreeFingerprint(opts.cd, relayArtifacts);
+  const argv = buildArgv(opts, brief, run);
+  // Antigravity's installer provides a native `agy` binary. Launch directly so
+  // multi-line briefs and paths with spaces are passed as argv, not shell text.
+  const child = spawn("agy", argv, {
+    cwd: opts.cd,
+    env: { ...process.env, PWD: opts.cd },
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let stdout = "";
+  const stderrTail = [];
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, watchdogMs);
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the agy child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdogTimer);
+      if (sigkillTimer) clearTimeout(sigkillTimer);
+      const finalMessage = stdout.trim();
+      if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        finalMessage,
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; agy was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      let finalized = false;
+      const finalizeAbort = () => {
+        if (finalized) return;
+        finalized = true;
+        if (sigkillTimer) clearTimeout(sigkillTimer);
+        const afterState = gitWorktreeFingerprint(opts.cd, relayArtifacts);
+        const result = writeResult({
+          ...abortedFields,
+          touchedFiles: gitTouchedFiles(opts.cd),
+          readOnlyViolation: readOnlyVerdict(opts, beforeState, afterState),
+        });
+        printSummary(result, run.resultPath);
+        process.exit(result.exitCode);
+      };
+      child.once("close", finalizeAbort);
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        killChild(child, "SIGKILL");
+      }, 2000);
+    });
+  }
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    stdout += stdoutDecoder.write(chunk);
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    const finalMessage = stdout.trim();
+    if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
+    const afterState = gitWorktreeFingerprint(opts.cd, relayArtifacts);
+    const readOnlyViolation = readOnlyVerdict(opts, beforeState, afterState);
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      readOnlyViolation,
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    const finalMessage = stdout.trim();
+    if (finalMessage) writeFileSync(run.finalPath, finalMessage, "utf8");
+    const touchedFiles = gitTouchedFiles(opts.cd);
+    const stderr = readFileSync(run.stderrPath, "utf8");
+    const diagnostics = stderr.split("\n").map((line) => line.trimEnd()).filter(Boolean).slice(-20);
+    const permissionDenied = /no output produced\s+[—-]\s+a tool required the "([^"]+)" permission that headless\s+mode cannot prompt for, so it was auto-denied/i.exec(stderr);
+    // A clean read-only run still owes the caller a plan. With neither a final message
+    // nor observable worktree changes, exit 0 cannot confirm any dispatch completed.
+    const afterState = gitWorktreeFingerprint(opts.cd, relayArtifacts);
+    const worktreeChanged = beforeState !== null && afterState !== null && beforeState !== afterState;
+    const readOnlyViolation = readOnlyVerdict(opts, beforeState, afterState);
+    const silentNoop = code === 0 && !finalMessage && !worktreeChanged;
+    // A timed-out run is failed even if agy handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired && !permissionDenied && !silentNoop;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
+      finalMessage,
+      touchedFiles,
+      readOnlyViolation,
+      ...(!succeeded || !finalMessage ? { stderrTail: diagnostics } : {}),
+      ...(watchdogFired
+        ? {
+            error: opts.timeout !== null
+              ? `agy did not finish within --timeout ${opts.timeout}; killed by the relay watchdog`
+              : `agy did not exit within --print-timeout ${opts.printTimeout} plus 60s grace; killed by the relay watchdog`,
+          }
+        : permissionDenied
+          ? { error: `Antigravity auto-denied the ${permissionDenied[1]} permission because headless --print cannot prompt; ask the human whether to re-dispatch with --dangerously-skip-permissions and treat that run as full access` }
+          : silentNoop
+            ? { error: "agy exited 0 without a final message or observable working-tree changes; the relay cannot confirm this dispatch completed" }
+            : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // agy --print takes the prompt as a CLI argument, so the brief rides argv. The OS caps a
+  // single argument (~128KB on Linux via MAX_ARG_STRLEN), so a huge brief would fail to spawn
+  // with an opaque E2BIG. Reject it early with a clear message instead of a generic failure.
+  const briefBytes = Buffer.byteLength(brief, "utf8");
+  const MAX_BRIEF_BYTES = 120 * 1024;
+  if (briefBytes > MAX_BRIEF_BYTES) {
+    fail(`brief is ${Math.round(briefBytes / 1024)}KB; agy passes the prompt as a CLI argument, which the OS caps (~128KB on Linux). Trim it, or have agy read large context from the workspace instead of inlining it.`);
+  }
+
+  const printTimeoutMs = parseDuration(opts.printTimeout);
+  // An explicit --timeout wins over the default print-timeout-plus-grace: agy can hang well
+  // past its own print timeout, which is exactly the case the grace window cannot cover.
+  const watchdogMs = opts.timeout !== null ? parseDuration(opts.timeout) : printTimeoutMs + 60_000;
+  const run = prepareRunDir(opts, brief);
+  let version;
+  try {
+    version = agyVersion(watchdogMs);
+  } catch (error) {
+    const writeResult = makeResultWriter(opts, "unknown", run);
+    reportVersionTimeout(writeResult, run, watchdogMs, error);
+    return;
+  }
+  const writeResult = makeResultWriter(opts, version, run);
+
+  if (!version) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+
+  dispatchToAgy(opts, brief, run, writeResult, watchdogMs);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  agy ${result.agyVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an agy error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated agy (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.resumed) lines.push("mode: resumed an existing conversation");
+  if (result.projectId) lines.push(`project id: ${result.projectId}`);
+  if (result.conversationId) lines.push(`conversation id (resume with: --conversation ${result.conversationId}): ${result.conversationId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- agy final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/aider-delegate/SKILL.md
+++ b/skills/aider-delegate/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: aider-delegate
+description: Delegate a coding task to Aider (`aider`) as a background implementer,
+  then review its diff and land it yourself. Use this whenever the user wants to hand
+  implementation work to Aider - phrasings like "have Aider do X", "delegate this
+  to aider", "run it through Aider", or...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `aider` CLI (`python -m pip install aider-chat`), Node
+  18+, and git. Aider must be able to authenticate to a model before dispatch - export
+  the provider key it expects (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …) or set it
+  in Aider's own config; a local OpenAI-compatible endpoint still needs a non-empty
+  `OPENAI_API_KEY`. The orchestrating agent must be able to run shell commands and
+  read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+# Aider Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `aider` implementer (`Aider`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Hand a bounded coding task to a separate **implementer** - Aider - then
+review what it produced and land it yourself. You write the brief and own the judgment; Aider does the
+typing in its own run; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## The one thing to know about Aider
+
+**Aider commits by default.** Two of its defaults would destroy the reviewable diff this skill exists
+to produce:
+
+- `--auto-commits` (default `True`) - Aider commits its own edits after each exchange.
+- `--dirty-commits` (default `True`) - Aider commits **your** pre-existing uncommitted work before it
+  starts editing.
+
+The relay always passes `--no-auto-commits` and `--no-dirty-commits`, and neither is configurable
+through it. If you ever drive `aider` by hand instead of through the relay, pass both yourself, or the
+work lands as commits you never reviewed. The relay also passes `--no-gitignore`, because Aider
+otherwise writes `.aider*` into `.gitignore` on startup and dirties the tree you are about to read.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `aider` CLI is not installed, or no model is configured for it.
+- You want the implementer to manage its own commits. Aider can, but this skill deliberately turns
+  that off - the diff is the deliverable.
+
+## Prerequisites (check once)
+
+1. Install Aider - `python -m pip install aider-chat`, or the standalone installer from the
+   [Aider install docs](https://aider.chat/docs/install.html).
+2. Configure a model. Aider reads provider keys from the environment (`OPENAI_API_KEY`,
+   `ANTHROPIC_API_KEY`, …) or its own config; see [Aider's model docs](https://aider.chat/docs/llms.html).
+3. Confirm `aider --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the model
+
+Aider uses its own configured model when `--model` is omitted. Pass `--model <name>` to pick another.
+
+## Local and self-hosted models
+
+Aider talks to any OpenAI-compatible endpoint, so this is also the skill for delegating to a model
+running on the user's own hardware - llama.cpp's server, Ollama, vLLM, LM Studio, or anything else
+that serves the same API. Pair `--model` with `--api-base`:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo \
+  --model openai/<served-model-name> --api-base http://127.0.0.1:<port>/v1
+```
+
+Three things differ from a hosted provider:
+
+- **The `openai/` prefix is required.** It tells Aider to speak the OpenAI protocol to your endpoint;
+  the part after it is whatever name your server reports, not a provider catalog name.
+- **A placeholder key is still needed.** Export any non-empty `OPENAI_API_KEY`. The client library
+  requires the header even when the server ignores its value.
+- **Ask for a smaller edit format.** Local models often fail Aider's default `diff` format, which
+  requires exact search/replace blocks. `--edit-format whole` trades tokens for reliability; keep the
+  brief's scope tight with `--file` so whole-file rewrites stay cheap.
+
+A local endpoint that is not running looks like a hang, not an error: Aider retries the connection
+until the relay's `--timeout` watchdog fires and reports `status: "timeout"`. Confirm the server is up
+before dispatching a long brief.
+
+### Staying offline
+
+No account or provider registration is involved: Aider is a pip install, the endpoint is yours, and
+`OPENAI_API_KEY` only has to be non-empty. The relay pins the flags that would otherwise reach the
+network on their own - `--no-check-update`, `--no-analytics` (Aider's own default is `random`, which
+opts some sessions in by itself), and `--no-detect-urls`, without which Aider offers to scrape any URL
+in the brief and `--yes-always` accepts that offer silently.
+
+`--no-suggest-shell-commands` closes the remaining path by which a run could reach the network without
+being asked to. What stays outside the relay's control is the brief itself: instructions that tell
+Aider to install a package or call an API will still be carried out, and `--auto-lint` runs the
+repository's own tooling. Offline here means nothing in the dispatch path reaches out on its own - not
+that a sandbox is stopping it.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Aider sees only the text you send plus the files in its editing scope - no chat history or shared
+context. Include the goal, current state, what to change, what to leave untouched, the project's
+**actual** gates, and a report contract. Keep one task per brief. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled helper. It wraps Aider's headless `--message-file` mode, captures the run, and writes
+`result.json`. (`<skill-dir>` is the installed folder containing this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a model:                        add --model <name>
+# point at an OpenAI-compatible server:  add --api-base <url>
+# scope the edit surface:                add --file <path> (repeatable), --read <path> for context only
+# dry run, no files modified:            add --read-only
+# continue the previous chat:            add --resume-last  (delta brief only)
+# hard time limit (watchdog):            add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
+# see all options:                       node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. The brief is delivered with `--message-file`, so it never
+rides argv: it stays out of the host process list and clear of the OS argument size cap. The relay
+writes artifacts under the system temp dir by default and never commits. See
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Aider finishes. Run it with the orchestrator's background-command facility, or
+background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
+result; a missing `aider` exits 127 and writes `status: "aider_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process exited
+and `result.json` exists. Aider's report is the `finalMessage` field in `result.json` (also printed in
+full on stdout between the report markers).
+
+Aider exits 0 even when it never reached a model, so the relay scans the run for Aider's own endpoint
+and authentication errors and reports `status: "failed"` when it finds one. Treat a `failed` status
+with an `error` mentioning the endpoint as a configuration problem, not a coding failure.
+
+### 4. Review - do not trust the self-report
+
+Treat Aider's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+Aider's `--auto-lint` is on by default, so it may have already run a linter and fixed its own
+complaints. That is Aider's lint, not your gates - run yours anyway. See
+[references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates pass
+and the diff holds. If rework is needed, send a delta brief with `--resume-last`, then review again.
+
+## Autonomy and permissions
+
+The relay passes `--yes-always`, Aider's own term for auto-confirming every prompt, because a headless
+run cannot answer one. **Understand what that consents to in advance.** Auto-confirmation applies to
+every prompt Aider would otherwise raise, and Aider's prompts are not limited to file edits: left at
+its defaults it also offers to run shell commands it has suggested, and `--yes-always` would accept
+those with nobody reading them. The relay therefore pins `--no-suggest-shell-commands`, which removes
+that path.
+
+What remains is not a sandbox, and nothing here pretends otherwise. Aider has no permission modes and
+no isolation: within its file scope it edits freely, and `--auto-lint` (on by default) runs whatever
+linter the repository configures. A brief that tells Aider to run a command still gets a command run.
+Delegation is the authorization; if a run must not be able to touch the host, run it in a container or
+a throwaway worktree, because no flag in this relay will give you that.
+
+**File selection is not a security boundary.** `--file`, `--read`, and `--subtree-only` set what Aider
+puts in its chat context, which is a scoping and token-cost decision. They do not confine what it can
+reach. See [references/writing-the-brief.md](references/writing-the-brief.md).
+
+`--read-only` maps to Aider's `--dry-run`, which performs the run without modifying files. The relay
+does not independently verify that claim - it reports what `git status --porcelain` shows and warns if
+a `--read-only` run left the tree changed. `touchedFiles` and the diff, not a flag, are the guarantee.
+
+## Resume
+
+Aider has no session ids. Its resume unit is the chat history file it keeps in the repository
+(`.aider.chat.history.md`), so `--resume-last` maps to Aider's `--restore-chat-history` and
+`--history-file` pins a specific one. Because that history lives in the repo, resume is per-worktree,
+not per-user: two clones of the same project do not share it.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't absorb**
+(report Aider's design decisions, defensible-but-unasked turns, and non-blocking nitpicks) and **stop
+for scope changes** (if correct completion needs going beyond the brief, ask instead of expanding the
+mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - structure, report contract,
+  real gates, file scope, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - review checklist, the commit
+  boundary, and rework through Aider's chat history.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues, constraint
+  carry-forward, progress tracking, and the final coherence pass.
+
+
+## Limitations
+
+- Requires the `aider` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/aider-delegate/references/dispatch-and-poll.md
+++ b/skills/aider-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,154 @@
+# Dispatch and poll
+
+The relay (`scripts/relay.mjs`) is the whole dispatch mechanic: it launches Aider headlessly, captures
+the run, and writes a structured `result.json`. Node built-ins only, no dependencies, and it never
+commits.
+
+## Before the first run
+
+1. `aider --version` succeeds.
+2. A model is configured - either Aider's own default, or the `--model` you intend to pass. Provider
+   keys come from the environment or Aider's config.
+3. The target directory is a git repository. Without git the relay cannot report `touchedFiles`, and
+   the diff is the deliverable.
+4. The working tree is clean, or you know exactly what was already dirty. `touchedFiles` reports
+   everything git sees, not only what Aider wrote.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Path to the brief. Omit to read it from stdin. |
+| `--cd <dir>` | Working root for Aider. Default: current directory. |
+| `--lane <name>` | Apply a fleet lane's dials from delegate-setup. Explicit flags win. |
+| `--model <name>` | Aider's `--model`. Default: Aider's own configured model. |
+| `--api-base <url>` | Aider's `--openai-api-base`, for an OpenAI-compatible server. |
+| `--edit-format <fmt>` | Aider's `--edit-format` (e.g. `diff`, `whole`, `udiff`). |
+| `--architect` | Aider's `--architect` edit format. Mutually exclusive with `--edit-format`. |
+| `--file <path>` | Add a file to Aider's editing scope. Repeatable. |
+| `--read <path>` | Add a read-only context file. Repeatable. |
+| `--subtree-only` | Restrict Aider to the current subtree. |
+| `--read-only` | Dispatch as Aider's `--dry-run`: no files modified. |
+| `--resume-last` | Restore Aider's chat history for this repo. Send a delta brief. |
+| `--history-file <path>` | Pin a specific chat history file (Aider's `--chat-history-file`). |
+| `--timeout <dur>` | Relay watchdog, h/m/s. Default `30m`. |
+| `--out-dir <dir>` | Where run artifacts go. Default: a fresh dir under the system temp dir. A reused directory has its previous `final.txt` and `result.json` removed before dispatch, so a poller can never read the last run's result as this one's. |
+
+Relative `--file`, `--read`, and `--history-file` paths resolve against `--cd`, not the relay's own
+cwd, so they mean what they look like they mean regardless of flag order.
+
+### Local and self-hosted endpoints
+
+`--api-base` points Aider at any OpenAI-compatible server - llama.cpp's server, Ollama, vLLM,
+LM Studio - so a delegated run can go to a model on the user's own hardware:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo \
+  --model openai/<served-model-name> --api-base http://127.0.0.1:<port>/v1 \
+  --edit-format whole --file src/target.py
+```
+
+The `openai/` prefix selects the protocol, not a provider catalog entry; the name after it is
+whatever the server reports. Export any non-empty `OPENAI_API_KEY` - the client library requires the
+header even when the server ignores its value. `--edit-format whole` is the usual choice for smaller
+local models, which frequently cannot produce the exact search/replace blocks Aider's default `diff`
+format needs; pair it with `--file` so whole-file rewrites stay small.
+
+A server that is not listening reads as a hang rather than an error: Aider retries the connection
+until the `--timeout` watchdog fires and the relay reports `status: "timeout"`. Check the endpoint is
+up before dispatching a long brief.
+
+The default `30m` watchdog suits short runs. Implementation briefs routinely need `--timeout 1h` or
+`2h`; a watchdog that fires mid-edit leaves a partial tree.
+
+## What the relay always passes
+
+These are not configurable, and the reason matters:
+
+| Flag | Why |
+| --- | --- |
+| `--no-auto-commits` | Aider's `--auto-commits` defaults to `True` and would commit its own edits. |
+| `--no-dirty-commits` | Aider's `--dirty-commits` defaults to `True` and would commit your pre-existing uncommitted work before starting. |
+| `--no-gitignore` | Aider otherwise writes `.aider*` into `.gitignore` on startup, dirtying the tree. |
+| `--yes-always` | A headless run cannot answer a confirmation prompt. |
+| `--no-suggest-shell-commands` | The other half of `--yes-always`. Aider's `--suggest-shell-commands` defaults to `True`, and an auto-confirmed suggestion runs on the host with nobody reading it. This is a blast-radius reduction, not a sandbox. |
+| `--no-analytics` | No telemetry from a dispatched run. Aider's own `--analytics` default is `random`, which opts some sessions in by itself. |
+| `--no-check-update` | No version check on a dispatch path. |
+| `--no-detect-urls` | Aider's `--detect-urls` defaults to `True` and offers to scrape any URL in the message. Under `--yes-always` that offer is auto-accepted, so a URL in the brief becomes an unannounced outbound fetch - and, with Playwright absent, a run that hangs until the watchdog fires. |
+| `--no-pretty` | Colour codes would corrupt the captured report. |
+| `--no-stream` | Whole responses; the relay captures text, not a live view. |
+
+The first two are why this skill can promise a reviewable diff. If you drive `aider` by hand instead,
+pass them yourself.
+
+## Artifacts and result fields
+
+Everything lands in the run directory (temp by default, so the repo under review stays clean):
+
+| File | Contents |
+| --- | --- |
+| `brief.txt` | The brief as dispatched - and the file Aider reads via `--message-file`. |
+| `final.txt` | Aider's report, when one was captured. |
+| `stderr.txt` | Aider's stderr, streamed through to your terminal as well. |
+| `result.json` | The structured result, written atomically. |
+
+`result.json` speaks `delegate-relay.result.v1`:
+
+| Field | Meaning |
+| --- | --- |
+| `status` | `completed`, `failed`, `timeout`, `aborted`, or `aider_unavailable`. |
+| `exitCode` | Aider's exit code, or 128+signal, or 127 when the binary is missing. An exit-0 model/endpoint failure detected in the report is remapped to `1`. |
+| `signal` | The signal that killed the child, else `null`. |
+| `aiderVersion` | What `aider --version` reported. |
+| `finalMessage` | Aider's own report. |
+| `touchedFiles` | `git status --porcelain` lines. `[]` when the tree is clean, `null` when git cannot report. |
+| `readOnly` | Whether this was dispatched as a dry run. |
+| `resumed` | Whether chat history was restored. |
+| `error` | Present on **every** non-clean outcome, including an ordinary nonzero exit; says what went wrong. |
+| `stderrTail` | Last stderr lines, on a non-clean outcome. |
+
+## Waiting for completion
+
+The relay blocks until Aider exits. Run it under the orchestrator's background-command facility, or
+background it and poll for `result.json` - it is published atomically via rename, so a poller never
+reads a half-written file.
+
+Completion means the process exited and `result.json` exists. Trust that over any progress display.
+
+## When a run misbehaves
+
+- **Exit 2, no result file.** A usage error - bad flag, missing value, empty brief, unparseable
+  `--timeout`. Nothing was dispatched. Fix the command.
+- **Exit 127, `status: "aider_unavailable"`.** `aider` is not on PATH. Install it, or check that the
+  environment running the relay sees the same PATH you do.
+- **`status: "failed"` with an endpoint or authentication `error`.** Aider exits 0 even when it never
+  reached a model, so the relay scans the run for Aider's own errors and reports this rather than a
+  false success. It is a configuration problem: check the model name, `--api-base`, and provider key.
+- **`status: "timeout"`.** The watchdog fired and the process tree was killed, possibly mid-edit.
+  Inspect `touchedFiles` before re-dispatching; re-run with a longer `--timeout`.
+- **`status: "aborted"`.** The relay itself was killed and forwarded the kill to Aider. Same caution:
+  the tree may be partial.
+- **`--read-only` run that changed something.** Aider's `--dry-run` is Aider's promise, not the
+  relay's measurement, so the relay warns when a read-only run leaves changed paths behind. Only the
+  files Aider *generates* are excluded from that check - `.aider.chat.history.md`,
+  `.aider.input.history`, `.aider.llm.history`, and the `.aider.tags.cache.v*` directory - because it
+  writes them even under `--dry-run`. Aider's user-managed settings are deliberately **not** excluded:
+  if `.aider.conf.yml`, `.aider.model.settings.yml`, `.aider.model.metadata.json`, or `.aiderignore`
+  changed during a dry run, that is exactly what the warning is for. Everything, generated or not,
+  still appears in `touchedFiles`, which reports git verbatim.
+
+## Recovering lost work
+
+If the orchestrator loses the relay's output, the run directory still has everything: `final.txt` for
+the report, `stderr.txt` for the failure, `result.json` for the structured facts. Nothing was
+committed, so the working tree is exactly as Aider left it - `git diff` is the source of truth.
+
+## The commit boundary
+
+The relay never runs `git commit`, `git add`, or `git push`, and it disables Aider's own committing.
+Reviewing and committing are the orchestrator's job, after the gates pass. See
+[review-and-land.md](review-and-land.md).

--- a/skills/aider-delegate/references/multi-task-queues.md
+++ b/skills/aider-delegate/references/multi-task-queues.md
@@ -1,0 +1,68 @@
+# Multi-task queues
+
+A queue is several bounded tasks run through the same loop, one after another, with you reviewing
+between them. It is not a way to dispatch a large task in parallel pieces.
+
+## Run sequentially, one commit per task
+
+Dispatch task N, review it, commit it, then dispatch task N+1. The reasons are practical:
+
+- **A clean base per task.** Reviewing a diff means reading what this task changed. If two runs edit
+  the tree at once, `touchedFiles` stops telling you who did what.
+- **Aider's chat history is per-repository.** `--resume-last` restores the history file in the repo,
+  so concurrent runs in one worktree share and clobber it. Genuine parallelism needs separate
+  worktrees, each with its own history.
+- **Failure stays contained.** A bad task N is one commit to inspect, not a tangle.
+
+If you truly need parallelism, use `git worktree` so each run gets its own tree, its own
+`.aider.chat.history.md`, and its own reviewable diff.
+
+## Carry decided constraints forward
+
+Aider starts each non-resumed run with no memory of the previous one. Anything decided in task 1 that
+constrains task 3 must be restated in task 3's brief:
+
+- Names, signatures, and interfaces settled earlier.
+- Patterns chosen ("we used the repository pattern here, follow it").
+- Boundaries that held ("still do not touch migrations/").
+
+A queue that does not carry constraints forward produces N locally-reasonable changes that do not
+agree with each other.
+
+## Keep a progress file
+
+For anything longer than three tasks, keep a small file outside the repo tracking: task, status,
+commit sha, and any decision that later tasks depend on.
+
+```
+1. reject negative windows       done    a1b2c3d   ValueError, not clamp
+2. propagate through scheduler   done    e4f5g6h   callers let it raise
+3. document the new behavior     pending           follow decision from 1
+```
+
+It survives a lost session, and it is what you carry forward into each brief.
+
+## Close with a coherence check
+
+Individually-correct tasks can still add up to something incoherent. After the last one, review the
+whole range as one diff:
+
+```bash
+git diff <sha-before-queue>..HEAD
+```
+
+Look for interfaces that drifted between tasks, duplicated helpers introduced independently, docs that
+describe an earlier iteration, and dead code left by a later task. Fix the seams before calling the
+queue done.
+
+## When to stop and ask
+
+Stop the queue and go back to the human when:
+
+- A task fails twice for the same reason. The brief is wrong, not the implementer.
+- A task reveals the plan itself was wrong - a later task no longer makes sense.
+- Correct completion needs a scope change: a `DO NOT TOUCH` file, a public interface, a new
+  dependency.
+- The queue's assumptions have gone stale because reality moved under it.
+
+Finishing a queue on a false premise is worse than stopping in the middle of it.

--- a/skills/aider-delegate/references/review-and-land.md
+++ b/skills/aider-delegate/references/review-and-land.md
@@ -1,0 +1,101 @@
+# Review and land
+
+Aider's report is a claim. Your review is the verification. The relay hands you a working tree and a
+report; deciding whether that work is correct, and committing it, is the part you do not delegate.
+
+## Check tests before trusting gates
+
+Before believing "all tests pass", confirm the suite actually ran something. A pytest run that
+collected zero items, a jest run that matched no files, and a green suite are three different things
+that can look alike in a summary. Check the counts.
+
+The same applies to a gate Aider chose for itself. If the brief named `python -m pytest tests/` and the
+report shows `pytest tests/test_window.py`, that is a narrower gate than you asked for.
+
+## Aider's lint is not your gates
+
+Aider's `--auto-lint` is on by default: after editing, it runs a linter and may fix its own
+complaints, which produces edits that no brief asked for. That is Aider's lint, not your gates. Run
+yours, and read the lint-driven edits as part of the diff.
+
+## Re-run the gates yourself
+
+Run the project's real commands in the working tree, yourself, and read the output. Not because the
+implementer lies, but because "I ran the tests" and "the tests pass in this tree right now" are
+different statements, and only the second one is what you are about to commit.
+
+If a gate fails, that is a rework loop (below), not a reason to commit and fix forward.
+
+## Read the diff against the brief
+
+Start with `touchedFiles` in `result.json`, then read the actual diff:
+
+- Every changed file should map to something the brief asked for.
+- Anything in the `DO NOT TOUCH` list that moved is a stop.
+- A file you did not expect is worth understanding before it lands - Aider builds a repo map and can
+  pull in files you did not scope.
+- Aider's own bookkeeping appears in the tree - `.aider.chat.history.md`, `.aider.input.history`, and
+  a `.aider.tags.cache.v*/` directory. Because the relay passes `--no-gitignore`, these show up as
+  untracked entries in `touchedFiles` rather than being hidden by a `.gitignore` Aider wrote itself.
+  They are not part of the change; do not commit them. Aider writes them under `--dry-run` too, so the
+  relay excludes them when deciding whether a read-only run misbehaved.
+
+## The implementer sweep
+
+Things worth checking specifically after a delegated run:
+
+- **Dangling references.** After a rename or removal, grep for the old name across the repo,
+  including docs, config, and generated code.
+- **Round-trip migrations.** A migration that applies is half-verified; roll it back too.
+- **Silent scope creep.** Refactors "while I was in there" are defensible and still need surfacing.
+- **Tests that assert the implementation.** A test written against the code just written can pass
+  while the behavior is wrong. Read new tests as carefully as new code.
+- **Swallowed errors.** A `try`/`except` added around the thing the brief asked to fail loudly.
+
+## The commit boundary
+
+**Aider edits the working tree; you commit.** The relay disables Aider's auto-commit and dirty-commit
+defaults precisely so this boundary exists, and it never runs `git commit` itself.
+
+Commit only when:
+
+1. The gates pass in the tree you are looking at.
+2. The diff matches the brief.
+3. Anything unasked-for has been surfaced to the human or reverted.
+
+Write the commit message yourself, describing the change as it landed. Aider's report describes what
+it believed it did.
+
+If the working tree was dirty before the run, separate your commit from the pre-existing changes -
+`git add -p` or explicit paths, never `git add -A` on a tree you did not start clean.
+
+## Rework: send the delta
+
+When the gates fail or the diff misses the brief, do not hand-patch the result and call it delegated -
+you lose the record of what the implementer actually produced. Re-dispatch:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief delta.txt --cd /path/to/repo --resume-last
+```
+
+`--resume-last` restores Aider's chat history for the repository, so the delta brief should say only
+what to change now - the failing gate output, the specific correction. Do not resend the original
+brief.
+
+Because that history lives in the repo (`.aider.chat.history.md`), resume is per-worktree. A fresh
+clone, or a different checkout of the same project, has nothing to resume; send a full brief there.
+
+Review the rework the same way. A second run is not more trustworthy than the first.
+
+## Surface, do not absorb
+
+Once the human has opted into delegation, committing verified, gate-passing work is the agreed
+contract - you do not need to ask again for each task. Two things still go back to them:
+
+- **Design decisions the brief did not specify.** Aider chose a name, a structure, an approach. Say
+  so, briefly, in your report.
+- **Defensible-but-unasked turns.** The extra refactor, the added helper, the reformatted file.
+
+And one thing stops the loop entirely: **a scope change**. If completing the task correctly requires
+going beyond the brief - touching a `DO NOT TOUCH` file, changing a public interface, adding a
+dependency - ask. Do not expand the mandate on the implementer's behalf.

--- a/skills/aider-delegate/references/writing-the-brief.md
+++ b/skills/aider-delegate/references/writing-the-brief.md
@@ -1,0 +1,142 @@
+# Writing the brief
+
+The brief is the whole contract. Aider sees the text you send plus the files in its editing scope -
+nothing else. No chat history, no shared context, none of the reasoning that led you here. Anything
+you leave implicit, Aider will decide for itself.
+
+Write it as if for a competent contractor who has never seen the project.
+
+## Model choice and resumed runs
+
+Aider uses its own configured model unless you pass `--model <name>`. For an OpenAI-compatible
+endpoint, pair it with `--api-base <url>`; a local server usually still needs a placeholder
+`OPENAI_API_KEY` in the environment because the client requires the header.
+
+On a resumed run (`--resume-last`), Aider restores its chat history for the repository, so send only
+the **delta** - what to change now, not the original brief again. That history lives in the repo
+(`.aider.chat.history.md`), so it is per-worktree: a fresh clone resumes nothing.
+
+## The shape that works
+
+```
+GOAL
+One sentence. What is true when this is done.
+
+CONTEXT
+Where the code lives, what currently happens, why it is wrong.
+Point at the files that matter. Name the ones you already ruled out.
+
+CHANGE
+The specific edits you want, in order. Be concrete about names and
+signatures you have already decided; say "your call" where you have not.
+
+DO NOT TOUCH
+Files, modules, behaviors, and public interfaces that must not move.
+Migrations, generated files, and vendored code belong here by default.
+
+GATES
+The project's real commands. Aider should run these and report results.
+
+REPORT
+What to tell me when done (see below).
+```
+
+## Scope the files explicitly
+
+Aider builds a repo map and pulls in files it thinks are relevant, which is useful for discovery and
+risky for a bounded task. Two relay flags aim the run:
+
+- `--file <path>` puts a file in Aider's **editing** scope. Repeatable.
+- `--read <path>` supplies a file as **read-only context**. Repeatable.
+
+Use `--read` for the interface, schema, or example the change must conform to, and `--file` for what
+should actually change. `--subtree-only` restricts Aider to the current subtree of the repository.
+
+**These are chat-context controls, not a security boundary.** They decide what Aider starts with, and
+what you pay for in tokens - they do not confine what the run can reach. Aider has no sandbox, the
+relay dispatches it with `--yes-always`, and a run that decides it needs another file is not stopped
+by their absence. Treat them as aim, not as a fence. When a change genuinely must not be able to touch
+something, the boundary has to come from outside Aider: a container, a VM, or a throwaway
+`git worktree` holding only what the task may see.
+
+Scoping the dispatch also does not replace a `DO NOT TOUCH` section - state the boundary in the brief
+too, because the brief is what Aider reasons about, and then verify it in the diff rather than
+assuming it held.
+
+## Always ask for the report explicitly
+
+Aider will not volunteer a structured summary. Ask for one:
+
+```
+REPORT
+- What you changed, file by file, and why.
+- Which gates you ran and their exact output.
+- Anything you decided that I did not specify.
+- Anything you could not do, and what blocked you.
+```
+
+## Discover the real gates
+
+Read the project's config before writing the brief - `package.json` scripts, `Makefile`, `noxfile.py`,
+`pyproject.toml`, the CI workflow. Name the actual commands. A brief that says "run the tests" against
+a project whose suite needs a service container produces a confident report and no verification.
+
+Aider's own `--auto-lint` runs a linter after edits by default; that is Aider's lint, not your gates.
+State your gates anyway.
+
+## Honor repo conventions
+
+If the project has a `CONVENTIONS.md`, a style guide, or a `CLAUDE.md`/`AGENTS.md`, pass it with
+`--read` and say in the brief that it is binding. Aider follows conventions it can see.
+
+## One task per brief
+
+One goal per dispatch. Bundled tasks produce a diff you cannot review cleanly, and a failure in one
+half strands the other. Queue them instead - see
+[multi-task-queues.md](multi-task-queues.md).
+
+## Premises freeze at dispatch
+
+Everything you assert in the brief is frozen the moment you dispatch. If you learn something that
+changes the premises while the run is in flight - a gate command was wrong, an interface moved - do
+not let the run land on a false basis. Stop it, or discard the result and re-dispatch with the
+corrected brief.
+
+## A worked example
+
+```
+GOAL
+`parse_window()` should reject a negative duration instead of silently
+clamping it to zero.
+
+CONTEXT
+src/chronal/window.py, parse_window() around line 40. It currently does
+max(0, seconds), which turns "-5m" into a zero-length window and makes the
+scheduler fire immediately. Callers in src/chronal/schedule.py assume a
+positive window.
+
+CHANGE
+- Raise ValueError("window must be positive") for a non-positive duration.
+- Leave the parsing of the h/m/s string itself alone.
+- Update the two call sites in schedule.py to let the error propagate;
+  do not add a try/except that swallows it.
+
+DO NOT TOUCH
+- The duration grammar or its regex.
+- Anything under migrations/ or tests/fixtures/.
+
+GATES
+- python -m pytest tests/test_window.py tests/test_schedule.py
+- python -m ruff check src/
+
+REPORT
+File-by-file summary, exact gate output, decisions I did not specify,
+and anything you could not do.
+```
+
+## Brief delivery
+
+The relay writes your brief to `brief.txt` in the run directory and passes it to Aider with
+`--message-file`. It never rides argv, so there is no process-list exposure and no OS argument size
+cap to work around: a long brief is fine. Large *context* still belongs in files Aider reads, not
+inlined into the brief.

--- a/skills/aider-delegate/scripts/relay.mjs
+++ b/skills/aider-delegate/scripts/relay.mjs
@@ -1,0 +1,752 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · aider-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to Aider (`aider --message-file`), capture the
+ * run, and write a structured result the orchestrating agent can review. The
+ * orchestrator runs this one command and reads the result JSON - every
+ * Aider-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. What was actually run, and on what, is recorded in the
+ * README's Verification status list rather than pinned here.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `aider` and `git`. The `aider` process it
+ * launches does reach its configured model endpoint - exactly as you do at the
+ * terminal. Read this file before you run it.
+ *
+ * The brief is delivered with `--message-file`, so it never rides argv: it is
+ * not visible in the host process list and is not subject to the OS argument
+ * size cap.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * - after it reviews the diff and re-runs the project gates. Aider is the one
+ * implementer here that commits by default, so the relay always passes:
+ *   --no-auto-commits    Aider's `--auto-commits` defaults to True and would
+ *                        otherwise commit its own edits.
+ *   --no-dirty-commits   Aider's `--dirty-commits` defaults to True and would
+ *                        otherwise commit YOUR pre-existing uncommitted work
+ *                        before it starts editing.
+ * Neither flag is configurable through this relay. A run that committed would
+ * destroy the reviewable diff this skill exists to produce.
+ *
+ * The relay also pins the following, none of them configurable, so a headless
+ * run stays quiet and leaves no artifacts of its own in the tree:
+ *   --yes-always         Aider's own autonomy term; headless runs cannot answer
+ *                        a confirmation prompt.
+ *   --no-suggest-shell-commands
+ *                        The other half of --yes-always: Aider's
+ *                        --suggest-shell-commands defaults to True, and under
+ *                        --yes-always a suggestion runs on the host unread.
+ *   --no-gitignore       Aider otherwise writes `.aider*` into .gitignore on
+ *                        startup, dirtying the tree the reviewer is about to read.
+ *   --no-analytics       No telemetry from the dispatched run. Aider's own
+ *                        --analytics default is "random", which opts some
+ *                        sessions in on its own.
+ *   --no-check-update    No version check on a dispatch path.
+ *   --no-detect-urls     Aider's --detect-urls defaults to True and offers to
+ *                        scrape any URL in the message. Under --yes-always that
+ *                        offer is auto-accepted, so a URL in the brief becomes an
+ *                        unannounced outbound fetch - and, without Playwright
+ *                        installed, a run that hangs until the watchdog fires.
+ *   --no-pretty          Plain output; colour codes would corrupt the captured report.
+ *   --no-stream          Whole responses; the relay captures text, not a live view.
+ *
+ * Autonomy, in Aider's own terms: `--yes-always` auto-confirms every prompt, and
+ * Aider has no sandbox and no permission modes. Within its file scope it edits
+ * freely. `--read-only` here maps to Aider's `--dry-run`, which performs the run
+ * without modifying files; the relay does not independently verify that claim, so
+ * `touchedFiles` remains the evidence of what changed.
+ *
+ * Aider has no session ids. Its resume unit is the chat history file in the
+ * repo (`.aider.chat.history.md`), so `--resume-last` maps to Aider's
+ * `--restore-chat-history` and `--history-file` pins a specific one.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for Aider (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Aider model name (default: Aider's own configured model).
+ *   --api-base <url>        OpenAI-compatible base URL (Aider's --openai-api-base).
+ *   --edit-format <fmt>     Aider edit format (its --edit-format, e.g. diff, whole, udiff).
+ *   --architect             Use Aider's architect edit format.
+ *   --file <path>           Add a file to Aider's editing scope. Repeatable.
+ *   --read <path>           Add a read-only context file. Repeatable.
+ *   --subtree-only          Restrict Aider to the current subtree of the repo.
+ *   --read-only             Dispatch as a dry run (Aider's --dry-run): no files modified.
+ *   --resume-last           Restore Aider's chat history for this repo; send only the delta brief.
+ *   --history-file <path>   Pin a specific chat history file (Aider's --chat-history-file).
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). Durations use h/m/s strings.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout -
+ *   status, exitCode, signal, aiderVersion, finalMessage (Aider's own report),
+ *   touchedFiles (git porcelain, null if git cannot report), and paths to
+ *   brief.txt, final.txt, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `aider` binary exits 127
+ * with one; otherwise the exit code mirrors Aider's own (0 success, non-zero
+ * failure), except an exit-0 model/endpoint failure detected in the report exits
+ * 1. If the child dies on a signal, the exit code is 128 plus the signal
+ * number and `result.json` records the signal. Once the brief validates,
+ * `result.json` is written on every outcome - completed, failed, timeout (the
+ * --timeout watchdog fired), aborted (the relay itself was killed and forwarded
+ * the kill to aider), or aider_unavailable.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync, rmSync } from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+
+const DEFAULT_TIMEOUT = "30m";
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_TIMER_MS = 2_147_483_647;
+
+const IMPLEMENTER_KEY = "aider";
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    apiBase: null,
+    editFormat: null,
+    architect: false,
+    files: [],
+    reads: [],
+    subtreeOnly: false,
+    readOnly: false,
+    resumeLast: false,
+    historyFile: null,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--api-base": opts.apiBase = next(); break;
+      case "--edit-format": opts.editFormat = next(); flagged.add("editFormat"); break;
+      case "--architect": opts.architect = true; flagged.add("editFormat"); break;
+      case "--file": opts.files.push(next()); break;
+      case "--read": opts.reads.push(next()); break;
+      case "--subtree-only": opts.subtreeOnly = true; break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--history-file": opts.historyFile = next(); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.architect && opts.editFormat) {
+    fail("--architect and --edit-format are mutually exclusive; pass only one");
+  }
+  // aider resolves a relative --file/--read/--chat-history-file against ITS cwd, so
+  // resolve against --cd (not the relay's own cwd) - and only after the loop, since
+  // they may appear before --cd on the command line. resolve() passes absolutes through.
+  opts.files = opts.files.map((path) => resolve(opts.cd, path));
+  opts.reads = opts.reads.map((path) => resolve(opts.cd, path));
+  if (opts.historyFile) opts.historyFile = resolve(opts.cd, opts.historyFile);
+  // The watchdog is relay-only (aider's own --timeout bounds a single API call, not
+  // the run), so a malformed --timeout must fail loudly here - a silent 30m fallback
+  // would be wrong.
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to aider --message-file\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once aider is running, so the preflight needs a bound of its
+  // own: an `aider --version` that never returns would wedge the relay here, before any
+  // result.json exists, and --timeout could not reach it.
+  return Math.min(parseDuration(opts.timeout), VERSION_PROBE_TIMEOUT_MS);
+}
+
+function aiderVersion(probeTimeoutMs) {
+  try {
+    const out = execFileSync("aider", ["--version"], {
+      encoding: "utf8",
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+    }).trim();
+    return { version: out || "unknown", error: null };
+  } catch (err) {
+    // Only a missing binary means "unavailable"; any other version-probe
+    // failure must not masquerade as exit 127.
+    if (err && err.code === "ENOENT") return { version: null, error: null };
+    // A hung probe we killed, or a real non-zero exit, means aider is installed but not
+    // usable. Dispatching anyway would send the brief to a CLI already known to be broken.
+    return { version: null, error: err };
+  }
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+// Aider writes its own bookkeeping into the repo and keeps doing so under --dry-run.
+// These stay in touchedFiles, which reports git verbatim, but they must not trip the
+// read-only warning: a dry run that touched nothing else is exactly what was asked for.
+// The list is exhaustive on purpose. A blanket `.aider*` match would also swallow
+// user-managed settings - .aider.conf.yml, .aider.model.settings.yml,
+// .aider.model.metadata.json, .aiderignore - and those changing during a dry run is
+// precisely what the warning exists to report.
+const AIDER_GENERATED_FILE = /^\.aider\.(?:chat\.history\.md|input\.history|llm\.history)$/;
+const AIDER_GENERATED_DIR = /^\.aider\.tags\.cache\.v\d+$/;
+
+function isAiderGenerated(path) {
+  const segments = path.split("/");
+  // the tags cache is a directory; git may report it or anything beneath it
+  if (segments.some((segment) => AIDER_GENERATED_DIR.test(segment))) return true;
+  return AIDER_GENERATED_FILE.test(segments[segments.length - 1]);
+}
+
+function withoutAiderArtifacts(touchedFiles) {
+  if (!Array.isArray(touchedFiles)) return [];
+  return touchedFiles.filter((line) => {
+    // git porcelain v1: two status columns, a space, then the path. A rename reports
+    // `old -> new`; judge the destination, which is what the run actually wrote.
+    const entry = line.slice(3).trim();
+    const target = entry.includes(" -> ") ? entry.slice(entry.lastIndexOf(" -> ") + 4) : entry;
+    return !isAiderGenerated(target.replace(/^"|"$/g, ""));
+  });
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  // A reused --out-dir must not advertise the previous run: a poller that races the
+  // dispatch would read the old result.json as if it were this run's, and a preflight
+  // failure or a run with no stdout would publish a finalPath for someone else's report.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function buildArgv(opts, run) {
+  // Non-negotiable posture. --no-auto-commits and --no-dirty-commits keep the diff
+  // reviewable (both default to True in aider); --no-gitignore stops aider writing
+  // `.aider*` into .gitignore and dirtying the tree; the rest keep headless output
+  // clean and side-effect free.
+  //
+  // --no-suggest-shell-commands is the other half of --yes-always. Aider's
+  // --suggest-shell-commands defaults to True, and a suggestion under --yes-always is
+  // accepted with nobody there to read it: the model's proposed command runs on the
+  // host. Turning the suggestions off is not a sandbox - see SKILL.md - but it removes
+  // the one path where a dispatched run executes a command the brief never named.
+  const argv = [
+    "--yes-always",
+    "--no-suggest-shell-commands",
+    "--no-auto-commits",
+    "--no-dirty-commits",
+    "--no-gitignore",
+    "--no-analytics",
+    "--no-check-update",
+    "--no-detect-urls",
+    "--no-pretty",
+    "--no-stream",
+  ];
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.apiBase) argv.push("--openai-api-base", opts.apiBase);
+  if (opts.architect) argv.push("--architect");
+  else if (opts.editFormat) argv.push("--edit-format", opts.editFormat);
+  if (opts.subtreeOnly) argv.push("--subtree-only");
+  if (opts.readOnly) argv.push("--dry-run");
+  if (opts.resumeLast) argv.push("--restore-chat-history");
+  if (opts.historyFile) argv.push("--chat-history-file", opts.historyFile);
+  for (const path of opts.reads) argv.push("--read", path);
+  for (const path of opts.files) argv.push("--file", path);
+  // Deliver the brief by file, never by argv: it keeps the brief out of the host
+  // process list and clear of the OS argument size cap, and it binds a brief that
+  // starts with "-" instead of letting it parse as a flag.
+  argv.push("--message-file", run.briefPath);
+  return argv;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "aider",
+      workdir: opts.cd,
+      model: opts.model,
+      editFormat: opts.architect ? "architect" : opts.editFormat,
+      readOnly: opts.readOnly,
+      resumed: Boolean(opts.resumeLast),
+      aiderVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(opts, writeResult, resultPath) {
+  const result = writeResult({
+    status: "aider_unavailable",
+    exitCode: 127,
+    signal: null,
+    finalMessage: "",
+    // git can still report here, and the contract reserves null for when it cannot.
+    // The tree is whatever it already was; say so rather than claiming ignorance.
+    touchedFiles: gitTouchedFiles(opts.cd),
+    error: "`aider` was not found on PATH; nothing was dispatched",
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `aider` not found on PATH. Install Aider (https://aider.chat/docs/install.html) and configure a model.\n");
+  // Set the code and return rather than process.exit(): printSummary writes aider's whole
+  // final report in one stdout write, and stdout to a pipe is asynchronous on macOS - which
+  // is exactly how an orchestrator captures this. Forcing exit can truncate that write.
+  // Every caller of this helper already returns, so falling through dispatches nothing.
+  process.exitCode = 127;
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `aider --version preflight timed out after ${probeTimeoutMs}ms; Aider was not dispatched`
+    : `aider --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Aider was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exitCode = result.exitCode;
+}
+
+// Aider exits 0 after reporting a model or endpoint failure, so exit status alone
+// cannot separate "did the work" from "never reached a model". These are aider's
+// own end-of-run error lines; matching them turns that silent success into a
+// failed status the orchestrator can act on.
+// Every pattern is line-anchored. An earlier revision matched a bare `OPENAI_API_KEY`
+// anywhere in the report, so a successful run whose report merely *mentioned* the
+// variable ("Updated the docs to explain OPENAI_API_KEY setup") was published as an
+// authentication failure. A diagnostic is a line aider emits, not a word it says.
+const MODEL_FAILURE_PATTERNS = [
+  // litellm surfaces the provider error class at the head of its own line; allow a
+  // short prefix ("Error: ", a retry counter) but not a sentence of prose.
+  /^.{0,60}?litellm\.(?:APIConnectionError|AuthenticationError|BadRequestError|RateLimitError|NotFoundError|InternalServerError|Timeout)\b/im,
+  /^\s*(?:Error|Warning) connecting to /im,
+  /^\s*(?:Error|Warning):?\s*(?:\w+_API_KEY|API key)\b.*\b(?:not set|not found|missing|invalid)\b/im,
+  /^\s*The API provider is not able to authenticate you\b/im,
+  // Needs an endpoint-shaped object: "Unable to connect" on its own is ordinary prose
+  // a report could easily contain while describing the very thing it just documented.
+  /^\s*Unable to (?:connect|reach)\s+(?:the\s+)?(?:model|endpoint|server|host|API|provider|https?:)/im,
+];
+
+function detectModelFailure(text) {
+  for (const pattern of MODEL_FAILURE_PATTERNS) {
+    const match = pattern.exec(text);
+    if (match) return match[0].trim();
+  }
+  return null;
+}
+
+function dispatchToAider(opts, run, writeResult) {
+  // Aider's pip install provides a native `aider` executable on every platform
+  // (including the `aider.exe` shim on Windows), so launch it directly: multi-line
+  // values and paths with spaces ride argv rather than shell text.
+  const child = spawn("aider", buildArgv(opts, run), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let stdout = "";
+  const stderrTail = [];
+  let stderrRemainder = "";
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    stdout += stdoutDecoder.write(chunk);
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    // Carry the un-newlined tail forward. A chunk that ends mid-line would otherwise
+    // publish half a line in stderrTail as though it were whole, and the rest of that
+    // line would arrive as a second, equally broken entry.
+    const text = stderrRemainder + stderrDecoder.write(chunk);
+    const lines = text.split("\n");
+    stderrRemainder = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  // Both decoders hold any trailing bytes of a split multibyte character until they
+  // are flushed, and stderr holds a final line that never got its newline. Drain both
+  // before assembling a result, or the last thing aider said is the thing that is lost.
+  const flushStreams = () => {
+    stdout += stdoutDecoder.end();
+    const tail = stderrRemainder + stderrDecoder.end();
+    stderrRemainder = "";
+    if (tail.trim()) stderrTail.push(tail.trimEnd());
+    while (stderrTail.length > 20) stderrTail.shift();
+  };
+
+  const assembleFinal = () => {
+    const message = stdout.trim();
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the aider child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdogTimer);
+      if (sigkillTimer) clearTimeout(sigkillTimer);
+      flushStreams();
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; aider was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        // The one forced exit the relay keeps. The other paths set process.exitCode so the
+        // summary can drain, but here a child that refused to die would keep the loop alive
+        // and hang the relay; after the grace window, leaving is the point.
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    flushStreams();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exitCode = 1;
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    flushStreams();
+    const finalMessage = assembleFinal();
+    const modelFailure = watchdogFired
+      ? null
+      : detectModelFailure(`${finalMessage}\n${readFileSync(run.stderrPath, "utf8")}`);
+    // A timed-out run is failed even if aider handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired && !modelFailure;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      // Every non-clean outcome carries an `error`. A plain nonzero exit used to fall
+      // through this chain with none, leaving the consumer to infer the cause from
+      // exitCode alone - which the result contract says it should never have to do.
+      ...(succeeded
+        ? {}
+        : watchdogFired
+          ? { error: `aider did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` }
+          : modelFailure
+            ? { error: `aider reported a model or endpoint failure and exited ${code}: ${modelFailure}` }
+            : signal
+              ? { error: `aider was killed by ${signal} — inspect the working tree before re-dispatching` }
+              : { error: `aider exited ${code} without reporting a model or endpoint failure; see stderrTail and final.txt` }),
+    });
+    printSummary(result, run.resultPath);
+    process.exitCode = result.exitCode;
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently. It also writes
+  // brief.txt, which is the file aider reads with --message-file.
+  const run = prepareRunDir(opts, brief);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = aiderVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    reportUnavailable(opts, writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+  dispatchToAider(opts, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  ${result.aiderVersion ?? "aider ?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an aider error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated aider (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.readOnly) lines.push("mode: dry run (aider --dry-run) - no files should be modified");
+  if (result.resumed) lines.push("mode: restored aider's chat history");
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  const unexpected = result.readOnly ? withoutAiderArtifacts(touched) : [];
+  if (unexpected.length) {
+    lines.push(`warning: --read-only dispatched aider --dry-run, yet ${unexpected.length} path(s) outside aider's own generated history and cache changed. Inspect the diff before trusting this run.`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- aider final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/claude-delegate/SKILL.md
+++ b/skills/claude-delegate/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: claude-delegate
+description: Delegate a coding task to a separate Claude Code CLI process or another
+  Claude session as an implementer, then review its diff and land it yourself. Use
+  only when the user explicitly asks to delegate implementation to Claude Code, another
+  Claude session, or the `claude` CLI —...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `claude` CLI (Claude Code) installed and authenticated,
+  Node 18+, and git. The orchestrating agent must be able to run shell commands and
+  read files. Claude's shell sandbox requires macOS, Linux, or WSL2; native Windows
+  launch is pending verification.
+metadata:
+  version: 0.5.0
+---
+# Claude Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `claude` implementer (`Claude Code`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Delegate one bounded coding task to a separate **implementer** — a Claude
+Code CLI session — then review what it produced and land it yourself. You write the brief and own the
+judgment; the separate Claude session edits the working tree; you verify and commit.
+
+This skill is not a signal for the current Claude to implement directly. Use it only after the human
+explicitly asks for delegation to another Claude Code process or session.
+
+## When not to use this
+
+- The human asked the current agent to implement the task directly.
+- The task is small enough to do inline and the human did not request delegation.
+- The `claude` CLI is missing or unauthenticated (`claude auth status`).
+- The task needs a stronger host boundary than Claude Code's tool permissions and shell-only sandbox
+  provide. Use an isolated container or VM for that requirement.
+
+## Prerequisites
+
+1. `claude --version` succeeds.
+2. `claude auth status` reports an authenticated session. On macOS the live credentials sit in the
+   login Keychain; when the orchestrator's own sandbox blocks Keychain access (Codex's sandbox
+   does), `claude` falls back to a possibly stale credentials file and reports `loggedIn: false`
+   even though the login is valid. Re-run the check — and the dispatch itself — with that sandbox
+   escalated or outside it before concluding the CLI is unauthenticated.
+3. The target repository is the directory passed with `--cd`.
+4. On Linux/WSL2, Claude's sandbox dependencies are installed. The normal relay profile is
+   configured to fail when the sandbox is unavailable instead of silently running shell commands
+   unsandboxed. Existing merged settings can still affect the effective boundary.
+
+## The loop
+
+### 1. Write the brief
+
+The separate session has no orchestrator chat history. It receives the brief on stdin and can inspect
+the target working tree.
+
+Claude Code automatically discovers the target project's `CLAUDE.md` and normal local Claude
+configuration because the relay does not use `--bare`. It does **not** generically auto-load
+`AGENTS.md`. Read `AGENTS.md` yourself and copy every load-bearing constraint and the real gate
+commands into the brief. Tell the implementer not to commit. Keep one task per brief.
+
+Template and details: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# review/diagnosis only:                 add --read-only
+# continue the latest session:           add --resume-last
+# continue the recorded session:         add --session <id>
+# choose limits:                         add --max-turns 40 --max-budget-usd 10
+# hard relay deadline:                   add --timeout 2h
+# inspect every option:                  node .../relay.mjs --help
+```
+
+`<skill-dir>` is this installed skill directory, the folder containing this `SKILL.md`.
+
+The relay runs `claude -p --output-format stream-json --verbose`, sends the brief through stdin, and
+writes artifacts under the system temp directory by default. It never uses `--bg` or `--bare`, and it
+never commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait
+
+The relay blocks until Claude exits. Use the orchestrator's background-command facility, or run it in
+the foreground and wait. Completion means the process exited and `result.json` exists.
+
+- A pre-run usage error exits 2 and writes no `result.json`.
+- A missing `claude` exits 127 and writes `status: "claude_unavailable"`.
+- Timeout and caught relay signals terminate the whole implementer process tree and preserve an
+  outcome artifact.
+
+Read `finalMessage`, `touchedFiles`, `resultSubtype`, and the raw artifact paths from `result.json`.
+
+### 4. Review
+
+Treat the implementer's report and gate outcomes as claims:
+
+- Review edits to existing tests before a green gate means anything.
+- Re-run the project's actual gates yourself.
+- Read the complete diff against the brief, starting with `touchedFiles`.
+- Inspect untracked and staged content as well as the ordinary diff.
+- Run relevant guard skills if installed.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land
+
+The **orchestrator commits** only after the gates pass and the diff holds. For rework, resume the same
+Claude session with a delta brief:
+
+```bash
+echo "Keep the implementation, replace the mocked DB test with the migrated fixture, and remove the
+unused import." | node "<skill-dir>/scripts/relay.mjs" --session <id> --cd /path/to/repo
+```
+
+Review a resumed run exactly like the first run.
+
+## Permission profiles
+
+The normal profile is deliberately explicit:
+
+- `acceptEdits` permission mode.
+- Built-in tools restricted to Read, Glob, Grep, Edit, Write, and the platform shell.
+- On macOS, Linux, and WSL2, Claude's shell sandbox is enabled with startup failure on missing
+  dependencies and no unsandboxed retry. Commands that stay sandboxed are auto-approved so ordinary
+  gates can run headlessly. The sandbox governs shell processes and their children only; merged
+  local or managed sandbox settings can add effective paths or exclusions.
+- Configured MCP discovery and Claude.ai connectors are disabled, all MCP tools are denied, and
+  skills, commands, and Claude's Agent tool are unavailable to the child. Project `CLAUDE.md`, hooks,
+  normal authentication, session persistence, and other local settings still load.
+- String rules deny common direct shell forms of `git commit`, `git push`, and nested `claude`, plus
+  any command containing `claude-delegate`. Aliases, scripts, and wrappers can bypass them, so they
+  are only a speed bump; the brief's no-commit instruction and orchestrator review remain the boundary.
+
+Native Windows does not support Claude's shell sandbox. The relay restricts the tool surface and
+pre-approves PowerShell so the run remains non-interactive, but that shell is not OS-isolated. Native
+`claude.exe` and npm `claude.cmd` launch paths are implemented; Windows verification is pending.
+
+`--read-only` uses `plan` mode with only Read, Glob, and Grep. It removes edit, write, and shell paths,
+then compares parsed git porcelain and fingerprints the working-tree identity and index entries of
+Git-visible paths that were already dirty.
+`readOnlyViolation` is `true` when either signal proves a change, `false` when coverage is complete and
+detects none, and `null` when coverage is incomplete. This is a reporting tripwire, not an OS boundary:
+ignored paths and perfect restores are outside it, local hooks can write, and concurrent changes cannot
+be attributed to Claude.
+
+`--dangerously-skip-permissions` is an explicit opt-in to Claude's `bypassPermissions` mode. The
+restricted tool surface, direct commit/push deny rules, and supported-platform shell sandbox remain,
+but direct file tools can cross normal permission boundaries. Use it only with the human's explicit
+acceptance.
+
+## Complementary to native Claude features
+
+Claude subagents, agent teams, and background sessions are useful when the current Claude environment
+is already the orchestrator and native coordination is the goal. This skill is complementary: it
+provides a cross-orchestrator contract — self-contained brief → dispatch → artifacts → review → land
+— and keeps the commit with the orchestrator.
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — context, `CLAUDE.md` versus
+  `AGENTS.md`, real gates, report contract, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — flags, profiles, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) — generated-code review, the commit
+  boundary, and session rework.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — sequential queues, progress
+  tracking, constraint carry-forward, and final coherence.
+
+
+## Limitations
+
+- Requires the `claude` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/claude-delegate/references/dispatch-and-poll.md
+++ b/skills/claude-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,220 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps Claude Code's non-interactive `claude -p` mode, sends a brief on stdin,
+captures the structured stream, and writes `delegate-relay.result.v1`.
+
+## Before the first run
+
+```bash
+command -v claude
+claude --version
+claude auth status
+```
+
+The relay performs its own `claude --version` preflight and records the answer as `claudeVersion`.
+When an orchestrator is itself Claude Code, the relay removes only inherited `CLAUDECODE` from the
+child environment so a separate CLI process can start. It preserves credentials,
+`CLAUDE_CODE_CHILD_SESSION`, and every other environment entry. Version preflight uses that same
+environment.
+
+## Dispatch
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read stdin. The exact text is then sent to Claude on stdin, never argv. |
+| `--cd <dir>` | Child process cwd and target working root (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp directory). |
+| `--timeout <dur>` | Relay watchdog, such as `30m`, `90s`, or `2h` (default: off). |
+| `--model <name>` | Claude model alias or full name (default: Claude's configured choice). The relay does not pin a model version. |
+| `--effort <level>` | Claude effort: `low`, `medium`, `high`, `xhigh`, `max`, or `ultracode`; availability depends on the model. |
+| `--max-turns <n>` | Positive agentic-turn cap. |
+| `--max-budget-usd <amount>` | Positive decimal spend cap for print mode. |
+| `--resume-last` | Resume the latest session for this cwd with Claude's `--continue`; send a delta brief. |
+| `--session <id>` | Resume a specific session with Claude's `--resume <id>`; mutually exclusive with `--resume-last`. |
+| `--read-only` | Plan mode with only Read, Glob, and Grep, plus a Git-visible change tripwire. |
+| `--dangerously-skip-permissions` | Opt into Claude's `bypassPermissions`; mutually exclusive with `--read-only`. |
+| `-h`, `--help` | Print the relay header and option reference. |
+
+Values that can reach an npm `claude.cmd` launch on Windows are token- or number-validated. The brief
+never reaches a shell command line.
+
+## What the relay launches
+
+The common shape is:
+
+```bash
+claude -p --output-format stream-json --verbose \
+  --tools Read,Glob,Grep,Edit,Write,Bash \
+  --strict-mcp-config --disallowedTools 'mcp__*' \
+  --disable-slash-commands \
+  --settings <profile.json> \
+  --permission-mode acceptEdits \
+  < brief.txt
+```
+
+On native Windows, `PowerShell` replaces `Bash` and is passed through `--allowedTools` because Claude's
+shell sandbox is unavailable there. Read-only uses `--tools Read,Glob,Grep --permission-mode plan`. A
+specific session adds `--resume <id>`; the latest session adds `--continue`. The permission and tool
+profile is re-passed on every resumed invocation.
+
+The relay never adds `--bg`: Claude documents background mode as incompatible with `-p`. It never adds
+`--bare`, because bare mode skips `CLAUDE.md` and OAuth/keychain authentication.
+
+`--strict-mcp-config` without an MCP config prevents configured-server discovery. The inline settings
+also disable Claude.ai connectors, while `--disallowedTools 'mcp__*'` denies any MCP tool that managed
+policy still supplies. `--disable-slash-commands` prevents skill and command recursion, and `--tools`
+omits the Agent tool. These controls do not suppress project `CLAUDE.md` or normal authentication.
+
+## Permission reach
+
+### Normal write-capable profile
+
+The normal profile pairs `acceptEdits` with sandbox auto-approval on supported platforms.
+`acceptEdits` accepts file edits but does not, by itself, approve ordinary shell gates in a headless
+run. `autoAllowBashIfSandboxed: true` approves commands that stay inside Claude's sandbox. A command
+that cannot stay sandboxed fails instead of being retried outside it. Native Windows is the explicit
+exception: the relay pre-approves PowerShell because no Claude shell sandbox is available there.
+
+The generated `profile.json`:
+
+- uses string rules to deny common direct shell forms of `git commit`, `git push`, and nested
+  `claude`, plus any command containing `claude-delegate`; aliases, scripts, and wrappers can bypass
+  these speed bumps, so the brief's no-commit instruction and orchestrator review remain the boundary;
+- on macOS, Linux, and WSL2, enables Claude's Bash sandbox with `failIfUnavailable: true`,
+  `autoAllowBashIfSandboxed: true`, `allowUnsandboxedCommands: false`, and filesystem isolation
+  explicitly enabled;
+- on native Windows, leaves the unsupported sandbox unconfigured and enables Claude's PowerShell
+  tool through its documented settings environment switch;
+- disables Claude.ai connectors for every profile.
+
+On supported platforms, the strict settings prevent a shell command from silently falling back to an
+unsandboxed retry. Claude's sandbox covers **Bash and its child processes only**. Edit/Write remain
+Claude Code tools governed by its permission system; the Claude process, local hooks, inherited
+configuration, and unrelated host processes are not enclosed in a universal workspace sandbox.
+
+Claude merges some sandbox arrays across settings scopes. Existing managed, user, project, or local
+allowlists and `excludedCommands` can therefore affect the effective shell boundary, while managed
+policy can further restrict or reject the run. Existing `ask` and `deny` permission rules take
+precedence over sandbox auto-approval, so they can still stop a headless gate. Inspect both
+`profile.json` and the effective local Claude configuration when the precise boundary matters. Use a
+container or VM when only a host-level boundary is acceptable.
+
+### Read-only profile
+
+`--read-only` removes Edit, Write, Bash/PowerShell, Agent, MCP, skills, and commands from the child and
+uses `plan` mode. Local hooks still load outside that tool surface and can write. The relay compares
+parsed `git status --porcelain -z -uall` and fingerprints working-tree identity and index entries for
+paths that were already dirty on every outcome, including aborts:
+
+- `readOnlyViolation: true` — either signal proves a Git-visible change.
+- `readOnlyViolation: false` — coverage was complete and neither signal detected a change.
+- `readOnlyViolation: null` — coverage was incomplete, for example because git could not report or a
+  dirty submodule or unreadable path could not be fingerprinted.
+
+This detects new dirt and changes to readable, already-dirty Git-visible paths, but cannot attribute a
+concurrent change. Ignored paths, submodule internals, and writes perfectly restored before the final
+snapshot remain outside coverage. Inspect the diff whenever read-only integrity matters.
+
+### Permission bypass
+
+`--dangerously-skip-permissions` passes Claude's flag and records
+`permissionMode: "bypassPermissions"` unless the init event reports another value. The explicit tool
+surface, commit/push deny rules, MCP/skill restrictions, and supported-platform shell sandbox remain.
+However, direct file tools can cross ordinary Claude permission boundaries. This mode requires the
+human's explicit acceptance.
+
+## Artifacts
+
+The default artifact directory is outside the repository so relay output does not pollute
+`touchedFiles`. A caller-selected `--out-dir` inside the worktree will appear in git status. For a
+meaningful `--read-only` review, keep artifacts outside the worktree. The fingerprint signal excludes
+only the relay-owned artifact paths, so their later writes do not prove a violation.
+
+- `brief.txt` — exact stdin brief.
+- `events.jsonl` — raw stdout bytes from `--output-format stream-json`.
+- `final.txt` — final `result` event's `result` text; present even when empty.
+- `stderr.txt` — complete stderr.
+- `profile.json` — exact inline settings passed to Claude.
+- `result.json` — stable result contract, written atomically.
+
+## `result.json`
+
+Core fields:
+
+- `schema` — `"delegate-relay.result.v1"`.
+- `tool` — `"claude"`.
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `claude_unavailable`.
+- `exitCode` — Claude's code, `127` when missing, a signal-derived code when available, or a forced
+  non-zero value when the watchdog or terminal error result makes a zero code non-successful.
+- `signal` — terminating child/relay signal when reported, otherwise `null`.
+- `claudeVersion` — version preflight text, `"unknown"` when the binary answered abnormally, or `null`
+  when unavailable.
+- `permissionMode` — selected profile, updated from `system/init` when present.
+- `sessionId` — parsed defensively from init/result events; use with `--session`.
+- `resultSubtype` — final result subtype, such as `success` or an error subtype.
+- `finalMessage` — final result text.
+- `numTurns`, `usage`, `totalCostUsd` — terminal result metadata when present.
+- `touchedFiles` — final `git status --porcelain` lines for `--cd`; `null` means git could not report,
+  while `[]` means git reported a clean tree. This is the whole final tree, not attribution.
+- `readOnlyViolation` — present only on `--read-only`, with the three-state meaning above.
+
+Run metadata includes `workdir`, `model`, `effort`, `maxTurns`, `maxBudgetUsd`, `timeout`, `readOnly`,
+`resumed`, `resumeLast`, `toolSurface`, `shellSandbox`, `dangerouslySkipPermissions`, timestamps, and
+all artifact paths. Failed, timed-out, and aborted runs include `stderrTail` when available;
+launch/watchdog/signal failures include `error`.
+
+The relay prints a concise summary and the complete final report to stdout, then exits with
+`result.json`'s `exitCode`.
+
+## Wait for completion
+
+The relay blocks. Use the orchestrator's background-command facility or foreground it for short work.
+If using a shell's own background feature, completion requires both:
+
+1. the relay process has exited; and
+2. `result.json` contains a terminal `status`.
+
+A usage error exits 2 before creating `result.json`, so also observe process exit. A missing CLI is
+different: it exits 127 **with** `status: "claude_unavailable"`.
+
+## Failure recovery
+
+- **`claude_unavailable`:** install Claude Code, authenticate with `claude auth login`, and verify the
+  same PATH the orchestrator uses.
+- **`failed`:** inspect `resultSubtype`, `error`, `stderrTail`, `stderr.txt`, and the tail of
+  `events.jsonl`. Common causes are authentication, a model/effort mismatch, managed policy, a missing
+  sandbox dependency, or a gate that needs access outside the strict shell boundary.
+- **`timeout`:** the relay sent termination to the whole process group/tree and escalated. The working
+  tree may contain partial edits; inspect it before resuming or re-dispatching.
+- **`aborted`:** the relay caught SIGTERM, SIGINT, or SIGHUP, terminated the implementer tree, wrote an
+  outcome, then refreshed `touchedFiles` after a grace window. Native Windows cannot deliver every
+  termination as a catchable Node signal; a vanished relay with no result still requires direct
+  artifact/tree inspection.
+- **Host `SIGKILL`:** the relay cannot catch its own SIGKILL. If the child reports SIGKILL, investigate
+  host memory or supervisor deadlines.
+- **Empty `finalMessage`:** inspect the raw events and diff. Require a closing report in the next brief.
+
+Never clean, reset, or switch branches before inspecting partial work, staged changes, and untracked
+files.
+
+## Windows launch
+
+The relay resolves PATH itself. A native `claude.exe` is spawned directly. An npm `claude.cmd` is
+invoked through `cmd.exe /d /v:off /s /c` with every argument quoted and user-selectable values
+restricted; stdin still carries the brief. `taskkill /t /f` terminates the process tree.
+
+This path is implemented but not yet verified on native Windows. Claude's Bash sandbox is unsupported
+there, so even a successful Windows smoke would verify launch and termination mechanics, not provide
+the supported-platform shell boundary.
+
+## Commit boundary
+
+The relay never commits. Claude edits; the orchestrator reviews, re-runs gates, and lands. See
+[review-and-land.md](review-and-land.md).

--- a/skills/claude-delegate/references/multi-task-queues.md
+++ b/skills/claude-delegate/references/multi-task-queues.md
@@ -1,0 +1,66 @@
+# Multi-task queues
+
+The single-task loop scales to a migration, removal, or refactor queue. Sequencing and bookkeeping,
+not parallelism, keep the work reviewable.
+
+## Run sequentially
+
+Dispatch one task at a time in dependency order. Review, run gates, and land it before dispatching the
+next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later tasks can rely on earlier behavior only after it lands.
+- One reviewed commit per task keeps rollback and history clear.
+- A clean tree before each dispatch makes `touchedFiles` useful.
+
+Use parallel dispatches only for genuinely independent tasks in separate working trees. Multiple
+implementers editing one tree destroy attribution and make the review boundary unreliable.
+
+## Use fresh sessions for fresh tasks
+
+Each unrelated queue item should start a new Claude session. Use `--resume-last` or `--session <id>`
+only for rework on the same task; send a delta brief.
+
+A fresh session does not remember prior queue decisions. If task 2 chose a helper name, fixture
+location, interface, or migration ordering that task 5 needs, write that fact explicitly into task
+5's brief.
+
+Claude Code will discover `CLAUDE.md`, but it does not generically auto-load `AGENTS.md`. Carry the
+applicable `AGENTS.md` constraints into every brief rather than assuming the first session established
+them for later sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one durable progress file:
+
+- **Status:** queued / dispatched / reviewed+landed, including the commit hash.
+- **Per-task review:** what landed, what was inspected, and gate outcomes.
+- **Needs your eyes:** design decisions, non-blocking concerns, and questions for the human.
+- **Session/artifact pointers:** the task's `sessionId` and `result.json` path for rework or diagnosis.
+- **End-of-run gates:** the final cross-task verification still required.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with coherence
+
+After the last task:
+
+- run the full project gates, not only the last task's narrow slice;
+- search repository-wide for the concept the queue migrated, removed, or renamed;
+- replay all new migrations from a clean state and check drift when applicable;
+- inspect the final commit sequence and working tree;
+- only then push and open or update the pull request.
+
+## Stop and ask when
+
+Proceed on work that follows from the agreed queue. Stop and surface when:
+
+- a task cannot be completed correctly within its brief;
+- review calls the plan itself into question;
+- a gate reveals a problem in an already-landed task;
+- the next task requires a permission or host-boundary change the human did not approve.
+
+Report what has landed, commit hashes, the current tree state, and the open question, then wait.

--- a/skills/claude-delegate/references/review-and-land.md
+++ b/skills/claude-delegate/references/review-and-land.md
@@ -1,0 +1,117 @@
+# Review and land
+
+The separate Claude session did the typing; the orchestrator owns the judgment. Verify against the
+working tree and gate output, never against the implementer's self-report.
+
+## Review tests before trusting gates
+
+If existing tests changed, inspect those edits first:
+
+- An unbriefed test edit is a contract change, not automatically part of the fix.
+- Treat a new skip, disable marker, commented-out case, or deleted test as a failure until justified.
+- Reject assertions weakened from exact behavior to contains/truthy, broader error types, or wider
+  tolerances unless the brief required that semantic change.
+
+A green gate proves less if the implementer shortened the yardstick.
+
+## Re-run the gates
+
+`finalMessage` reports Claude's claims. Run the project's actual test, lint, format, type, and build
+commands yourself in the final working tree and read their output. Passing is necessary, not
+sufficient.
+
+Add verification suited to the change:
+
+- **Migrations/schema:** apply, reverse, and re-apply from a clean scratch state; check drift.
+- **Removals/renames:** search repository-wide for dangling names and stale docs/config.
+- **Stateful behavior:** exercise the behavior, not only compilation.
+- **Generated output:** regenerate it through the canonical command and compare.
+
+## Inspect the complete tree
+
+Start with `touchedFiles`, but remember it is final git porcelain, not attribution. It includes
+pre-existing dirt and can omit modifications inside ignored files. Inspect:
+
+```bash
+git status --short
+git diff
+git diff --cached
+```
+
+Open every untracked file directly; ordinary `git diff` does not show its contents. Review staged
+changes even though the relay denies common direct `git commit`/`git push` shell forms and the brief
+forbids staging. A local hook, another tool, or an unusual command path may still have touched the
+index.
+
+For `--read-only`, treat `readOnlyViolation: true` as a hard warning and `null` as unknown. `false`
+means the Git-visible tripwire had complete coverage and detected no change. Ignored paths, submodule
+internals, perfect restores, and attribution remain outside its contract. Compare the actual diff when
+read-only integrity matters.
+
+## Hold the diff against the brief
+
+- **Scope creep:** files or behavior the brief excluded, unrelated cleanup, opportunistic renames.
+- **Scope shortfall:** missing edge cases, integration updates, cleanup, or required gates.
+- **Quiet judgment calls:** defensible choices not authorized by the brief. Understand and surface
+  them rather than silently accepting them.
+- **Repository constraints:** especially constraints copied from `AGENTS.md`, which Claude Code does
+  not generically auto-load.
+
+## Implementer sweep
+
+Generated code can satisfy tests while remaining wrong. Check every diff for:
+
+- hardcoded success, fixture values, or fake fallbacks on real-work paths;
+- broad catches that suppress failures and return defaults;
+- APIs, methods, flags, and dependencies absent from the installed versions;
+- unused imports, uncalled helpers, unreachable branches, and scaffolding comments;
+- a second HTTP client, error idiom, state mechanism, or logging style beside the existing one;
+- tests that assert implementation details or mock the project's own behavior;
+- near-duplicate tests that inflate volume without adding behavior coverage;
+- optional parameters, configuration, or abstractions with no caller;
+- guards for impossible internal states that obscure real trust-boundary validation;
+- network or filesystem assumptions hidden by the implementer's environment.
+
+Run relevant guard skills when installed. Anything blocking goes back through a delta brief or is
+fixed in the tree, and either choice is reported to the human.
+
+## Preserve interrupted work
+
+From dispatch until a reviewed commit, the uncommitted tree is the authoritative copy. Do not
+reflexively run `git checkout`, `git reset`, `git clean`, or switch branches after a timeout, abort, or
+failed result. First inspect status, unstaged and staged diffs, untracked files, `events.jsonl`, and
+`stderr.txt`. After inspection, discarding premise-invalid work can be the correct decision.
+
+## Rework in the same session
+
+Send only the review delta:
+
+```bash
+echo "The runtime fix is correct. Replace the mocked database test with the existing migrated fixture,
+remove the unused import, rerun the original gates, and leave the tree uncommitted." |
+  node "<skill-dir>/scripts/relay.mjs" --session <id> --cd /path/to/repo
+```
+
+Use `--resume-last` only when the latest session for that cwd is unambiguous. `--session <id>` is safer
+when several Claude sessions exist. The relay maps them to `--continue` and `--resume`, respectively,
+and re-passes the permission profile.
+
+Rework gets the same test review, gate rerun, diff review, and implementer sweep. Repeat until the work
+holds.
+
+## Commit boundary
+
+When the gates pass and the diff satisfies the brief, **the orchestrator commits**, never the
+implementer. Write a clear message describing what landed.
+
+## Surface, do not absorb
+
+The human opted into delegation, so landing verified work is the contract. Keep them informed when
+the work changes shape:
+
+- report design decisions and defensible-but-unrequested turns;
+- note non-blocking concerns you chose not to block on;
+- stop and ask when correct completion requires expanding the brief.
+
+For a queue, record these in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/claude-delegate/references/writing-the-brief.md
+++ b/skills/claude-delegate/references/writing-the-brief.md
@@ -1,0 +1,158 @@
+# Writing the brief
+
+A brief carries the task-specific context from the orchestrator to the separate Claude Code session.
+The implementer has **no orchestrator chat history or other shared context**. It receives the brief on
+stdin, can inspect the target working tree, and loads Claude Code's usual local context as described
+below. A resumed session also retains its own Claude conversation.
+
+If a fact is not in the brief, discoverable in that tree, or present in the loaded Claude context, do
+not assume the implementer knows it.
+
+## Know what Claude loads
+
+The relay deliberately does not use `--bare`, so Claude Code discovers the project's `CLAUDE.md`,
+normal local Claude settings, and session state in its usual way. The relay overrides a small,
+inspectable subset for the child: MCP servers are not discovered, skills and commands are disabled,
+and the built-in tool surface is restricted. Local hooks still load; account for any repository
+effects they are configured to perform.
+
+Claude Code does **not** generically auto-load `AGENTS.md`. Before writing the brief:
+
+1. Read the applicable `AGENTS.md` files yourself.
+2. Copy every load-bearing rule into the brief: scope boundaries, forbidden patterns, required
+   commands, generated-file policy, and commit policy.
+3. Name the real gates rather than telling Claude to "run the tests."
+
+The implementer can read an `AGENTS.md` when the brief points to it, but that is explicit task context,
+not automatic Claude Code behavior.
+
+## A compact structure
+
+Use a bounded, block-structured brief:
+
+```xml
+<task>
+State the concrete job, current behavior, desired behavior, and where it lives. Name what must remain
+untouched. Include any facts from the orchestrator conversation that the implementer cannot discover
+from the tree.
+</task>
+
+<repo_constraints>
+Copy the applicable load-bearing constraints from AGENTS.md and other project instructions here.
+Claude also loads CLAUDE.md, but restate rules whose violation would invalidate the work.
+</repo_constraints>
+
+<verification_loop>
+Run these exact project gates, fix failures caused by the change, and report the final outcomes:
+  <actual test command>
+  <actual lint/format command>
+  <actual build/typecheck command>
+Confirm the working tree contains only intended changes.
+</verification_loop>
+
+<action_safety>
+Keep changes within the task. Do not perform unrelated cleanup. Do not run git add, git commit, or git
+push. Do not invoke another Claude session or delegation skill. Leave all work uncommitted for the
+orchestrator to review and land.
+</action_safety>
+
+<structured_output_contract>
+End with:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes, including useful counts
+  4. Deviations, open questions, and decisions the orchestrator should review
+</structured_output_contract>
+```
+
+Remove empty blocks rather than adding ceremony. Add focused blocks when needed:
+
+- **Debugging:** `<completeness_contract>` to require a full root-cause fix, and
+  `<missing_context_gating>` to prohibit guesses about missing repository facts.
+- **Read-only diagnosis:** `<grounding_rules>` to require file/line or command evidence and clearly
+  label inference. Dispatch with `--read-only`.
+- **Migration or removal:** an explicit repository-wide search and round-trip requirement.
+
+## Discover the real gates
+
+Read the repository's `CLAUDE.md`, `AGENTS.md`, `Makefile`, package scripts, and language tooling before
+dispatch. Copy exact commands into `<verification_loop>`. Include required setup and the narrowest
+useful test slice, but do not replace a required full gate with a guessed shortcut.
+
+`acceptEdits` alone does not approve ordinary gate commands in non-interactive mode. On supported
+platforms the normal relay profile auto-approves commands that stay inside Claude's shell sandbox and
+requests failure when that sandbox is unavailable. A gate that needs network access, host services,
+or writes outside the working tree may fail under that profile; state the need in the brief and decide
+whether a different isolated environment is appropriate instead of silently weakening the boundary.
+Merged local or managed settings can affect the effective sandbox. Native Windows pre-approves
+PowerShell without that sandbox; see [dispatch-and-poll.md](dispatch-and-poll.md).
+
+## One task per brief
+
+One brief → one separate Claude session → one reviewed commit keeps scope and rollback clear. Split a
+mixed request such as "fix the bug, redesign the API, update unrelated docs, and propose a roadmap"
+into separate dispatches.
+
+Use a resumed session only for rework on the same task. Start unrelated queue items in fresh sessions.
+
+## Premises freeze at dispatch
+
+There is no steering channel while the relay is running. Audit ownership, scope, branch, constraints,
+and expected behavior before dispatch. If a premise changes during the run, stop it and inspect the
+working tree before sending a corrected brief. Do not discard partial edits before reviewing them.
+
+## Delta briefs for resumed sessions
+
+`--resume-last` maps to Claude's `--continue`; `--session <id>` maps to `--resume <id>`. Both retain the
+conversation, so send only what changed:
+
+```xml
+<review_delta>
+The implementation behavior is correct. Replace the test's mocked database session with the existing
+migrated fixture, remove the unused import, run the same gates, and leave the tree uncommitted.
+</review_delta>
+```
+
+The relay re-passes the selected permission profile on resume. A resumed run receives the same review
+as a fresh run.
+
+## Brief delivery
+
+The relay reads `--brief <file>` or stdin, saves the exact text as `brief.txt`, and sends it to
+`claude -p` through stdin — never as an argv value. It therefore stays out of the process list and
+needs no shell quoting. Claude Code caps piped stdin at 10 MB; the relay rejects a larger brief before
+dispatch. Put large context in workspace files and reference those paths instead.
+
+## Worked example
+
+```xml
+<task>
+In services/billing/, refund retries can create a second refund because the idempotency key is checked
+after submission. Check for an existing refund before creating one. Touch only refund handling and
+its behavior-level tests. Leave charge creation, routes, and data models unchanged.
+</task>
+
+<repo_constraints>
+Follow the repository's Python style and test conventions copied from AGENTS.md. Do not add ticket
+identifiers to source comments. Do not add dependencies.
+</repo_constraints>
+
+<verification_loop>
+Run and make green:
+  pytest tests/billing/ -q
+  ruff check services/billing/ tests/billing/
+Confirm git status contains only the intended refund implementation and tests.
+</verification_loop>
+
+<action_safety>
+No unrelated refactors. Do not git add, commit, or push; leave the work uncommitted.
+</action_safety>
+
+<structured_output_contract>
+Report the root cause and fix, files touched, pytest and ruff outcomes with counts, and anything left
+open or needing a decision.
+</structured_output_contract>
+```
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and land with
+[review-and-land.md](review-and-land.md).

--- a/skills/claude-delegate/scripts/relay.mjs
+++ b/skills/claude-delegate/scripts/relay.mjs
@@ -1,0 +1,1269 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · claude-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to a separate Claude Code CLI process
+ * (`claude -p`), capture the structured stream, and write a stable result the
+ * orchestrator can review.
+ *
+ * Trust posture: this relay makes no network calls of its own, reads or writes
+ * no credentials, sends no telemetry, and has no dependencies (Node built-ins
+ * only). It launches `claude` and uses `git status --porcelain`; on Windows it
+ * may also use cmd.exe for an npm .cmd shim and taskkill to terminate a process
+ * tree. Claude authenticates and makes its own network calls exactly as it does
+ * at the terminal.
+ *
+ * The relay never commits. Its write-capable profiles use string rules to deny
+ * common direct forms of `git commit`, `git push`, and nested `claude`, plus
+ * any command containing `claude-delegate`. Aliases, scripts, and wrappers can
+ * bypass those speed bumps; the brief's no-commit instruction and orchestrator
+ * review remain the boundary. The orchestrator re-runs the project gates and
+ * lands the work.
+ *
+ * Normal runs use Claude's `acceptEdits` permission mode with an explicit tool
+ * surface (Read, Glob, Grep, Edit, Write, and the platform shell). On macOS,
+ * Linux, and WSL2, an inline settings file requires Claude's shell sandbox,
+ * disables its unsandboxed escape hatch, and auto-approves commands that stay
+ * sandboxed so non-interactive gates can run. That sandbox covers shell
+ * processes and their children only; merged local or managed settings can
+ * affect its effective boundary, and it is not a universal boundary around
+ * Claude Code. Native Windows has no Claude shell sandbox, so the relay
+ * pre-approves PowerShell there and documents that it is not OS-isolated.
+ *
+ * `--read-only` uses plan mode and exposes only Read, Glob, and Grep: no edit,
+ * write, shell, MCP, skill, command, or Agent tool. The relay also compares git
+ * porcelain before and after, and also fingerprints working-tree and index state for paths
+ * that were already dirty, and emits `readOnlyViolation`. This is a tripwire,
+ * not an OS boundary: it reports detected Git-visible changes, it does not prevent them. It is
+ * three-valued - `null` means coverage was incomplete (git unavailable, a
+ * submodule, an unreadable path), never "nothing happened". Git-ignored paths
+ * are outside it.
+ *
+ * Every profile disables configured MCP discovery and Claude.ai connectors,
+ * denies all MCP tools, and disables skills and commands for the child while
+ * preserving normal authentication, CLAUDE.md discovery, hooks, and the rest of
+ * the inherited environment. Hooks are outside the tool restriction and can
+ * mutate a read-only run; readOnlyViolation is the tripwire. When nested under
+ * Claude Code, the child environment removes only CLAUDECODE;
+ * CLAUDE_CODE_CHILD_SESSION and credential variables are preserved. The same
+ * environment is used for version preflight.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>                    Brief path. Omit to read the brief from stdin.
+ *   --cd <dir>                        Child cwd (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --out-dir <dir>                   Artifact directory (default: system temp).
+ *   --timeout <dur>                   Relay watchdog; off by default. Use h/m/s,
+ *                                     such as 30m, 90s, or 1h30m.
+ *   --model <name>                    Claude model alias or full name.
+ *   --effort <level>                  low | medium | high | xhigh | max | ultracode
+ *   --max-turns <n>                   Positive agentic-turn limit.
+ *   --max-budget-usd <amount>         Positive decimal spend limit.
+ *   --resume-last                     Map to Claude's --continue.
+ *   --session <id>                    Map to Claude's --resume <id>.
+ *                                     Mutually exclusive with --resume-last.
+ *   --read-only                       Plan mode with Read, Glob, and Grep only.
+ *   --dangerously-skip-permissions    Opt into Claude's bypassPermissions mode.
+ *                                     Mutually exclusive with --read-only.
+ *   -h, --help                        Show this help.
+ *
+ * Claude is always launched with:
+ *   -p --output-format stream-json --verbose
+ * The brief is sent through stdin, never argv. `--bg` and `--bare` are not used.
+ *
+ * Artifacts:
+ *   brief.txt       exact brief sent on stdin
+ *   events.jsonl    raw Claude stdout stream
+ *   final.txt       final result event's text
+ *   stderr.txt      complete Claude stderr
+ *   profile.json    inspectable per-run settings passed with --settings
+ *   result.json     delegate-relay.result.v1
+ *
+ * Exit codes: usage errors exit 2 before result.json; a missing `claude` exits
+ * 127 with status "claude_unavailable"; otherwise the exit mirrors Claude, with
+ * a forced non-zero code for timeout or a terminal error result. Once the brief
+ * and artifact directory validate, result.json is written for completed,
+ * failed, timeout, aborted, and claude_unavailable outcomes.
+ *
+ * Native Windows launch behavior supports a directly spawned claude.exe and an
+ * npm claude.cmd shim through cmd.exe with strictly serialized arguments. It
+ * remains pending native-Windows verification.
+ */
+
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  accessSync,
+  appendFileSync,
+  constants as fsConstants,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+  lstatSync,
+  readlinkSync,
+  openSync,
+  readSync,
+  closeSync,
+  realpathSync,
+} from "node:fs";
+import {basename, delimiter, join, relative, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants as osConstants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+import { TextDecoder } from "node:util";
+
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const SCHEMA = "delegate-relay.result.v1";
+const MAX_BRIEF_BYTES = 10_000_000;
+const MAX_TIMER_MS = 2_147_483_647;
+const EFFORT_LEVELS = new Set(["low", "medium", "high", "xhigh", "max", "ultracode"]);
+const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:@\/\[\]-]*$/;
+const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+
+const IMPLEMENTER_KEY = "claude";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (
+      field === "readOnly" &&
+      (flagged.has("readOnly") || flagged.has("dangerouslySkipPermissions"))
+    ) {
+      continue;
+    }
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    outDir: null,
+    timeout: null,
+    model: null,
+    effort: null,
+    maxTurns: null,
+    maxBudgetUsd: null,
+    resumeLast: false,
+    session: null,
+    readOnly: false,
+    dangerouslySkipPermissions: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--effort": opts.effort = next(); flagged.add("effort"); break;
+      case "--max-turns": opts.maxTurns = next(); break;
+      case "--max-budget-usd": opts.maxBudgetUsd = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--dangerously-skip-permissions":
+        opts.dangerouslySkipPermissions = true;
+        flagged.add("dangerouslySkipPermissions");
+        break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  if (opts.readOnly && opts.dangerouslySkipPermissions) {
+    fail("--read-only and --dangerously-skip-permissions are mutually exclusive");
+  }
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  if (opts.model !== null && !SAFE_MODEL.test(opts.model)) {
+    fail("--model contains unsupported characters (allowed: letters, digits, . _ : @ / [ ] -)");
+  }
+  if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
+    fail("--session contains unsupported characters (allowed: letters, digits, . _ : -)");
+  }
+  if (opts.effort !== null && !EFFORT_LEVELS.has(opts.effort)) {
+    fail(`invalid --effort "${opts.effort}" (expected: ${[...EFFORT_LEVELS].join(", ")})`);
+  }
+  if (opts.maxTurns !== null) {
+    const turns = Number(opts.maxTurns);
+    if (!/^[1-9]\d*$/.test(opts.maxTurns) || !Number.isSafeInteger(turns)) {
+      fail("--max-turns must be a positive safe integer");
+    }
+  }
+  if (opts.maxBudgetUsd !== null) {
+    const budget = Number(opts.maxBudgetUsd);
+    if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(opts.maxBudgetUsd) || !Number.isFinite(budget) || budget <= 0) {
+      fail("--max-budget-usd must be a positive decimal number");
+    }
+  }
+  try {
+    if (!statSync(opts.cd).isDirectory()) fail(`--cd is not a directory: ${opts.cd}`);
+  } catch {
+    fail(`--cd directory not found: ${opts.cd}`);
+  }
+  if (opts.outDir && existsSync(opts.outDir)) {
+    try {
+      if (!statSync(opts.outDir).isDirectory()) fail(`--out-dir is not a directory: ${opts.outDir}`);
+    } catch {
+      fail(`cannot inspect --out-dir: ${opts.outDir}`);
+    }
+  }
+  return opts;
+}
+
+function headerComment() {
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to a separate claude -p session\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    try {
+      return readFileSync(opts.brief, "utf8");
+    } catch (error) {
+      fail(`cannot read brief file: ${error && error.message ? error.message : String(error)}`);
+    }
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function childEnvironment() {
+  const env = { ...process.env };
+  if (process.platform === "win32") {
+    for (const key of Object.keys(env)) {
+      if (key.toUpperCase() === "CLAUDECODE") delete env[key];
+    }
+  } else {
+    delete env.CLAUDECODE;
+  }
+  return env;
+}
+
+function environmentValue(env, name) {
+  if (Object.prototype.hasOwnProperty.call(env, name)) return env[name];
+  if (process.platform !== "win32") return undefined;
+  const key = Object.keys(env).find((candidate) => candidate.toUpperCase() === name);
+  return key ? env[key] : undefined;
+}
+
+function resolveClaudeLauncher(env, cwd) {
+  const pathValue = environmentValue(env, "PATH");
+  if (!pathValue) return null;
+  const pathEntries = pathValue.split(delimiter).map((entry) => entry.replace(/^"(.*)"$/, "$1"));
+
+  if (process.platform === "win32") {
+    const pathExt = (environmentValue(env, "PATHEXT") || ".COM;.EXE;.BAT;.CMD")
+      .split(";")
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean);
+    for (const entry of pathEntries) {
+      const directory = resolve(cwd, entry || ".");
+      for (const extension of pathExt) {
+        const candidate = join(directory, `claude${extension}`);
+        try {
+          if (!statSync(candidate).isFile()) continue;
+          const kind = extension === ".cmd" || extension === ".bat" ? "cmd" : "direct";
+          return { path: candidate, kind };
+        } catch {
+          // Keep searching PATH.
+        }
+      }
+    }
+    return null;
+  }
+
+  for (const entry of pathEntries) {
+    const candidate = join(resolve(cwd, entry || "."), "claude");
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      if (statSync(candidate).isFile()) return { path: candidate, kind: "direct" };
+    } catch {
+      // Keep searching PATH.
+    }
+  }
+  return null;
+}
+
+function quoteCmdArgument(value) {
+  // cmd expands %VAR% even inside quotes, and embedded quotes/newlines can break
+  // the /c command boundary. Reject those rare path characters instead of
+  // pretending an npm .cmd launch is safe. All user-selectable token values are
+  // independently restricted by parseArgs.
+  if (/[\0\r\n"%!]/.test(value)) {
+    throw new Error("the npm claude.cmd launch cannot safely serialize an argument containing %, !, a quote, or a newline; use the native claude.exe or a safe artifact path");
+  }
+  return `"${value}"`;
+}
+
+function launchSpec(launcher, argv, env) {
+  if (launcher.kind === "direct") {
+    return { command: launcher.path, argv, windowsVerbatimArguments: false };
+  }
+  const commandLine = [launcher.path, ...argv].map(quoteCmdArgument).join(" ");
+  const commandProcessor = environmentValue(env, "COMSPEC") || "cmd.exe";
+  return {
+    command: commandProcessor,
+    argv: ["/d", "/v:off", "/s", "/c", `"${commandLine}"`],
+    // The final argv element is an intentionally serialized cmd /c program.
+    // Letting libuv quote it again would change cmd's nested-quote boundary.
+    windowsVerbatimArguments: true,
+  };
+}
+
+function preflightVersion(launcher, env, cwd) {
+  try {
+    const spec = launchSpec(launcher, ["--version"], env);
+    const probe = spawnSync(spec.command, spec.argv, {
+      cwd,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 15_000,
+      windowsHide: true,
+      windowsVerbatimArguments: spec.windowsVerbatimArguments,
+    });
+    if (probe.error && probe.error.code === "ENOENT") return null;
+    if (probe.status !== 0) return "unknown";
+    return String(probe.stdout || "").trim() || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function shellTool() {
+  return process.platform === "win32" ? "PowerShell" : "Bash";
+}
+
+function selectedPermissionMode(opts) {
+  if (opts.readOnly) return "plan";
+  if (opts.dangerouslySkipPermissions) return "bypassPermissions";
+  return "acceptEdits";
+}
+
+function toolSurface(opts) {
+  if (opts.readOnly) return "Read,Glob,Grep";
+  return `Read,Glob,Grep,Edit,Write,${shellTool()}`;
+}
+
+function profileSettings(opts) {
+  const shell = shellTool();
+  const shellSandboxEnabled = !opts.readOnly && process.platform !== "win32";
+  return {
+    disableClaudeAiConnectors: true,
+    ...(process.platform === "win32"
+      ? { env: { CLAUDE_CODE_USE_POWERSHELL_TOOL: "1" } }
+      : {}),
+    permissions: {
+      deny: opts.readOnly
+        ? []
+        : [
+            // Two-wildcard git forms require text after the subcommand, so the
+            // single-wildcard forms also catch `git -C <dir> push`; they also
+            // deny reads like `git log --grep push`. Anchor `claude` at command
+            // position so reads mentioning it remain allowed. Keep
+            // `claude-delegate` as a substring rule to stop recursive relay
+            // invocation; any command containing it is denied.
+            `${shell}(git commit *)`,
+            `${shell}(git * commit *)`,
+            `${shell}(git * commit)`,
+            `${shell}(git push *)`,
+            `${shell}(git * push *)`,
+            `${shell}(git * push)`,
+            `${shell}(claude *)`,
+            `${shell}(*claude-delegate*)`,
+          ],
+    },
+    ...(shellSandboxEnabled
+      ? {
+          sandbox: {
+            enabled: true,
+            failIfUnavailable: true,
+            autoAllowBashIfSandboxed: true,
+            allowUnsandboxedCommands: false,
+            excludedCommands: [],
+            filesystem: {
+              disabled: false,
+            },
+          },
+        }
+      : {}),
+  };
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function prepareRun(opts, brief) {
+  const outDir =
+    opts.outDir ||
+    join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}-${process.pid}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt: new Date().toISOString(),
+    outDir,
+    briefPath: join(outDir, "brief.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    finalPath: join(outDir, "final.txt"),
+    stderrPath: join(outDir, "stderr.txt"),
+    settingsPath: join(outDir, "profile.json"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.finalPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  writeFileSync(run.settingsPath, `${JSON.stringify(profileSettings(opts), null, 2)}\n`, "utf8");
+  return run;
+}
+
+function buildArgv(opts, run) {
+  const argv = [
+    "-p",
+    "--output-format", "stream-json",
+    "--verbose",
+    "--tools", toolSurface(opts),
+    "--strict-mcp-config",
+    "--disallowedTools", "mcp__*",
+    "--disable-slash-commands",
+    "--settings", run.settingsPath,
+  ];
+
+  if (opts.readOnly) {
+    argv.push("--permission-mode", "plan");
+  } else if (opts.dangerouslySkipPermissions) {
+    argv.push("--dangerously-skip-permissions");
+  } else {
+    argv.push("--permission-mode", "acceptEdits");
+    // Supported platforms auto-approve only commands that remain inside
+    // Claude's sandbox. Native Windows has no shell sandbox, so approving its
+    // selected shell is the explicit tradeoff that keeps print mode headless.
+    if (process.platform === "win32") argv.push("--allowedTools", "PowerShell");
+  }
+
+  // The selected permission profile is passed on every invocation, including
+  // --continue/--resume, rather than assuming a session remembers it.
+  if (opts.resumeLast) argv.push("--continue");
+  else if (opts.session) argv.push("--resume", opts.session);
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.effort) argv.push("--effort", opts.effort);
+  if (opts.maxTurns) argv.push("--max-turns", opts.maxTurns);
+  if (opts.maxBudgetUsd) argv.push("--max-budget-usd", opts.maxBudgetUsd);
+  return argv;
+}
+
+function eventSessionId(event) {
+  return (
+    event.session_id ??
+    event.sessionId ??
+    (event.session && (event.session.id ?? event.session.session_id)) ??
+    null
+  );
+}
+
+function handleEvent(event, state, run) {
+  if (!event || typeof event !== "object") return;
+  const sessionId = eventSessionId(event);
+  if (typeof sessionId === "string" && sessionId) state.sessionId = sessionId;
+
+  if (event.type === "system" && event.subtype === "init") {
+    const mode = event.permissionMode ?? event.permission_mode;
+    if (typeof mode === "string" && mode) state.permissionMode = mode;
+  }
+
+  if (event.type !== "result") return;
+  state.sawResult = true;
+  state.resultSubtype = typeof event.subtype === "string" ? event.subtype : null;
+  state.resultIsError =
+    event.is_error === true ||
+    (state.resultSubtype !== null && /^error(?:_|$)/i.test(state.resultSubtype));
+  state.finalMessage = typeof event.result === "string" ? event.result : "";
+  state.usage = event.usage && typeof event.usage === "object" ? event.usage : null;
+
+  const cost = event.total_cost_usd ?? event.cost_usd;
+  state.totalCostUsd = typeof cost === "number" && Number.isFinite(cost) ? cost : null;
+  const turns = event.num_turns ?? event.numTurns;
+  state.numTurns = typeof turns === "number" && Number.isFinite(turns) ? turns : null;
+  writeFileSync(run.finalPath, state.finalMessage, "utf8");
+}
+
+// Porcelain status alone cannot see every write. A path that is " M file" before a run and
+// " M file" after it produces an identical line, so comparing status lines proves nothing about
+// its contents — which is why the read-only tripwire below fingerprints the already-dirty paths
+// as well. Two sentinels stand for "could not fingerprint"; they are never treated as unchanged.
+const FINGERPRINT_UNREADABLE = "<unreadable>";
+const FINGERPRINT_DIRECTORY = "<directory>";
+
+function gitRepoRoot(cwd) {
+  // Porcelain paths are relative to the repository ROOT, not to the directory git ran in
+  // (--porcelain forces status.relativePaths off). Joining them against a --cd that is a
+  // subdirectory would look for <repo>/src/src/file and find nothing at either end.
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).replace(/\n$/, "") || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitStatusEntries(cwd) {
+  // -z so a path containing a space, a quote, or a newline stays one field rather than being
+  // quoted and escaped; -uall so an untracked directory is expanded into its files, because a
+  // collapsed "?? dir/" line never changes when a file inside it does.
+  try {
+    const output = execFileSync("git", ["status", "--porcelain", "-z", "-uall"], {
+      cwd,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const fields = new TextDecoder("utf-8", { fatal: true }).decode(output)
+      .split("\0").filter((field) => field.length > 0);
+    const entries = [];
+    for (let i = 0; i < fields.length; i += 1) {
+      const entry = fields[i];
+      const status = entry.slice(0, 2);
+      const path = entry.slice(3);
+      // R and C can sit in EITHER status column, and under -z such an entry is followed by its
+      // origin path as its own unprefixed field. Consume that field in both cases. A rename
+      // origin belongs in the dirty set (the file moved away from it); a copy origin does not,
+      // since a copy source can be a perfectly clean file.
+      const renamed = status.includes("R");
+      const copied = status.includes("C");
+      let origin = null;
+      if (renamed || copied) {
+        i += 1;
+        origin = fields[i] ?? null;
+      }
+      entries.push({ status, path, origin });
+    }
+    return entries;
+  } catch {
+    return null;
+  }
+}
+
+function dirtyPaths(cwd) {
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const paths = [];
+  for (const entry of entries) {
+    paths.push(entry.path);
+    if (entry.status.includes("R") && entry.origin !== null) paths.push(entry.origin);
+  }
+  return paths;
+}
+
+function asciiFold(value) {
+  return value.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+}
+
+function canonicalFilePath(path) {
+  const absolute = resolve(path);
+  let parent;
+  try { parent = realpathSync.native(dirname(absolute)); } catch { return absolute; }
+  const leaf = basename(absolute);
+  const canonical = join(parent, leaf);
+  try { lstatSync(canonical); } catch { return canonical; }
+  try {
+    const entries = readdirSync(parent);
+    if (entries.includes(leaf)) return canonical;
+    const matches = entries.filter((entry) => asciiFold(entry) === asciiFold(leaf));
+    return join(parent, matches.length === 1 ? matches[0] : leaf);
+  } catch {
+    return canonical;
+  }
+}
+
+function gitPathKey(root, path) {
+  let canonicalRoot;
+  try { canonicalRoot = realpathSync.native(root); } catch { canonicalRoot = resolve(root); }
+  const key = relative(canonicalRoot, canonicalFilePath(path));
+  return process.platform === "win32" ? key.replaceAll("\\", "/") : key;
+}
+
+function gitPathIsExcluded(root, path, excluded, foldedExcluded) {
+  return excluded.has(path) ||
+    (foldedExcluded.has(asciiFold(path)) && excluded.has(gitPathKey(root, join(root, path))));
+}
+
+function gitTripwireState(cwd, excludedPaths) {
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return entries.flatMap((entry) => [
+    [entry.status, "path", entry.path],
+    ...(entry.origin === null ? [] : [[entry.status.replace(/[^RC]/g, " "), "origin", entry.origin]]),
+  ]
+    .filter(([, , path]) => !gitPathIsExcluded(root, path, excluded, foldedExcluded)));
+}
+
+function pathFingerprint(absolutePath) {
+  // Identity, not just bytes: a retargeted symlink, a flipped mode bit, or a file replaced by a
+  // directory are all writes, and none of them change file contents.
+  let stats;
+  try {
+    stats = lstatSync(absolutePath);
+  } catch (error) {
+    // Absence is a state, not a failure - it differs from every real fingerprint, so a deletion
+    // or a re-creation still registers. Any other errno means we genuinely cannot tell.
+    return error && error.code === "ENOENT" ? "absent" : FINGERPRINT_UNREADABLE;
+  }
+  if (stats.isSymbolicLink()) {
+    try {
+      return `symlink:${readlinkSync(absolutePath, { encoding: "buffer" }).toString("hex")}`;
+    } catch {
+      return FINGERPRINT_UNREADABLE;
+    }
+  }
+  // A directory in the dirty set is a submodule, whose contents belong to another repository.
+  // Reported as unknown coverage rather than silently passed off as unchanged.
+  if (stats.isDirectory()) return FINGERPRINT_DIRECTORY;
+  if (!stats.isFile()) return FINGERPRINT_UNREADABLE;
+  let fd;
+  try {
+    // Streamed rather than read whole: an unignored multi-gigabyte artifact must not be pulled
+    // into memory just to answer whether it changed.
+    const hash = createHash("sha256");
+    fd = openSync(absolutePath, "r");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    for (;;) {
+      const read = readSync(fd, buffer, 0, buffer.length, null);
+      if (read <= 0) break;
+      hash.update(buffer.subarray(0, read));
+    }
+    return `file:${(stats.mode & 0o7777).toString(8)}:${hash.digest("hex")}`;
+  } catch {
+    return FINGERPRINT_UNREADABLE;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* already closed */ }
+    }
+  }
+}
+
+function gitIndexFingerprints(root, paths) {
+  if (paths.length === 0) return new Map();
+  try {
+    const output = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const wanted = new Set(paths);
+    const prints = new Map(paths.map((path) => [path, []]));
+    for (const field of new TextDecoder("utf-8", { fatal: true }).decode(output).split("\0")) {
+      if (!field) continue;
+      const separator = field.indexOf("\t");
+      if (separator === -1) return null;
+      const path = field.slice(separator + 1);
+      if (wanted.has(path)) prints.get(path).push(field.slice(0, separator));
+    }
+    return prints;
+  } catch {
+    return null;
+  }
+}
+
+function fingerprintPaths(root, paths) {
+  // `complete` goes false the moment one path cannot be fingerprinted, so the caller reports
+  // "unknown" instead of an unearned clean bill of health.
+  const indexPrints = gitIndexFingerprints(root, paths);
+  const prints = new Map();
+  let complete = indexPrints !== null;
+  for (const path of paths) {
+    const file = pathFingerprint(join(root, path));
+    if (file === FINGERPRINT_UNREADABLE || file === FINGERPRINT_DIRECTORY) complete = false;
+    prints.set(path, { file, index: indexPrints?.get(path) ?? null });
+  }
+  return { prints, complete };
+}
+
+function fingerprintDirtyPaths(cwd, excludedPaths) {
+  // Only the already-dirty set is covered. A path that is clean at dispatch and gets written
+  // surfaces as a brand-new porcelain line anyway, and fingerprinting a whole repository per run
+  // would cost far more than the case it covers.
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const paths = dirtyPaths(cwd);
+  if (paths === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return {
+    root,
+    ...fingerprintPaths(root, paths.filter((path) => !gitPathIsExcluded(root, path, excluded, foldedExcluded))),
+  };
+}
+
+function changedDirtyPaths(before) {
+  // Re-fingerprint exactly the baseline paths, not whatever happens to be dirty now: a path the
+  // run newly dirtied is already reported by the porcelain comparison, and letting an unreadable
+  // one of those blind this signal would be a regression, not caution.
+  if (!before) return { changed: [], complete: false };
+  const now = fingerprintPaths(before.root, [...before.prints.keys()]);
+  const changed = [];
+  for (const [path, print] of before.prints) {
+    const current = now.prints.get(path);
+    const fileKnown = print.file !== FINGERPRINT_UNREADABLE && current.file !== FINGERPRINT_UNREADABLE;
+    const fileChanged = fileKnown &&
+      !(print.file === FINGERPRINT_DIRECTORY && current.file === FINGERPRINT_DIRECTORY) &&
+      current.file !== print.file;
+    const indexChanged = print.index !== null && current.index !== null &&
+      JSON.stringify(current.index) !== JSON.stringify(print.index);
+    if (fileChanged || indexChanged) changed.push(path);
+  }
+  return { changed: changed.sort(), complete: before.complete && now.complete };
+}
+
+function readOnlyVerdict(beforeTree, afterTree, beforeFingerprints) {
+  // Three-valued on purpose. Proof of a write settles it even when the other signal is unknown;
+  // only when nothing is proven AND coverage is incomplete is the answer genuinely unknown.
+  // Collapsing that last case to false is the false assurance a tripwire must never give.
+  const changed = changedDirtyPaths(beforeFingerprints);
+  const porcelainMoved =
+    beforeTree !== null && afterTree !== null && JSON.stringify(beforeTree) !== JSON.stringify(afterTree);
+  if (porcelainMoved || changed.changed.length > 0) return true;
+  if (beforeTree === null || afterTree === null || !changed.complete) return null;
+  return false;
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function stderrTail(stderrPath) {
+  try {
+    return readFileSync(stderrPath, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trimEnd())
+      .filter((line) => line.trim())
+      .slice(-20);
+  } catch {
+    return [];
+  }
+}
+
+function writeJsonAtomic(path, value) {
+  const temporary = `${path}.tmp-${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  renameSync(temporary, path);
+}
+
+function makeResultWriter(opts, version, run, state, beforeTree, beforeFingerprints) {
+  return (extra) => {
+    const result = {
+      schema: SCHEMA,
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "claude",
+      workdir: opts.cd,
+      model: opts.model,
+      effort: opts.effort,
+      maxTurns: opts.maxTurns === null ? null : Number(opts.maxTurns),
+      maxBudgetUsd: opts.maxBudgetUsd === null ? null : Number(opts.maxBudgetUsd),
+      timeout: opts.timeout,
+      readOnly: opts.readOnly,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      resumeLast: opts.resumeLast,
+      permissionMode: state.permissionMode || selectedPermissionMode(opts),
+      toolSurface: toolSurface(opts).split(","),
+      shellSandbox: opts.readOnly
+        ? "not-applicable"
+        : process.platform === "win32"
+          ? "unsupported-on-native-windows"
+          : "strict",
+      dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
+      claudeVersion: version,
+      sessionId: state.sessionId,
+      resultSubtype: state.resultSubtype,
+      numTurns: state.numTurns,
+      usage: state.usage,
+      totalCostUsd: state.totalCostUsd,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      eventsPath: run.eventsPath,
+      finalPath: run.finalPath,
+      stderrPath: run.stderrPath,
+      settingsPath: run.settingsPath,
+      ...extra,
+    };
+    if (opts.readOnly) {
+      result.readOnlyViolation = readOnlyVerdict(
+        beforeTree,
+        gitTripwireState(opts.cd, [run.briefPath, run.eventsPath, run.finalPath, run.stderrPath, run.settingsPath, run.resultPath]),
+        beforeFingerprints,
+      );
+    }
+    writeJsonAtomic(run.resultPath, result);
+    return result;
+  };
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function reportUnavailable(writeResult, opts, run) {
+  const result = writeResult({
+    status: "claude_unavailable",
+    exitCode: 127,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write("relay: `claude` not found on PATH. Install Claude Code and run `claude auth login`.\n");
+  process.exit(127);
+}
+
+function dispatch(opts, brief, launcher, env, run, state, writeResult) {
+  let child;
+  try {
+    const spec = launchSpec(launcher, buildArgv(opts, run), env);
+    child = spawn(spec.command, spec.argv, {
+      cwd: opts.cd,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      windowsHide: true,
+      windowsVerbatimArguments: spec.windowsVerbatimArguments,
+    });
+  } catch (error) {
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      finalMessage: state.finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      error: error && error.message ? error.message : String(error),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+    return;
+  }
+
+  const stdoutDecoder = new StringDecoder("utf8");
+  const scan = makeEventScanner((event) => handleEvent(event, state, run));
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+  });
+
+  let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        if (!settled) killChild(child, "SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  for (const signalName of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(signalName, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      const exitCode = 128 + (osConstants.signals[signalName] || 15);
+      const fields = () => ({
+        status: "aborted",
+        exitCode,
+        signal: signalName,
+        finalMessage: state.finalMessage,
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail(run.stderrPath),
+        error: `the relay was killed by ${signalName}; claude was terminated with it — inspect the working tree before re-dispatching`,
+      });
+      const result = writeResult(fields());
+      printSummary(result, run.resultPath);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // Claude may flush files and terminal metadata while handling SIGTERM.
+        // Rebuild every dynamic field, especially touchedFiles/readOnlyViolation.
+        writeResult(fields());
+        process.exit(exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (error) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const unavailable = error && error.code === "ENOENT";
+    const result = writeResult({
+      status: unavailable ? "claude_unavailable" : "failed",
+      exitCode: unavailable ? 127 : 1,
+      signal: null,
+      finalMessage: state.finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(unavailable ? {} : { stderrTail: stderrTail(run.stderrPath) }),
+      error: error && error.message ? error.message : String(error),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+
+  child.on("close", (code, signalName) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    scan(stdoutDecoder.end());
+    if (watchdogFired) killChild(child, "SIGKILL");
+
+    const missingResult = !state.sawResult;
+    const terminalError = state.resultIsError || missingResult;
+    const succeeded = code === 0 && !watchdogFired && !terminalError;
+    const mapped =
+      code ??
+      (signalName && osConstants.signals[signalName]
+        ? 128 + osConstants.signals[signalName]
+        : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const status = succeeded ? "completed" : watchdogFired ? "timeout" : "failed";
+    let error = null;
+    if (watchdogFired) {
+      error = `claude did not finish within --timeout ${opts.timeout}; killed by the relay watchdog`;
+    } else if (missingResult) {
+      error = "claude exited without a terminal result event; inspect events.jsonl and stderr.txt";
+    } else if (state.resultIsError) {
+      error = `claude returned an error result${state.resultSubtype ? ` (${state.resultSubtype})` : ""}`;
+    }
+    const result = writeResult({
+      status,
+      exitCode,
+      signal: signalName ?? null,
+      finalMessage: state.finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail(run.stderrPath) }),
+      ...(error ? { error } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+
+  // A launch failure can surface on child and on its stdin. The child error
+  // handler owns the outcome, so the pipe error is intentionally swallowed.
+  child.stdin.on("error", () => {});
+  child.stdin.end(brief);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(
+    `relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  claude ${result.claudeVersion ?? "?"}`,
+  );
+  lines.push(`permission mode: ${result.permissionMode}  ·  shell sandbox: ${result.shellSandbox}`);
+  if (result.dangerouslySkipPermissions) {
+    lines.push("warning: bypassPermissions was explicitly enabled; direct file tools can reach beyond normal permission boundaries.");
+  }
+  if (result.readOnlyViolation === true) {
+    lines.push("warning: a git-visible change was detected during this --read-only run; inspect the working tree immediately.");
+  } else if (result.readOnlyViolation === null) {
+    lines.push("warning: this --read-only tripwire had incomplete coverage; inspect the working tree directly.");
+  }
+  if (result.signal === "SIGKILL" && result.status === "failed") {
+    lines.push("hint: the host killed claude (commonly an OOM killer or supervisor timeout); inspect the tree and host resources.");
+  }
+  if (result.resumed) lines.push("mode: resumed an existing Claude session");
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  if (result.resultSubtype) lines.push(`result subtype: ${result.resultSubtype}`);
+  if (typeof result.numTurns === "number") lines.push(`turns: ${result.numTurns}`);
+  if (typeof result.totalCostUsd === "number") lines.push(`cost: $${result.totalCostUsd}`);
+  if (result.usage) {
+    const input = result.usage.input_tokens ?? result.usage.inputTokens ?? "?";
+    const output = result.usage.output_tokens ?? result.usage.outputTokens ?? "?";
+    lines.push(`tokens: in ${input}, out ${output}`);
+  }
+
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- claude final report ---");
+  lines.push(result.finalMessage || "(no final result text captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then land it from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+  const briefBytes = Buffer.byteLength(brief, "utf8");
+  if (briefBytes > MAX_BRIEF_BYTES) {
+    fail(`brief is ${Math.ceil(briefBytes / 1_000_000)}MB; Claude Code caps piped stdin at 10MB. Put large context in the workspace and reference it from a smaller brief.`);
+  }
+
+  const env = childEnvironment();
+  const launcher = resolveClaudeLauncher(env, opts.cd);
+  let run;
+  try {
+    run = prepareRun(opts, brief);
+  } catch (error) {
+    fail(`cannot prepare run artifacts: ${error && error.message ? error.message : String(error)}`);
+  }
+  // Capture after relay artifacts exist so an --out-dir inside the worktree does
+  // not make the relay itself look like a read-only violation.
+  const relayArtifacts = [run.briefPath, run.eventsPath, run.finalPath, run.stderrPath, run.settingsPath, run.resultPath];
+  const beforeTree = opts.readOnly ? gitTripwireState(opts.cd, relayArtifacts) : null;
+  // Working-tree and index state for paths that are ALREADY dirty. Their porcelain lines will not
+  // move if the run edits them, so the line comparison above cannot see those writes on its own.
+  const beforeFingerprints = opts.readOnly ? fingerprintDirtyPaths(opts.cd, relayArtifacts) : null;
+  const version = launcher ? preflightVersion(launcher, env, opts.cd) : null;
+  const state = {
+    sessionId: opts.session,
+    permissionMode: selectedPermissionMode(opts),
+    sawResult: false,
+    resultSubtype: null,
+    resultIsError: false,
+    finalMessage: "",
+    numTurns: null,
+    usage: null,
+    totalCostUsd: null,
+  };
+  const writeResult = makeResultWriter(opts, version, run, state, beforeTree, beforeFingerprints);
+
+  if (!launcher || version === null) {
+    reportUnavailable(writeResult, opts, run);
+    return;
+  }
+  dispatch(opts, brief, launcher, env, run, state, writeResult);
+}
+
+main();

--- a/skills/cline-delegate/SKILL.md
+++ b/skills/cline-delegate/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: cline-delegate
+description: Delegate a coding task to the Cline coding agent CLI (`cline`) as a background
+  implementer, then review its diff and land it yourself. Use this whenever the user
+  wants to delegate implementation work to Cline - phrasings like "have Cline implement
+  X", "delegate this to...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `cline` CLI installed and authenticated with `cline auth`,
+  Node 18+, and git. The orchestrator must be able to run shell commands and read
+  files.
+metadata:
+  version: 0.5.0
+---
+# Cline Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `cline` implementer (`Cline`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Delegate a bounded coding task to a separate **implementer** - the Cline
+coding agent CLI - then review what it produced and land it yourself. You write the brief and own
+the judgment; the implementer makes changes in its own session in a clean working tree; you verify
+and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `cline` CLI is not installed or authenticated.
+- You require the relay to configure a sandbox. Cline exposes sandbox controls, but this relay
+  leaves them to the CLI environment; use `--plan` when the run must be read-only.
+
+## Prerequisites (check once)
+
+1. Install `cline` (npm or bundled binary; the relay probes `cline --version`).
+2. Authenticate: run `cline auth` (interactive sign-in), or configure
+   `ANTHROPIC_API_KEY` / an OpenAI-compatible base URL.
+3. Confirm `cline --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the model (optional)
+
+Cline picks a default model. To choose another, pass the separate `--model <id>` or `--provider <name>`
+(e.g. `anthropic`, `openai-native`, `openrouter`). The relay accepts letters, digits,
+and `. _ : / -` only (the value reaches a shell on Windows).
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write a brief
+
+Cline sees only the text you send. It cannot read your conversation: the brief must stand alone
+with the goal, current state, what to change, what to leave untouched, the project's **real**
+gates, and a report contract. Keep each brief to a single task. Write it to a file and pass it as
+the relay's `--brief`. See [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled relay. It runs `cline --json -v`, streams the brief on stdin behind a fixed
+positional instruction, captures the JSON event stream, and writes `result.json`.
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a model / provider:        add --model <id>  --provider <name>
+# read-only planning pass:          add --plan   (forces --auto-approve false)
+# deny approval-required tools:     add --auto-approve false
+# hard time limit (watchdog):        add --timeout 2h   (the 30m default suits brief runs; most implementation briefs should be 1-2h)
+# see all options:                   node .../relay.mjs --help
+```
+
+The child's cwd pins the workspace. The relay writes artifacts under the system temp dir by
+default and never commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until cline finishes. Run it with the orchestrator's background-command
+facility, or background it in the shell and poll for `result.json`. A pre-run usage error exits 2
+and writes no result; a missing `cline` exits 127 and writes `status: "cline_unavailable"`.
+
+Completion means the process exited and `result.json` exists - trust process state and the
+working tree, not the progress display. Cline's final message is the `finalMessage` field of
+`result.json`.
+
+### 4. Review - do not trust the self-report
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+If the work is good, commit it. The relay never commits - the diff and `result.json` are the
+record; run `git status` and `git diff` first to confirm exactly what changed. If the group has a
+PR flow, make the commit and push a branch; let human review happen. If the diff is wrong or
+incomplete, re-dispatch a corrected brief in a fresh run and review again.
+
+## Autonomy and permissions
+
+The relay explicitly passes Cline's `--auto-approve`, defaulting to `true` in act mode. Cline
+plan mode can request a switch to act mode, so `--plan` forces `--auto-approve false`; the relay
+rejects `--plan --auto-approve true`. That pair is the read-only gate. Cline also exposes sandbox
+through `--data-dir` / `CLINE_SANDBOX`, but the relay does not configure or override it. Plan-first
+for anything risky, then review the plan before a separate act-mode dispatch. Malformed or malicious
+briefs remain dangerous in act mode because commands run as the current user.
+
+## Authorization model
+
+Delegation is something the human opts into. Once briefed, cline works as a tool you approved use
+of. The boundary is: **do not accept conclusions from the self-report**; verify everything on
+disk. For anything touching credentials, production data, or irreversible operations, stop and ask
+the human first instead of encoding it in a brief.
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - structure, scope, gates,
+  brief delivery.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, artifacts,
+  `result.json`, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - what to verify before calling
+  the diff done, at the end of a run.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues,
+  constraint carry-forward, progress tracking, and the final coherence pass.
+
+
+## Limitations
+
+- Requires the `cline` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/cline-delegate/references/dispatch-and-poll.md
+++ b/skills/cline-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,142 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps cline's headless JSON mode, captures its NDJSON event stream, and writes
+a `result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v cline
+cline --version
+```
+
+Install `cline`; on macOS/Linux it ships as a native binary, on Windows as an npm package (the
+relay launches the `.cmd` shim with `shell:true`). Authenticate with `cline auth`. A headless run
+that is not authenticated fails with `status: "failed"` (exit 1).
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--provider <name>` | Cline provider name (default: cline's own default). Token-validated. |
+| `--model <id>` | Cline model id (default: cline's own default). Provider-local and qualified ids are accepted. Token-validated: letters, digits, `. _ : / -`. |
+| `--plan` | Plan mode with `--auto-approve false`; explicit `--auto-approve true` is rejected so Cline cannot auto-approve a switch to act mode. |
+| `--auto-approve <bool>` | Cline tool auto-approval. Defaults to `true` in act mode and `false` with `--plan`. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). The relay never passes it as Cline's own `-t` / `--timeout`. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+The child cwd pins the workspace; the relay does not pass Cline's `--cwd`. `-v` (verbose) exposes
+provider and model in `run_start`. Fresh JSON runs may omit `sessionId`, and the verified headless
+JSON path does not support resume, so the relay has no resume flag.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an
+`--out-dir` inside the worktree can make the artifacts appear there:
+
+- `brief.txt` - the exact brief.
+- `events.jsonl` - raw cline stdout events (every event cline emitted).
+- `final.txt` - cline's final text (`run_result.text`); absent if none was emitted.
+- `stderr.txt` - complete stderr.
+- `result.json` - the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"cline"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `cline_unavailable`), `exitCode`, and `signal` (`null` unless the child died on a signal).
+- `workdir`, requested `provider`/`model`, `planMode`, `autoApprove`, `clineVersion`, `sessionId`,
+  `startedAt`, and `finishedAt`.
+- `actualProvider` and the initial `actualModel` from `run_start`; `run_result` can update the model
+  and supplies `finishReason`, `usage`, and `durationMs`.
+- `briefPath`, nullable `finalPath`, `eventsPath`, and `stderrPath`. `finalPath` is `null` when
+  Cline emitted no final text and `final.txt` was not created.
+- `sessionId` - parsed from `run_start` when Cline emits one; otherwise `null`. It is observational,
+  not a resume promise.
+- `finalMessage` - cline's final text (`run_result.text`).
+- `touchedFiles` - `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of cline's edits: anything already dirty before dispatch shows up too.
+  Dispatch from a clean tree when you want the list to read as "what cline changed". `null` means
+  git could not report; `[]` means git ran and the tree is clean.
+- `stderrTail` - the last 20 non-empty stderr lines on any run that did not complete (`failed`,
+  `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`.
+- `error` - present for launch failures, preflight failures, when the relay watchdog fires
+  (`timeout`), and on an `aborted` run.
+
+## Waiting for completion
+
+The relay blocks. Use the orchestrator's background-command facility, or background it in a shell
+and poll for `result.json`. The run is done only when the process exits and the file contains a
+`status`. The result file is written atomically, so a partial read is impossible.
+
+A pre-run usage error exits 2 and writes no result. A missing `cline` exits 127 and writes
+`status: "cline_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "cline_unavailable"` (exit 127):** cline is not on PATH. Install it, authenticate,
+  and re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
+  causes: an unknown `--model`, expired credentials, or a provider error. A `run_result` with a
+  `finishReason` other than `completed` is failed even if cline exits zero.
+- **`status: "failed"` with an `error` mentioning `version preflight`:** the bounded `cline --version`
+  probe failed or hung, so cline was never dispatched. Check the install (`cline --version` yourself).
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to cline. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through
+  the OOM killer or a supervisor timeout. This is not a cline error; check host memory and
+  re-dispatch, or split the task into smaller briefs.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `cline did not finish within --timeout <dur>; killed by the relay watchdog`. Increase
+  `--timeout` or split the task. On POSIX the relay sends SIGTERM to the process group, waits 10
+  seconds, then sends SIGKILL if needed; on Windows there is no escalation phase - the whole
+  process tree is felled immediately with `taskkill /pid <pid> /t /f`.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost - the run killed late, or the working tree damaged afterward - read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Tool execution events carry the write/edit arguments, but treat any
+reconstruction as unverified until it matches a working-tree diff - when the tree still holds the
+work, preserve the tree rather than replaying the log.
+
+## What the relay runs
+
+The launch is equivalent to:
+
+```bash
+cline --json -v [--provider <name>] [--model <id>] \
+  --auto-approve <true|false> [--plan] \
+  "Follow the task instructions provided on stdin." < brief.txt
+```
+
+Current Cline JSON mode checks for a positional prompt before reading piped input, so the relay
+passes the fixed instruction and streams the real brief on stdin. The child process cwd pins the
+workspace. Only token-validated provider/model values and fixed text reach the `shell:true` launch
+on native Windows; the brief and cwd do not. `-v` (verbose) exposes the requested provider/model.
+Before dispatch the relay runs a
+bounded `cline --version` preflight (10s cap) so a hung or crashing CLI fails fast and explicitly
+instead of hanging the run. In act mode, auto-approval defaults true. With `--plan`, the relay
+forces it false because Cline can otherwise auto-approve a switch to act mode. Cline also exposes
+sandbox through `--data-dir` / `CLINE_SANDBOX`; the relay leaves that control to the inherited CLI
+environment.
+
+## The commit boundary
+
+The relay never commits. Cline edits the working tree; the orchestrator reviews, re-runs the
+gates, and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/cline-delegate/references/multi-task-queues.md
+++ b/skills/cline-delegate/references/multi-task-queues.md
@@ -1,0 +1,58 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is
+the default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh cline sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture
+location, or interface that task 5 needs, write that fact into task 5's brief.
+
+Cline's verified headless JSON path does not support session resume. Rework and unrelated queue
+items both use fresh runs, so every brief must carry the context it needs.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** - queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** - what landed, what you verified, and gate outcomes.
+- **Needs your eyes** - design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** - the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/cline-delegate/references/review-and-land.md
+++ b/skills/cline-delegate/references/review-and-land.md
@@ -1,0 +1,80 @@
+# Review and land
+
+The implementer made the changes; you own the judgment. Verify against reality, never the
+self-report, and read the diff as generated code because a green gate cannot catch every failure
+mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened
+  error types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries cline's claims, not evidence. Re-run the project's actual test, lint, and
+build commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** - changes the brief excluded.
+- **Scope shortfall** - missed behavior, edges, or cleanup.
+- **Quiet judgment calls** - defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to cline as a delta brief, or fix it in the tree, and report either
+choice to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer.
+Write a clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work - the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points -
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`,
+`git diff --cached` for anything the implementer staged (plain `git diff` is blind to the index),
+and commit the intended files explicitly.
+
+## Rework: re-dispatch a corrected brief
+
+Re-dispatch the correction with the needed context:
+
+```bash
+echo "The fix is right, but the tests mock the DB session: use the real migrated fixture and
+remove the unused import." | node "<skill-dir>/scripts/relay.mjs" --cd /path/to/repo
+```
+
+Cline's verified headless JSON path does not support session resume, so each correction is a fresh
+run and its brief must restate the required context. Rework gets the same test review, diff review,
+and implementer sweep.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep
+them in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/cline-delegate/references/writing-the-brief.md
+++ b/skills/cline-delegate/references/writing-the-brief.md
@@ -1,0 +1,129 @@
+# Writing the brief
+
+A brief is the entire task as cline will see it. It runs in a separate process with **no memory of
+your conversation and no shared context** - only the text you send and whatever it can inspect in
+the workspace. If a constraint is not in the brief or discoverable in the repo, it does not exist
+for cline.
+
+Cline can auto-discover the workspace's `AGENTS.md`. Still restate load-bearing repo constraints in
+the brief so the implementer does not have to infer which rules matter for this task.
+
+## Model choice
+
+Cline picks a default model when `--model` is omitted, so a fresh dispatch does not require it.
+Pass `--model <id>` only when the human asked for a specific model, or `--provider <name>` to
+pick a provider. The relay forwards ids and provider names made of letters, digits, `. _ : / -`
+only.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report cline must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** - add `<completeness_contract>` (resolve fully, not just the
+  first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
+  unknown).
+- **Research or recommendations** - add `<research_mode>` (separate observed facts, inferences,
+  and open questions), and dispatch with `--plan`; the relay pairs it with
+  `--auto-approve false` to prevent a switch to act mode.
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from cline's final `run_result` event text. Without a closing
+summary, the edits may exist but the result is hard to review. The `<structured_output_contract>`
+block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy
+the actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Cline can inspect the workspace, but the
+important constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one cline run -> one reviewed commit keeps the diff and
+rollback clean. Split mixed implementation, review, documentation, and roadmap requests into
+separate dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending - ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; inspect the working tree and reconcile any
+partial or premise-contaminated edits - keep or revert them - before the re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Brief delivery
+
+The relay streams the full brief on stdin and passes only a fixed positional instruction. Current
+Cline JSON mode checks for a positional prompt before reading piped input, so a pure stdin launch
+does not work; the fixed instruction satisfies that guard without exposing the brief in argv or
+subjecting it to command-line length and Windows shell-quoting limits. Keep secrets out of the
+brief anyway: it is preserved in the run's `brief.txt` artifact.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/cline-delegate/scripts/relay.mjs
+++ b/skills/cline-delegate/scripts/relay.mjs
@@ -1,0 +1,794 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · cline-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Cline coding agent CLI (`cline --json -v`),
+ * capture the JSON event stream, and write a structured result the orchestrating
+ * agent can review. The orchestrator runs this one command and reads the result
+ * JSON — every cline-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `cline` and `git` (plus `where.exe` / `taskkill`
+ * on Windows) — and to `node` for the delegate-setup lane resolver when `--lane`
+ * is used. The `cline` process it launches does authenticate — exactly as you do
+ * at the terminal. Read this file before you run it.
+ *
+ * The brief is streamed to cline on stdin. Current Cline JSON mode checks for
+ * a positional prompt before it reads piped input, so the relay passes a fixed
+ * positional instruction and keeps the full brief out of argv.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Autonomy: the relay explicitly sets Cline's `--auto-approve` (true in act
+ * mode, false with `--plan`). Plan mode can request a switch to act mode, so
+ * `--plan --auto-approve true` is rejected to preserve the read-only gate.
+ * Cline also supports sandbox through `--data-dir` / `CLINE_SANDBOX`; this
+ * relay does not configure it. The diff reported in `touchedFiles` records
+ * what changed.
+ *
+ * On native Windows `cline` is an npm-installed `.cmd` shim this relay launches
+ * with shell:true. Provider and model values therefore accept only shell-safe
+ * tokens; the working directory is the child process cwd and the brief stays
+ * on stdin.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for cline (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --provider <name>       cline provider id (default: cline's own default).
+ *   --model <id>            cline model id (default: cline's own default).
+ *                           Letters, digits, and . _ : / - only.
+ *   --plan                  Read-only plan mode; forces --auto-approve false.
+ *   --auto-approve <bool>   Cline tool auto-approval (default: true in act mode,
+ *                           false with --plan). True conflicts with --plan.
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). h/m/s strings.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, clineVersion, sessionId, finalMessage (cline's own
+ *   report, from run_result.text), requested/actual provider and model, usage,
+ *   finishReason, touchedFiles (git porcelain, null if git cannot report),
+ *   planMode, autoApprove, briefPath, nullable finalPath, eventsPath, and
+ *   stderrPath. sessionId is nullable because fresh JSON runs omit it.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `cline` binary exits 127;
+ * otherwise the exit code mirrors cline's own (0 success, non-zero failure),
+ * except a run_result whose finishReason is not "completed" exits 1 even if
+ * cline exits 0. If the child dies on a signal, the exit code is 128 plus the
+ * signal number and `result.json` records the signal. Once the brief validates,
+ * `result.json` is written on every outcome — completed, failed, timeout (the
+ * --timeout watchdog fired, or the bounded --version preflight hung), aborted
+ * (the relay itself was killed and forwarded the kill to cline), or
+ * cline_unavailable.
+ */
+
+import { spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const MAX_BUFFERED_CHARS = 1_048_576;
+const VERSION_TIMEOUT_MS = 10_000;
+const STDIN_PROMPT = "Follow the task instructions provided on stdin.";
+// --model and --provider values reach a shell on win32 (shell:true for the .cmd
+// shim), so they are restricted to safe tokens.
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const IMPLEMENTER_KEY = "cline";
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    provider: null,
+    model: null,
+    plan: false,
+    autoApprove: null,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--provider": opts.provider = next(); flagged.add("provider"); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--plan": opts.plan = true; break;
+      case "--auto-approve": {
+        const value = next();
+        if (value !== "true" && value !== "false") fail("--auto-approve must be true or false");
+        opts.autoApprove = value === "true";
+        break;
+      }
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.plan && opts.autoApprove === true) {
+    fail("--plan conflicts with --auto-approve true; plan mode requires auto-approve false to prevent a switch to act mode");
+  }
+  if (opts.autoApprove === null) opts.autoApprove = !opts.plan;
+  for (const flag of ["model", "provider"]) {
+    if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a positive schedulable duration; use h/m/s strings like 30m, 90s, or 1h30m (maximum ~24.8 days)`);
+  }
+  if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
+    fail(`working directory not found: ${opts.cd}`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to cline --json -v\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+async function clineVersion(timeoutMs, onChild) {
+  const limit = Math.min(timeoutMs, VERSION_TIMEOUT_MS);
+  const runProbe = (command, argv, options = {}) => new Promise((resolveProbe) => {
+    const child = spawn(command, argv, {
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      ...options,
+    });
+    onChild(child);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let timer;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveProbe({ stdout, stderr, ...result });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => finish({ code: null, error, timedOut: false }));
+    child.on("close", (code) => finish({ code, error: null, timedOut }));
+    timer = setTimeout(() => {
+      timedOut = true;
+      killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+    }, limit);
+  });
+
+  // shell:true resolves cline.cmd, but a missing command is only an exit 1 from
+  // cmd.exe. Ask the in-box where.exe first so absence stays cline_unavailable.
+  if (process.platform === "win32") {
+    const wherePath = join(process.env.SystemRoot || process.env.WINDIR || "C:\\Windows", "System32", "where.exe");
+    const found = await runProbe(wherePath, ["cline"]);
+    if (found.timedOut) {
+      return { version: null, error: Object.assign(new Error("where.exe cline timed out"), { code: "ETIMEDOUT", stderr: found.stderr }) };
+    }
+    if (found.error && found.error.code !== "ENOENT") return { version: null, error: found.error };
+    if (!found.error && found.code !== 0) return { version: null, error: null };
+  }
+
+  const probe = process.platform === "win32"
+    ? await runProbe("cline --version", [], { shell: true, detached: false })
+    : await runProbe("cline", ["--version"]);
+  if (probe.timedOut) {
+    return { version: null, error: Object.assign(new Error("cline --version timed out"), { code: "ETIMEDOUT", stderr: probe.stderr }) };
+  }
+  if (probe.error && probe.error.code === "ENOENT") return { version: null, error: null };
+  if (probe.error) return { version: null, error: probe.error };
+  if (probe.code !== 0) {
+    return { version: null, error: Object.assign(new Error("cline --version failed"), { status: probe.code, stderr: probe.stderr }) };
+  }
+  return { version: probe.stdout.trim() || "unknown", error: null };
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts) {
+  // Current Cline JSON mode checks for a positional prompt before reading
+  // piped input. Keep that positional fixed and stream the user brief on stdin.
+  const argv = ["--json", "-v", "--auto-approve", String(opts.autoApprove)];
+  if (opts.provider) argv.push("--provider", opts.provider);
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.plan) argv.push("--plan");
+  argv.push(process.platform === "win32" ? `"${STDIN_PROMPT}"` : STDIN_PROMPT);
+  return argv;
+}
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  // A reused --out-dir must not leak a previous run's artifacts into this one.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "cline",
+      workdir: opts.cd,
+      provider: opts.provider,
+      model: opts.model,
+      planMode: opts.plan,
+      autoApprove: opts.autoApprove,
+      clineVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    // Atomic write: a polling orchestrator never reads a half-written result.
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "cline_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    actualProvider: null,
+    actualModel: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `cline` not found on PATH. Install or add it to PATH, then re-dispatch.\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(writeResult, run, error, timeoutMs) {
+  const timedOut = error && error.code === "ETIMEDOUT";
+  const stderr = String((error && error.stderr) || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `cline --version preflight timed out after ${Math.min(timeoutMs, VERSION_TIMEOUT_MS)}ms; cline was not dispatched`
+    : `cline --version preflight failed${Number.isInteger(error && error.status) ? ` with exit ${error.status}` : ""}; cline was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error && error.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    actualProvider: null,
+    actualModel: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: null,
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: null,
+        actualProvider: null,
+        actualModel: null,
+        usage: null,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the cline version preflight; cline was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      const child = getChild();
+      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
+}
+
+function dispatchToCline(opts, brief, run, writeResult) {
+  const child = spawn("cline", buildArgv(opts), {
+    cwd: opts.cd,
+    stdio: ["pipe", "pipe", "pipe"],
+    // shell:true on win32 so the cline.cmd shim resolves. Safe on both
+    // platforms the same way codex-delegate's launch is: argv holds only fixed
+    // values plus token-validated --provider/--model values. The brief is
+    // stdin and cwd is a spawn option, so neither reaches cmd.exe.
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = null;
+  let actualProvider = null;
+  let actualModel = null;
+  let usage = null;
+  let finishReason = null;
+  let durationMs = null;
+  let resultText = null;
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    // run_start (verbose-only): requested model/provider (a sessionId is set
+    // when cline surfaces one; some builds only emit provider/model)
+    if (event.type === "run_start") {
+      if (event.sessionId) sessionId = event.sessionId;
+      if (typeof event.modelId === "string" || typeof event.model === "string") actualModel = event.modelId || event.model;
+      if (typeof event.providerId === "string" || typeof event.provider === "string") actualProvider = event.providerId || event.provider;
+    }
+    // run_result: the final event; finishReason "completed" is success
+    if (event.type === "run_result") {
+      if (typeof event.finishReason === "string") finishReason = event.finishReason;
+      if (typeof event.text === "string") resultText = event.text;
+      if (event.usage && typeof event.usage === "object") usage = event.usage;
+      if (typeof event.model === "string") actualModel = event.model;
+      if (event.model && typeof event.model === "object" && typeof event.model.id === "string") actualModel = event.model.id;
+      if (typeof event.durationMs === "number") durationMs = event.durationMs;
+    }
+    // run_aborted / run_abort_requested: the run stopped early
+    if (event.type === "run_aborted" || event.type === "run_abort_requested") {
+      finishReason = "aborted";
+    }
+  });
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  // A fast-exiting cline (usage error, crashed startup) closes the pipe before
+  // the write; swallow EPIPE here — the exit code reports the failure.
+  child.stdin.on("error", () => {});
+  child.stdin.end(brief);
+
+  const assembleFinal = () => {
+    const message = resultText ?? "";
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the cline child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        actualProvider,
+        actualModel,
+        usage,
+        finishReason,
+        durationMs,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; cline was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      actualProvider,
+      actualModel,
+      usage,
+      finishReason,
+      durationMs,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // A timed-out run is failed even if cline handles SIGTERM by exiting 0 —
+    // orchestrators key off status and the relay exit code.
+    const assistantFailed = finishReason !== null && finishReason !== "completed";
+    const succeeded = code === 0 && !watchdogFired && finishReason === "completed";
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      actualProvider,
+      actualModel,
+      usage,
+      finishReason,
+      durationMs,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `cline did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...(!watchdogFired && assistantFailed ? { error: `cline ended with finishReason "${finishReason}"` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const run = prepareRunDir(opts, brief);
+  let writeResult = makeResultWriter(opts, null, run);
+  let preflightChild = null;
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult, () => preflightChild);
+  const probe = await clineVersion(timeoutMs, (child) => { preflightChild = child; });
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (!probe.version) {
+    clearPreflightSignals();
+    reportVersionFailure(writeResult, run, probe.error, timeoutMs);
+    return;
+  }
+  clearPreflightSignals();
+  dispatchToCline(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  cline ${result.clineVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a cline error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated cline (a supervisor, the session ending, or a manual kill) — when the relay itself kills it, reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.planMode) lines.push("mode: plan-only (analysis, no edits)");
+  if (result.actualModel) lines.push(`model: ${result.actualModel}${result.actualProvider ? ` (provider: ${result.actualProvider})` : ""}`);
+  if (result.sessionId) lines.push(`session id: ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- cline final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main().catch((error) => {
+  const detail = error && error.stack ? error.stack : String(error);
+  process.stderr.write(`relay: unexpected internal error: ${detail}\n`);
+  process.exit(2);
+});

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: codex-delegate
+description: Delegate a coding task to the OpenAI Codex CLI as a background implementer,
+  then review its diff and land it yourself. Use this whenever the user wants to hand
+  implementation work to Codex — phrasings like "have Codex do X", "delegate this
+  to Codex", "run it through Codex",...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `codex` CLI (OpenAI Codex) installed and authenticated,
+  Node 18+, and git. The orchestrating agent must be able to run shell commands and
+  read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+# Codex Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `codex` implementer (`OpenAI Codex`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the OpenAI Codex CLI — then review what it produced and land it yourself. You write
+the brief and own the judgment; Codex does the typing in its own sandbox; you verify and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so it works the same whether you are Claude Code, OpenCode with a selected
+model, or any comparable agent. (It is designed for and run on Claude Code; treat other orchestrators
+as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- The `codex` CLI is not installed or not authenticated (run `codex login`).
+- You want to write the code yourself, or you only need a review (use Codex's own `review` command).
+
+## Prerequisites (check once)
+
+1. `codex --version` succeeds. If not, install (`npm i -g @openai/codex`) and `codex login`.
+2. **Confirm which `codex` is on PATH.** Multiple installs are common (e.g. a current npm/nvm copy and
+   a stale Homebrew one). `command -v codex` shows the active one and `codex --version` its version —
+   an old binary predates flags this skill relies on (`codex exec --json`, `-o`, `exec resume`). The
+   relay also records the version it ran into `result.json`, so a stale binary is visible after the fact.
+3. You are in (or will point `--cd` at) the target git repository.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Codex sees **only** the text you send — no repo memory, no chat history, no shared context. Everything the
+task needs goes in the brief: the goal, the current state, what to change, what to leave untouched,
+the project's **actual** gate commands (discover them from the repo's CLAUDE.md/AGENTS.md/Makefile —
+do not assume), and a report contract. Tell Codex it will **not** commit (you will). Keep one task per
+brief. Full guidance and a template: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to Codex with the bundled helper. It wraps `codex exec`, captures the run, and writes a
+structured `result.json` — so your only job is "run a command, read a file." (`<skill-dir>` below is
+this skill's installed directory — the folder containing this `SKILL.md`, i.e. the directory you loaded
+the skill from. Claude Code prints it as "Base directory for this skill" when the skill loads; on other
+orchestrators use that same directory — if unsure where it landed, run
+`find ~ -name relay.mjs -path '*codex-delegate*'` and substitute the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only (review/diagnosis, no edits):   add --read-only
+# continue the exact Codex session:         add --session <threadId>  (from result.json; send only the delta brief)
+# fallback when no thread id is available:  add --resume-last
+# hard time limit (watchdog):               add --timeout 2h  (default: off; implementation runs routinely need 1-2h)
+# see all options:                          node .../relay.mjs --help
+```
+
+The helper defaults to a write-capable (`workspace-write`) sandbox and writes its artifacts to a temp
+dir, so the repo under review stays clean. It **never commits** — see step 5. Mechanics, flags, and the
+`result.json` shape: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Codex finishes, so back it with whatever your orchestrator offers and resume
+when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job`
+  in PowerShell, `start /b` in cmd). The run is done when `result.json` exists with a `status`. (A
+  pre-run usage error — bad args or an empty brief — instead exits with code 2 and a stderr message and
+  writes no result file, so check the exit code too. A missing `codex` binary exits 127 but *does* write
+  a `result.json` with status `codex_unavailable`.)
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line. The implementer's full report is
+the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
+
+### 4. Review — do not trust the self-report
+
+Codex's `result.json` includes its own summary and gate claims. **Re-verify, don't accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did Codex do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+Because Codex's sandbox cannot reliably write `.git` (it varies by version, OS, and path), **the
+orchestrator commits.** Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--session <threadId>` from the prior `result.json`
+  (use `--resume-last` only when no thread id is available), and review again.
+
+## Read-only second opinions
+
+The relay doubles as a clean way to get an adversarial second opinion with no write risk: dispatch
+`--read-only` with a brief that lists the agreed points, then each contested point with both
+positions, and ask Codex to defend or concede each — deliverable in its final message, touching no
+files. Any delegation skill whose implementer offers a read-only mode supports the same use, but
+check how hard that mode's guarantee is first: Codex's sandbox enforces it, while Grok's is
+best-effort and only flagged after the fact (`readOnlyViolation`) — for those implementers,
+verify `touchedFiles` came back empty instead of assuming no edits.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report Codex's design decisions, defensible-but-unasked turns, and
+non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if correct
+completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
+is in [references/review-and-land.md](references/review-and-land.md).
+
+## If you have the openai-codex plugin
+
+The official openai-codex Claude Code plugin is excellent and **complementary** — `codex-delegate`
+builds on the same `codex` CLI, it doesn't replace the plugin. They point in different directions:
+
+- The plugin's `codex:codex-rescue` agent is a **forwarder**: it hands one task to Codex and returns
+  the output. It deliberately does not poll, review, or commit.
+- The plugin's review command and stop-review gate run the **inverse** direction: **Codex reviews your work**.
+- `codex-delegate` is the **orchestration loop in the other direction**: *you* drive Codex to
+  implement across one task or a queue, and *you* review and land each result. That loop — brief →
+  dispatch → poll → review → commit, with the orchestrator owning the commit — is what the plugin
+  leaves to you, and what this skill encodes.
+
+If you have the plugin installed, its companion CLI is an optional alternative dispatch backend; the
+bundled `relay.mjs` is the default because it adds no install of its own beyond the `codex` binary
+(Node and `git`, which the relay also needs, are prerequisites for every skill here).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief Codex can
+  execute blind: structure, XML blocks, the report contract, embedding the real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the exact-session rework cycle.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.
+
+
+## Limitations
+
+- Requires the `codex` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/codex-delegate/references/dispatch-and-poll.md
+++ b/skills/codex-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,161 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `codex exec`, runs the brief in a sandbox, captures
+everything, and writes a structured `result.json`. Your job collapses to: run one command, then read
+one file. Everything Codex-specific lives in the helper, which is what keeps the loop portable across
+orchestrators.
+
+## Before the first run: check the binary
+
+Two gotchas, both worth 30 seconds:
+
+```bash
+command -v codex      # the active binary; a stale install (e.g. Homebrew) can shadow a current one
+codex --version       # an old binary predates `exec --json`, `-o`, and `exec resume`
+codex login status    # must be authenticated
+```
+
+The Codex CLI moves fast and behavior shifts between versions, so the helper records the version it
+actually ran into `result.json` — if something behaves oddly, check which binary answered.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for Codex (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Codex model (default: Codex's own configured default). |
+| `--effort <level>` | Reasoning effort, passed to Codex as `-c model_reasoning_effort=<level>` (default: Codex's own configured default). The relay accepts a bare token; Codex and the model own the supported levels. Applies to fresh and resumed runs. |
+| `--sandbox <mode>` | `read-only` \| `workspace-write` \| `danger-full-access` (default: `workspace-write`). |
+| `--read-only` | Shortcut for `--sandbox read-only` — review/diagnosis with no edits. |
+| `--resume-last` | Continue the most recent Codex session; send only the delta brief (see review-and-land). "Most recent" is global, so an unrelated Codex run can steal it — prefer `--session`. |
+| `--session <id>` | Continue one specific thread by id (the `threadId` from a prior `result.json`); send only the delta brief. Mutually exclusive with `--resume-last`; an empty id is rejected. |
+| `--clean-env` | Pass only runtime basics (`PATH`, home, locale, temp, `CODEX_HOME`, and Windows equivalents) to Codex and its version preflight. This changes inherited variables only; it does not protect files or other same-user secrets. |
+| `--keep-env <name>` | Keep one additional variable under `--clean-env`; repeat for each required environment-backed auth, custom-provider credential, proxy, certificate, or MCP variable. The name must be set and use portable environment-variable syntax. |
+| `--skip-git-repo-check` | Allow running outside a git repo. |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only Codex's edits and nothing of the helper's own.
+
+`--clean-env` is not a broader security boundary: Codex can still access files and other same-user
+secrets available through `HOME`, `CODEX_HOME`, OS facilities, and the selected sandbox. File- or
+OS-backed auth and normal configuration still load, but direct environment-backed auth
+(`CODEX_API_KEY` or `CODEX_ACCESS_TOKEN`) needs that variable named with `--keep-env`.
+`OPENAI_API_KEY` can still matter as a custom-provider credential; provider, proxy, certificate, or
+MCP settings that reference any stripped variable likewise need it named with `--keep-env`. The same
+filtered environment is used for preflight and dispatch.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `codex_unavailable`
+- `exitCode` — mirrors Codex's exit code; `128` plus the signal number if the child was killed; `127` if `codex` isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
+- `signal` — the signal that killed the child, otherwise `null`
+- `codexVersion` — the binary that actually ran
+- `threadId` — feed this to a later `--session <id>` (exact thread; preferred) or `--resume-last` (global "most recent", which another Codex run can steal)
+- `finalMessage` — Codex's own final report (the `<structured_output_contract>` you asked for)
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report — `git` missing, or a non-repo run under `--skip-git-repo-check`; `[]` means git ran and the tree is clean
+- `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSONL event stream, and the final-message file
+- `workdir`, `sandbox`, `model`, `effort`, `resumeLast`, `session`, `cleanEnv`, `keepEnv`, `startedAt`, `finishedAt` — `sandbox` is the applied mode, or a note that Codex used its active config on an unqualified resume; `session` is the explicit session id, or `null` for fresh and `--resume-last` runs; `keepEnv` records names only, never values
+- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `codex_unavailable`, and launch failures
+- `error` — present on a launch failure, and on `timeout` and `aborted` runs
+
+The helper also prints a summary to stdout and exits with Codex's exit code, so a wrapping script can
+branch on success/failure directly.
+
+## Waiting for completion
+
+The helper blocks until Codex finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job` in PowerShell,
+  `start /b` in cmd). A run is done when `result.json` exists with a `status`. **But** a pre-run usage
+  error (bad args, empty brief) exits with code 2 *before* writing any file — so check the exit code
+  too, don't only watch for the file. (A missing `codex` binary exits 127 but *does* write a
+  `result.json` with status `codex_unavailable`.)
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## When a run misbehaves
+
+- **`status: codex_unavailable` (exit 127):** `codex` isn't on PATH or isn't found. Install
+  (`npm i -g @openai/codex`) and `codex login`, then re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `codex --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
+  codex was never dispatched; only the relay's own artifacts may already exist under `--out-dir`.
+  Check the install by running `codex --version` yourself.
+- **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
+  Common causes: an auth lapse, an invalid `--model` or unsupported `--effort`, or a sandbox that
+  blocked something the task needed. Fix the cause and re-dispatch; don't paper over it by doing the
+  work yourself unless that's what the user wants.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a resume.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to codex. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
+  or a supervisor timeout, not an implementer error. Free up host memory or split the task into
+  smaller briefs, then re-dispatch.
+- **Empty `finalMessage`:** Codex exited before producing a final message. Treat as a failed run;
+  the events log usually shows where it stopped.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. It cannot rebuild the changes themselves — Codex's JSON stream currently
+reports a file change as its path and kind only, without the diff contents — so when the tree
+still holds the work, preserve the tree, and otherwise re-dispatch with the log as the map of
+what was lost.
+
+## What the helper is doing (and the alternatives)
+
+Under the hood the helper runs roughly:
+
+```bash
+codex exec --json -o <final.txt> -s workspace-write [-m model] [-c model_reasoning_effort=<level>] - < brief.txt   # fresh run
+codex exec [-s mode] resume --last --json -o <final.txt> [-m model] [-c model_reasoning_effort=<level>] - < delta-brief.txt  # resume
+```
+
+On resume, the helper places an explicit `--sandbox`/`--read-only` or fleet-lane sandbox before the
+`resume` subcommand so Codex applies it to the resumed turn. Without one, Codex uses its active config.
+The helper sets the child process's working directory instead of forwarding `-C`.
+
+Two alternatives exist if you ever want them, but the helper is the recommended path:
+
+- **Raw `codex exec`** — fine for one-offs; you give up the captured `result.json`, touched-files
+  summary, and thread-id extraction the helper does for you.
+- **The openai-codex Claude Code plugin's companion CLI** (`task`/`status`/`result`) — richer job
+  tracking if you have that plugin installed. It runs Codex as a background job behind a broker process,
+  so you track jobs through `queued`/`running` states; the bundled helper instead spawns `codex`
+  in-process and blocks until completion, so the only state to track is whether `result.json` exists —
+  which is why it's the default here.
+
+## The commit boundary
+
+The helper never commits — by design, not omission. Whether Codex's sandbox can write `.git` varies by
+version, OS, and execution path, so relying on it is a coin flip. The robust contract is: Codex edits
+the working tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/codex-delegate/references/multi-task-queues.md
+++ b/skills/codex-delegate/references/multi-task-queues.md
@@ -1,0 +1,66 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential.
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. Codex has no memory of the earlier run, so a constraint that
+emerged in task 2 must be restated in task 5's brief or it won't hold. This is the queue equivalent of
+keeping briefs self-contained.
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions Codex made, non-blocking nitpicks, anything you want the
+  human to overrule or confirm. This is the section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/codex-delegate/references/review-and-land.md
+++ b/skills/codex-delegate/references/review-and-land.md
@@ -1,0 +1,126 @@
+# Review and land
+
+Codex did the typing; you own the judgment. This is where delegation earns its keep or quietly ships a
+mistake. The discipline is simple to state and easy to skip under time pressure: **verify against
+reality, never against the self-report — and read the diff as generated code, which fails in ways a
+green gate can't see.**
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries Codex's own claim that the gates passed. Treat that as a claim, not evidence —
+re-run the project's actual test/lint/build commands in the working tree and read the output. And keep
+the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a gate,
+not just misreport it — that is what the test check above and the sweep below exist to catch.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Scope creep** — did Codex change things the brief said to leave untouched? Unasked refactors,
+  renames, "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version?
+- **Quiet judgment calls** — sometimes Codex makes a defensible decision the brief didn't anticipate.
+  Don't just accept it because it looks reasonable; understand it and decide.
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If Codex couldn't implement something,
+  the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to Codex as a delta brief (below) or gets fixed in the tree before
+commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never Codex. This isn't a
+workaround for a missing feature; it's the deliberate boundary. Codex's sandbox can't reliably write
+`.git`, and more importantly, committing should be the act of the party that verified the work. Write
+a clear message describing what landed. If your project attributes co-authorship, that's the place
+for it.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same Codex session with
+just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
+
+`--session <threadId>` (or `--resume-last`) keeps Codex's context from the first run, so a short delta is enough. Then review
+again — rework gets the same gate-rerun, test check, diff-read, and sweep as the original, no
+shortcuts. Repeat until it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** Codex made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or Codex's.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/codex-delegate/references/writing-the-brief.md
+++ b/skills/codex-delegate/references/writing-the-brief.md
@@ -1,0 +1,125 @@
+# Writing the brief
+
+A brief is the entire task as Codex will see it. Codex runs in a fresh process with **no memory of
+your conversation, no access to your prior notes, and no shared context** — only the text you send and
+whatever it can read from the working tree (including the repo's own `AGENTS.md`, which it picks up
+automatically).
+If a constraint isn't in the brief or discoverable in the repo, it doesn't exist for Codex. The single
+most common failure is a brief that assumes context Codex doesn't have.
+
+## The shape that works
+
+Codex responds best to compact, block-structured prompts with XML tags rather
+than long prose. State the task, what "done" looks like, how to behave by default, and the few
+constraints that actually matter. Add a block only when the task needs it — don't ship empty ceremony.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps Codex from
+wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — you cannot reliably write .git, and the orchestrator
+commits after reviewing. Leave the work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
+  inferences) and run with `--read-only` so Codex can't edit.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`CLAUDE.md` / `AGENTS.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you a Codex that guesses — or skips.
+
+## Honor the repo's conventions
+
+Codex reads the repo's `AGENTS.md` automatically, so house rules there (style, forbidden patterns,
+commit conventions) already apply. If the project forbids certain things in code — say, spec/ticket IDs
+in comments, process language like "MVP"/"for now"/"phase N", or specific test conventions, whatever
+the repo's own conventions ban — restate the load-bearing ones in the brief too, because Codex's
+compliance is only as reliable as what's in front of it.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and
+suggest a roadmap" produces a muddled run; split it into separate dispatches. One brief → one Codex
+run → one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## Expect environment preamble in the reply
+
+Codex's final message may carry environment noise on top of your requested report — a banner injected
+by the repo's `AGENTS.md`, extra text from an MCP tool or extension you've configured, and similar
+local additions. That comes from your own Codex setup, not a relay defect. The
+`<structured_output_contract>` is your defense: ask for a clearly delimited report section so you can
+find the real output regardless of what wraps it.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout (the idempotency key isn't checked before re-submitting). Make the refund
+submission idempotent: check for an existing refund by idempotency key before creating a new one.
+Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes, and the
+data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/codex-delegate/scripts/relay.mjs
+++ b/skills/codex-delegate/scripts/relay.mjs
@@ -1,0 +1,679 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · codex-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the OpenAI Codex CLI (`codex exec`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every Codex-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified on Claude Code; other shell-capable agents
+ * (OpenCode, Cursor, …) are designed-for but not yet verified.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `codex` and `git`. The `codex` process it
+ * launches does authenticate — exactly as you do at the terminal. Read this
+ * file before you run it.
+ *
+ * It deliberately does NOT commit. Whether Codex's sandbox can write `.git`
+ * varies by Codex version, OS, and execution path, so committing is always the
+ * orchestrator's job — after it reviews the diff and re-runs the project gates.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for Codex (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Codex model (default: Codex's own configured default).
+ *   --effort <level>        Reasoning effort, passed to Codex as
+ *                           `-c model_reasoning_effort=<level>` (default: Codex's
+ *                           own configured default).
+ *   --sandbox <mode>        read-only | workspace-write | danger-full-access
+ *                           (default: workspace-write).
+ *   --read-only             Shortcut for --sandbox read-only (review/diagnosis, no edits).
+ *   --resume-last           Continue the most recent Codex session; send only the delta brief.
+ *                           An explicit --sandbox/--read-only override applies to the resumed turn.
+ *   --session <id>          Continue a specific Codex session by thread id (from a prior
+ *                           result.json). Safer than --resume-last when other Codex runs
+ *                           may have happened since - "last" is global, not per-repo.
+ *                           Mutually exclusive with --resume-last.
+ *   --clean-env             Launch Codex and its version preflight with only runtime basics.
+ *                           Changes inherited variables only; does not protect files or other
+ *                           same-user secrets.
+ *   --keep-env <name>       Keep one additional variable under --clean-env (repeatable).
+ *                           Required for environment-backed auth and other stripped variables.
+ *   --skip-git-repo-check   Allow running outside a git repository.
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the codex child is killed
+ *                           and result.json gets status "timeout". Codex has no timeout
+ *                           flag of its own, so the watchdog is relay-only.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, codexVersion, threadId (for a later resume), finalMessage
+ *   (Codex's own report), touchedFiles (git porcelain, null if git can't report), and the paths to
+ *   events.jsonl and final.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `codex` binary exits 127;
+ * otherwise the exit code mirrors Codex's own (0 success, non-zero failure).
+ * If the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, timeout (the --timeout watchdog fired), aborted (the relay
+ * itself was killed and forwarded the kill to codex), or codex_unavailable. An
+ * orchestrator that polls for the file must therefore also treat a non-zero exit
+ * with no file as a usage error.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_TIMER_MS = 2_147_483_647;
+const SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
+const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+// Model reaches cmd.exe on win32 (shell:true for the codex.cmd shim) — same shell-safe
+// family as grok/pi. Keep in lockstep with delegate-setup MODEL_TOKEN.shellSafe.
+const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const IMPLEMENTER_KEY = "codex";
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+    if (field === "sandbox") opts.sandboxConfigured = true;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    effort: null,
+    sandbox: "workspace-write",
+    sandboxConfigured: false,
+    resumeLast: false,
+    session: null,
+    cleanEnv: false,
+    keepEnv: [],
+    skipGitRepoCheck: false,
+    timeout: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--effort": opts.effort = next(); flagged.add("effort"); break;
+      case "--sandbox": opts.sandbox = next(); opts.sandboxConfigured = true; flagged.add("sandbox"); break;
+      case "--read-only": opts.sandbox = "read-only"; opts.sandboxConfigured = true; flagged.add("sandbox"); flagged.add("readOnly"); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--clean-env": opts.cleanEnv = true; break;
+      case "--keep-env": opts.keepEnv.push(next()); break;
+      case "--skip-git-repo-check": opts.skipGitRepoCheck = true; break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (!SANDBOX_MODES.has(opts.sandbox)) {
+    fail(`invalid --sandbox "${opts.sandbox}" (expected: ${[...SANDBOX_MODES].join(", ")})`);
+  }
+  if (opts.effort !== null && !/^[a-z][a-z0-9-]*$/i.test(opts.effort)) {
+    fail(`invalid --effort "${opts.effort}" (expected a non-empty bare token)`);
+  }
+  if (opts.model !== null && !SAFE_MODEL.test(opts.model)) {
+    fail("--model contains unsupported characters (allowed: letters, digits, . _ : / -)");
+  }
+  if (opts.keepEnv.length && !opts.cleanEnv) {
+    fail("--keep-env requires --clean-env");
+  }
+  const invalidEnvName = opts.keepEnv.find((name) => !SAFE_ENV_NAME.test(name));
+  if (invalidEnvName) {
+    fail(`invalid --keep-env "${invalidEnvName}" (expected an environment variable name)`);
+  }
+  const missingEnvName = opts.keepEnv.find((name) => process.env[name] === undefined);
+  if (missingEnvName) {
+    fail(`--keep-env "${missingEnvName}" is not set`);
+  }
+  // The watchdog is relay-only (codex has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  if (opts.session !== null && opts.resumeLast) {
+    fail("--session and --resume-last are mutually exclusive; pass only one");
+  }
+  // This value reaches cmd.exe on win32 (shell:true for the codex.cmd shim), so
+  // accept only the same shell-safe session token shape used by sibling relays.
+  if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
+    fail("--session must be a shell-safe thread id (letters, digits, . _ : -)");
+  }
+  return opts;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to codex exec\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once codex is running, so the preflight needs a bound of
+  // its own: a `codex --version` that never returns would wedge the relay here, before
+  // any result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function codexEnv(opts) {
+  if (!opts.cleanEnv) return process.env;
+  const keep = ["PATH", "HOME", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "LC_CTYPE", "TERM",
+    "TMPDIR", "CODEX_HOME", "SystemRoot", "SystemDrive", "USERPROFILE", "APPDATA", "LOCALAPPDATA",
+    "TEMP", "TMP", "PATHEXT", "COMSPEC", ...opts.keepEnv];
+  return Object.fromEntries(keep.filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]]));
+}
+
+function codexVersion(probeTimeoutMs, env) {
+  try {
+    // On Windows, npm installs `codex` as a .cmd shim; Node's CreateProcess only
+    // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
+    // ENOENTs on a working install. POSIX is unaffected. (git installs a real
+    // git.exe and must NOT get this flag — see gitTouchedFiles.)
+    const version = execFileSync("codex", ["--version"], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+      env,
+    }).trim();
+    return { version: version || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+    // exit rather than ENOENT; that is still "not installed", not a broken install.
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    // Anything else — a hung probe we killed, or a real non-zero exit — means codex is
+    // installed but not usable. Reporting that as "unavailable" would send the caller
+    // off to reinstall a binary that is already there.
+    return { version: null, error };
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, finalPath) {
+  const argv = ["exec"];
+  const resuming = Boolean(opts.session || opts.resumeLast);
+  // Codex accepts shared exec options before the resume subcommand. Reapply only
+  // an explicitly selected sandbox; otherwise leave the active Codex config alone.
+  if (resuming && opts.sandboxConfigured) argv.push("-s", opts.sandbox);
+  if (opts.session) argv.push("resume", opts.session);
+  else if (opts.resumeLast) argv.push("resume", "--last");
+  // ponytail: shell:true on win32 (needed for the codex.cmd shim) doesn't quote
+  // args, so a temp path with spaces (C:\Users\First Last\...) splits and the
+  // trailing "-" misparses (issue #3). Quote the only spaceable arg in argv.
+  // Ceiling: if quoting proves too blunt, drop shell:true and resolve the shim.
+  const outPath = process.platform === "win32" ? `"${finalPath}"` : finalPath;
+  argv.push("--json", "-o", outPath);
+  if (!resuming) {
+    argv.push("-s", opts.sandbox);
+  }
+  if (opts.model) argv.push("-m", opts.model);
+  // `-c` is accepted by the resume subcommand, so the effort override applies to
+  // fresh and resumed runs alike.
+  if (opts.effort !== null) argv.push("-c", `model_reasoning_effort=${opts.effort}`);
+  if (opts.skipGitRepoCheck) argv.push("--skip-git-repo-check");
+  argv.push("-"); // read the prompt from stdin
+  return argv;
+}
+
+function extractThreadId(event) {
+  return (
+    event.thread_id ??
+    event.threadId ??
+    (event.thread && (event.thread.thread_id ?? event.thread.id)) ??
+    null
+  );
+}
+
+function recordEventLine(eventsPath, line) {
+  // Append one stdout line to the event log and pull a thread id from it when the
+  // line is a JSON event. Non-JSON progress lines (and a newline-less final line)
+  // are preserved in events.jsonl regardless; they just carry no thread id.
+  appendFileSync(eventsPath, `${line}\n`, "utf8");
+  try {
+    return extractThreadId(JSON.parse(line));
+  } catch {
+    return null;
+  }
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only Codex's edits, not relay's artifacts.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    eventsPath: join(outDir, "events.jsonl"),
+    finalPath: join(outDir, "final.txt"),
+    briefPath: join(outDir, "brief.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  return (extra) => {
+    const resuming = Boolean(opts.resumeLast || opts.session);
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      workdir: opts.cd,
+      sandbox: !resuming || opts.sandboxConfigured ? opts.sandbox : "(Codex config on resume)",
+      model: opts.model,
+      effort: opts.effort,
+      resumeLast: opts.resumeLast,
+      session: opts.session,
+      cleanEnv: opts.cleanEnv,
+      keepEnv: opts.keepEnv,
+      codexVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      eventsPath: run.eventsPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "codex_unavailable", exitCode: 127, signal: null, threadId: null, finalMessage: "", touchedFiles: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `codex` not found on PATH. Install it (npm i -g @openai/codex) and run `codex login`.\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `codex --version preflight timed out after ${probeTimeoutMs}ms; Codex was not dispatched`
+    : `codex --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Codex was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    threadId: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToCodex(opts, brief, run, writeResult, env) {
+  const argv = buildArgv(opts, run.finalPath);
+  // shell:true on Windows so the codex.cmd shim resolves (see codexVersion). Safe:
+  // the brief is fed via child.stdin below — never argv — and argv holds only
+  // sandbox enums, model names, the pattern-checked effort, and file paths.
+  // detached on POSIX: the child leads a new process group so killChild can fell the whole tree
+  const child = spawn("codex", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: process.platform === "win32", detached: process.platform !== "win32", env });
+
+  let threadId = null;
+  let stdoutBuf = "";
+  const stderrTail = [];
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    stdoutBuf += stdoutDecoder.write(chunk);
+    let nl;
+    while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+      const line = stdoutBuf.slice(0, nl);
+      stdoutBuf = stdoutBuf.slice(nl + 1);
+      if (!line.trim()) continue;
+      const tid = recordEventLine(run.eventsPath, line);
+      if (tid) threadId = tid;
+    }
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk); // surface Codex progress live for the orchestrator
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        if (!settled) killChild(child, "SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the codex child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const finalMessage = existsSync(run.finalPath) ? readFileSync(run.finalPath, "utf8").trim() : "";
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        threadId,
+        finalMessage,
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; codex was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({ status: "failed", exitCode: 1, signal: null, threadId, finalMessage: "", touchedFiles: gitTouchedFiles(opts.cd), error: String(err && err.message ? err.message : err) });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    if (stdoutBuf.trim()) {
+      const tid = recordEventLine(run.eventsPath, stdoutBuf);
+      if (tid) threadId = tid;
+    }
+    const finalMessage = existsSync(run.finalPath) ? readFileSync(run.finalPath, "utf8").trim() : "";
+    // A timed-out run is never a success even if codex handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
+      threadId,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `codex did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+
+  // If the child failed to launch, writing to its stdin can emit a stray 'error'
+  // on the pipe; the 'error' handler above owns that outcome, so swallow it here.
+  child.stdin.on("error", () => {});
+  child.stdin.write(brief);
+  child.stdin.end();
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
+  const run = prepareRunDir(opts, brief);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const env = codexEnv(opts);
+  const probe = codexVersion(probeTimeoutMs, env);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+
+  if (!probe.version && !probe.error) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+
+  dispatchToCodex(opts, brief, run, writeResult, env);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  codex ${result.codexVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a codex error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated codex (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.resumeLast) lines.push("mode: resumed most recent session");
+  if (result.session) lines.push(`mode: resumed session ${result.session}`);
+  if (result.threadId) lines.push(`thread id (resume with: --session ${result.threadId}): ${result.threadId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- codex final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/commandcode-delegate/SKILL.md
+++ b/skills/commandcode-delegate/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: commandcode-delegate
+description: Delegate a coding task to the Command Code CLI (`cmd`) as a background
+  implementer, then review its diff and land it yourself. Use this whenever the user
+  wants to hand implementation work to Command Code — phrasings like "have Command
+  Code do X", "delegate this to...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the Command Code CLI (`cmd`, from commandcode.ai) installed
+  and authenticated via `cmd login`, Node 18+, and git. The orchestrating agent must
+  be able to run shell commands and read files. Shell examples assume bash/zsh (macOS/Linux).
+  On Windows the binary name collides with `cmd.exe`, so `COMMANDCODE_BIN` must be
+  the real binary's absolute path, not the system command interpreter.
+metadata:
+  version: 0.5.0
+---
+# Command Code Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `commandcode` implementer (`Command Code`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the Command Code CLI (`cmd`) — then review what it produced and land it yourself.
+You write the brief and own the judgment; Command Code does the typing in your working tree; you
+verify and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so it works the same whether you are Claude Code, OpenCode with a selected
+model, or any comparable agent. (It is designed for and run on Claude Code; treat other orchestrators
+as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- The `cmd` CLI is not installed or not authenticated (run `cmd login`).
+- You want to write the code yourself, or you only need a review (Command Code has its own `/review`).
+- You are on native Windows without `COMMANDCODE_BIN` set — see the autonomy and platform notes below.
+
+## Read this before the first dispatch: the autonomy model
+
+Command Code's headless mode has **exactly two states, with nothing in between**:
+
+- **Default (`-p` with no `--yolo`):** read, grep, and glob work. Every write, edit, and shell call is
+  refused by the CLI's permission layer, and headless mode has no prompt to grant them mid-run. This
+  is the relay's `--read-only`.
+- **`--yolo` (alias `--dangerously-skip-permissions`):** every tool is allowed, anywhere the process
+  can reach. There is no filesystem sandbox and no path restriction. This is what an implementation
+  run needs, so the relay passes it by default.
+
+`--permission-mode auto-accept` and `--tools-all` do **not** lift the headless write gate. Direct CLI
+probes refused write, edit, and shell with both. So an implementation run
+through Command Code is a full-trust run: scope it with a tight brief and a clean working tree, not
+with a sandbox. The brief is guidance, and a git worktree isolates a checkout without containing the
+process. If writes outside the target tree are unacceptable, use an OS-enforced sandbox such as
+`codex-delegate` or run this one inside a container.
+
+## Prerequisites (check once)
+
+1. `cmd --version` succeeds and `cmd status` reports authenticated. If not, install Command Code and
+   run `cmd login`.
+2. **Confirm which `cmd` is on PATH.** The name is generic, so a shell builtin, an alias, or another
+   tool can shadow it — `command -v cmd` shows the active one. On native Windows `cmd` *is* `cmd.exe`;
+   the relay refuses to guess there and requires `COMMANDCODE_BIN` to be the real binary's absolute
+   path, not the system command interpreter. The relay records the version it actually ran into
+   `result.json`, so a wrong binary is visible after the fact.
+3. You are in (or will point `--cd` at) the target git repository, and its tree is clean before you
+   dispatch — a full-trust run is much easier to review against a clean baseline.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Command Code sees **only** the text you send — no repo memory, no chat history, no shared context
+(beyond the repo's own `AGENTS.md`, which it reads automatically). Everything the task needs goes in
+the brief: the goal, the current state, what to change, what to leave untouched, the project's
+**actual** gate commands (discover them from the repo's AGENTS.md/CLAUDE.md/Makefile — do not assume),
+and a report contract. Tell it that it will **not** commit (you will). Keep one task per brief. Full
+guidance and a template: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to Command Code with the bundled helper. It wraps `cmd -p`, captures the run, and
+writes a structured `result.json` — so your only job is "run a command, read a file." (`<skill-dir>`
+below is this skill's installed directory — the folder containing this `SKILL.md`, i.e. the directory
+you loaded the skill from. Claude Code prints it as "Base directory for this skill" when the skill
+loads; on other orchestrators use that same directory — if unsure where it landed, run
+`find ~ -name relay.mjs -path '*commandcode-delegate*'` and substitute the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only (review/diagnosis, no edits):   add --read-only
+# continue the exact session:               add --session <sessionId>  (from result.json; send only the delta brief)
+# fallback when no session id is available: add --continue-last
+# hard time limit (watchdog):               add --timeout 2h  (default: off; implementation runs routinely need 1-2h)
+# see all options:                          node .../relay.mjs --help
+```
+
+The helper defaults to a write-capable (`--yolo`) run, which intentionally edits the target repository.
+Its temp directory keeps only relay artifacts out of that repository. The relay **never commits** —
+see step 5. Mechanics, flags, and the
+`result.json` shape: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Command Code finishes, so back it with whatever your orchestrator offers and
+resume when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh, or your shell's equivalent. The run is done when `result.json`
+  exists with a `status`. (A pre-run usage error — bad args or an empty brief — instead exits with code
+  2 and a stderr message and writes no result file, so check the exit code too. A missing `cmd` binary
+  exits 127 but *does* write a `result.json` with status `commandcode_unavailable`.)
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line. The implementer's full report is the
+`finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
+
+### 4. Review — do not trust the self-report
+
+`result.json` includes Command Code's own summary and gate claims. **Re-verify, don't accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did it do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point — and because the run was
+  full-trust, check for edits *outside* the paths the brief named, not just inside them.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The relay never commits, but it cannot stop Command Code under `--yolo` from writing `.git`. The brief
+forbids implementer commits, and the reviewer compares `HEAD` with the recorded pre-dispatch baseline
+before landing anything. **The orchestrator commits.** Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--session <sessionId>` from the prior `result.json`
+  (use `--continue-last` only when no session id is available), and review again.
+
+## Read-only second opinions
+
+The relay doubles as a clean way to get an adversarial second opinion: dispatch `--read-only` with a
+brief that lists the agreed points, then each contested point with both positions, and ask Command
+Code to defend or concede each — deliverable in its final message, touching no files. The read-only
+guarantee here is the CLI's own permission layer rather than an OS sandbox, so the relay also checks
+it after the fact: `readOnlyViolation: false` means the Git-visible detector saw no change (ignored
+or outside-repository paths are not covered); `true` means it saw one; `null` means git could not tell.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report Command Code's design decisions, defensible-but-unasked
+turns, and non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if
+correct completion needs going beyond the brief, ask — don't expand the mandate yourself). The full
+treatment is in [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief Command
+  Code can execute blind: structure, XML blocks, the report contract, embedding the real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the exact-session rework cycle.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.
+
+
+## Limitations
+
+- Requires the `commandcode` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/commandcode-delegate/references/dispatch-and-poll.md
+++ b/skills/commandcode-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,223 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `cmd -p`, feeds it the brief on stdin, captures the
+NDJSON event stream, and writes a structured `result.json`. Your job collapses to: run one command,
+then read one file. Everything Command Code-specific lives in the helper, which is what keeps the loop
+portable across orchestrators.
+
+## Before the first run: check the binary
+
+Three gotchas, all worth 30 seconds:
+
+```bash
+command -v cmd        # `cmd` is a generic name — an alias or another tool can shadow it
+cmd --version         # the relay records this in result.json; confirm it is Command Code's
+cmd status            # must report authenticated (else `cmd login`)
+```
+
+On native Windows, `cmd` resolves to `cmd.exe`. The relay refuses to run there rather than hand your
+brief to a shell: set `COMMANDCODE_BIN` to the Command Code binary's absolute path, not `COMSPEC`, and
+note that it must be a real executable — the relay never launches through a shell, so a `.cmd`/`.bat`
+wrapper will not start.
+Windows is untested for this skill. The same variable overrides the binary on any platform when several
+installs compete.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for Command Code (default: current directory). It is the child's working directory — Command Code has no `--cd` of its own, and under `--yolo` it is a starting point, not a boundary. |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Model for this run, e.g. `vendor/model` (default: Command Code's own). `cmd --list-models` lists what your account can use. |
+| `--effort <level>` | Reasoning effort — `low` \| `medium` \| `high`, model-dependent. The relay accepts a bare token; Command Code and the model own the supported levels. |
+| `--read-only` | Withhold the write, edit, and shell tools: no `--yolo`, plus `--permission-mode plan`. For review and diagnosis, followed by a Git-visible `readOnlyViolation` tripwire. |
+| `--tools-all` | Also pass `--tools-all`, so no tool stays withheld. Ignored under `--read-only` — it does not lift the write gate. |
+| `--max-turns <n>` | Cap conversation turns (default: Command Code's own, 100). Command Code may exit 0 at the cap; when its complete result reports `max_turns`, the relay reports failure and exits 1. |
+| `--session <id>` | Continue one specific session by id (the `sessionId` from a prior `result.json`); send only the delta brief. Mutually exclusive with `--continue-last`. |
+| `--continue-last` | Continue the most recent session. "Most recent" is global, not per-repo, so an unrelated run can steal it — prefer `--session`. |
+| `--clean-env` | Pass only runtime basics (`PATH`, home, locale, temp, and Windows equivalents) to Command Code and its version preflight. This changes inherited variables only; it does not protect files or other same-user secrets. |
+| `--keep-env <name>` | Keep one additional variable under `--clean-env`; repeat for each required environment-backed credential, proxy, certificate, or MCP variable. The name must be set and use portable environment-variable syntax. |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh private dir under the system temp dir). |
+
+Artifacts default to the system temp dir so relay-created files stay out of the target repository.
+On POSIX, that directory is mode `0700` and its files are created as `0600`. The touched-files report
+then shows Command Code's Git-visible edits without the helper's artifacts.
+
+`--clean-env` is not a security boundary: Command Code still reaches files and other same-user secrets
+through `HOME` (its own state lives in `~/.commandcode`) and OS facilities, and under `--yolo` there is
+no sandbox at all. Its login credentials are file-backed, so a `--clean-env` run stays authenticated;
+provider, proxy, certificate, or MCP settings that reference a stripped variable need it named with
+`--keep-env`. The same filtered environment is used for preflight and dispatch.
+
+## What the helper is doing
+
+```bash
+cmd -p --output-format json --skip-onboarding --no-auto-update -t --yolo [--tools-all] \
+    [-m <model>] [--effort <level>] [--max-turns <n>] < brief.txt          # fresh implementation run
+cmd -p --output-format json --skip-onboarding --no-auto-update -t --permission-mode plan …  # --read-only
+cmd -p … --resume <sessionId> < delta-brief.txt                            # exact-session rework
+cmd -p … --continue < delta-brief.txt                                      # most-recent fallback
+```
+
+The four constant flags earn their place: `--output-format json` is what makes the run machine-readable
+at all, `--skip-onboarding` stops the taste-onboarding prompt from blocking an automated run, `-t`
+auto-trusts the project so the trust prompt doesn't, and `--no-auto-update` keeps a background update
+from swapping the binary mid-run. The brief goes in on stdin, never in argv — Command Code's `-p` takes
+an optional query argument, so an unrecognized flag would be read as that query and the run would die
+with "too many arguments". Command Code waits at most 30 seconds for piped stdin; the relay writes the
+brief immediately.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `commandcode_unavailable`
+- `exitCode` — preserves Command Code's non-zero exit code; changes a zero exit with a complete non-success result to 1; uses `128` plus the signal number if the child was killed;
+  `127` if the binary isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child
+  exited `0` after the watchdog's SIGTERM
+- `signal` — the signal that killed the child, otherwise `null`
+- `commandCodeVersion` — the binary that actually ran
+- `sessionId` — feed this to a later `--session <id>` (exact session; preferred) or `--continue-last`
+  (global "most recent", which another run can steal)
+- `finalMessage` — Command Code's own final report (the `<structured_output_contract>` you asked for),
+  lifted from `finalText` on a complete result line or recovered from the last `message_end` or
+  `text_delta`; recovered text may be partial or empty, and is written to `finalPath` only when non-empty
+- `resultLine` — how much of the tail survived: `complete`, `truncated`, or `absent`. See the
+  truncation section below; the four fields under it are null unless this says `complete`
+- `resultSubtype` / `stopReason` / `usage` / `durationMs` — straight from that result line: `success`,
+  `error`, or `max_turns`; why the turn ended; token counts; wall-clock
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point.
+  `null` (not `[]`) when git can't report — `git` missing, or a non-repo working root; `[]` means git
+  ran and the tree is clean
+- `readOnlyViolation` — only meaningful under `--read-only`: `false` when the Git-visible detector
+  saw no change beyond the relay's own artifacts; it does not cover ignored or outside-repository
+  paths. `true` when the detector saw a change, `null` when git couldn't snapshot either side.
+  `null` on write-capable runs, where the question doesn't apply
+- `autonomy` — the state the run actually got, in Command Code's terms (`--yolo …` or `plan …`)
+- `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw NDJSON event stream,
+  and the final-message file; `finalPath` is `null` when `finalMessage` is empty
+- `workdir`, `readOnly`, `toolsAll`, `model`, `effort`, `maxTurns`, `session`, `continueLast`,
+  `cleanEnv`, `keepEnv`, `startedAt`, `finishedAt` — `session` is the explicit session id, or `null`
+  for fresh and `--continue-last` runs; `keepEnv` records names only, never values
+- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`,
+  `timeout`, `aborted`), absent on `completed`, `commandcode_unavailable`, and launch failures
+- `error` — present on a launch failure, on `timeout` and `aborted` runs, and when Command Code
+  reported a non-success result of its own
+
+The helper also prints a summary to stdout and exits with Command Code's exit code, so a wrapping
+script can branch on success/failure directly.
+
+## The tail is not reliable — read `resultLine`
+
+`cmd` ends a run with a `run_end` event that embeds the **entire conversation** — every tool call,
+its arguments, and its result — and then exits with `process.exit`, which discards whatever is still
+queued in its stdout pipe. On any run big enough to matter, the tail therefore arrives cut mid-write
+and the `result` line after it never lands. Successful live write runs have lost the result line,
+either truncating `run_end` or dropping the rest of the stream. A synthetic writer that exits the
+same way loses the stream down to whatever fits the OS
+pipe buffer, no matter how fast the reader is — so this is the CLI's flush behavior, not the relay's
+read speed (the relay batches its event-log writes precisely so it drains as fast as it can).
+
+What the relay does about it, and what it means for you:
+
+- Nothing load-bearing is read from the tail. `sessionId` comes from `run_start`, the **first** line of
+  the stream, so resume always works. The report is taken from the last `message_end`, falling back to
+  the streamed `text_delta`s of a message whose `message_end` was lost.
+- `resultLine` tells you which case you got. Under `truncated` or `absent`, `resultSubtype`,
+  `stopReason`, `usage`, and `durationMs` are `null` because the CLI never delivered them — not because
+  the run lacked them. The summary prints a note saying so.
+- `finalMessage` can still come back short or empty when the report itself was in the discarded
+  region. **The diff is the deliverable, not the report** — review `touchedFiles` and `git diff`, and
+  treat a thin report as missing information rather than as a failed run.
+- Read-only runs are small and usually keep a `complete` result line, so the second-opinion use is
+  unaffected.
+
+When a complete result line arrives, `status: "completed"` requires exit 0 and
+`resultSubtype: "success"`; any other subtype is reported as failed with exit 1. When the result line
+is truncated or absent, the relay falls back to the process exit code: exit 0 is completed and a
+non-zero exit is failed. In that fallback case, read `resultLine` and review the diff because the
+missing subtype cannot prove the task finished.
+
+## Waiting for completion
+
+The helper blocks until Command Code finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh, or your shell's equivalent (`Start-Job` in PowerShell). A run is done when
+  `result.json` exists with a `status`. **But** a pre-run usage error (bad args, empty brief) exits with
+  code 2 *before* writing any file — so check the exit code too, don't only watch for the file. (A
+  missing binary exits 127 but *does* write a `result.json` with status `commandcode_unavailable`.)
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## When a run misbehaves
+
+- **`status: commandcode_unavailable` (exit 127):** the binary isn't on PATH. Install Command Code, run
+  `cmd login`, or set `COMMANDCODE_BIN`, then re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `cmd --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
+  Command Code was never dispatched; only the relay's own artifacts may already exist under
+  `--out-dir`. Check the install by running `cmd --version` yourself.
+- **`status: failed` at exit 3:** not authenticated. `cmd login`, then re-dispatch.
+- **`status: failed` at exit 5 or 10:** rate limited, or out of credits. Wait, lower the model tier, or
+  top up — the relay's summary names which.
+- **`status: failed` with `stopReason: max_turns`:** the run hit the turn cap mid-task. If Command Code exited 0, the relay exits 1; otherwise it preserves the non-zero child exit. The
+  tree may hold a half-applied change. Inspect it, then either raise `--max-turns` and re-dispatch, or
+  split the brief.
+- **`status: failed` at exit 0→1 with an `error` about subtype:** Command Code ended the run cleanly
+  without succeeding. The usual cause is a write-capable task dispatched `--read-only`, where the report
+  says the tools were refused. Re-dispatch without `--read-only`.
+- **`status: failed` otherwise:** read `result.json`'s `stderrTail` and the tail of `eventsPath`. Common
+  causes: an invalid `--model`, an unsupported `--effort` for the selected model, or a network lapse.
+  Fix the cause and re-dispatch; don't paper over it by doing the work yourself unless that's what the
+  user wants.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a resume.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a closed
+  terminal) and forwarded the kill to `cmd`. The result is written before the relay exits; inspect the
+  working tree before re-dispatching. On native Windows a hard kill of the relay is uncatchable (Node
+  supports no `SIGTERM` handler there), so this status may never get written — a relay process that is
+  gone without a `result.json` is an aborted run; inspect the working tree and `events.jsonl` directly.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer or
+  a supervisor timeout, not an implementer error. Free up host memory or split the task into smaller
+  briefs, then re-dispatch.
+- **`readOnlyViolation: true`:** the tripwire detected a Git-visible change during a `--read-only`
+  run. It cannot attribute a concurrent change to Command Code, but its read-only state is a permission
+  layer rather than an OS sandbox. Review the diff and report the warning before doing anything else.
+- **Empty `finalMessage`:** this is missing information, not a separate failure state. Read `status`
+  and `resultLine`; when the result line is truncated or absent, inspect the event log and diff before
+  landing.
+
+## Recovering lost work
+
+`events.jsonl` records every NDJSON line Command Code streamed, and its `run_end` event embeds the
+whole conversation — every tool call, its arguments, and its result. That makes the log both the map of
+what a lost run did and, for file writes, often a literal copy of the content it wrote. If finished work
+is lost — the run killed late, or the tree damaged afterward — read the event log before re-dispatching.
+The flip side of that completeness: the log contains whatever the run read or wrote, so treat it as
+sensitive as the repo itself, and note that it grows with the transcript (tens of KB for a trivial run,
+much more for a long one).
+
+## The commit boundary
+
+The helper never commits — by design, not omission. Under `--yolo` Command Code *can* write `.git`,
+which is the reason: a run that commits itself is a run you must unpick before you can review it. The
+robust contract is: Command Code edits the working tree, the orchestrator reviews and commits. See
+[review-and-land.md](review-and-land.md).

--- a/skills/commandcode-delegate/references/multi-task-queues.md
+++ b/skills/commandcode-delegate/references/multi-task-queues.md
@@ -1,0 +1,81 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+With Command Code there's a fourth reason, and it's the strongest: an implementation run has no
+filesystem sandbox. Two concurrent `--yolo` runs in one tree can interleave writes to the same file with
+nothing arbitrating between them, and the resulting diff belongs to neither task. If you do need
+parallelism, give each run its own tree — `git worktree add` per task, or a container — rather than
+running two of them side by side in the same checkout. Default to sequential.
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. Command Code has no memory of the earlier run, so a constraint that
+emerged in task 2 must be restated in task 5's brief or it won't hold. This is the queue equivalent of
+keeping briefs self-contained.
+
+(`--session` does carry one run's context into its own rework, but that's for reworking a single task —
+not a channel for handing task 2's discoveries to task 5. Each task in a queue gets a fresh dispatch.)
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions Command Code made, non-blocking nitpicks, any write that
+  landed outside the brief's paths, anything you want the human to overrule or confirm. This is the
+  section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Watch the per-task budget
+
+Each dispatch has its own turn cap (Command Code's default is 100; `--max-turns` overrides it) and its
+own `--timeout` if you set one. In a long queue those limits bite unevenly: the task in the middle that
+touches twenty files is the one that stops at `stopReason: max_turns` with a half-applied change. Size
+briefs so no single task needs the whole budget, and treat a capped task as an unfinished one — inspect
+the tree, then re-dispatch or split, rather than letting the queue move on past it.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/commandcode-delegate/references/review-and-land.md
+++ b/skills/commandcode-delegate/references/review-and-land.md
@@ -1,0 +1,144 @@
+# Review and land
+
+Command Code did the typing; you own the judgment. This is where delegation earns its keep or quietly
+ships a mistake. The discipline is simple to state and easy to skip under time pressure: **verify
+against reality, never against the self-report — and read the diff as generated code, which fails in
+ways a green gate can't see.**
+
+One thing to add to the usual routine here: the run had no sandbox. An implementation dispatch goes out
+under `--yolo`, so "did it stay inside the brief's paths?" is a question you answer from `touchedFiles`,
+not one the tooling answered for you.
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries Command Code's own claim that the gates passed. Treat that as a claim, not
+evidence — re-run the project's actual test/lint/build commands in the working tree and read the output.
+And keep the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a
+gate, not just misreport it — that is what the test check above and the sweep below exist to catch.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Out-of-scope writes** — this is the first check here, not an afterthought. Under `--yolo` there was
+  nothing stopping a write outside `--cd` or outside the paths the brief named. `touchedFiles` is a
+  `git status` review aid, not containment proof: it misses ignored files and anything outside the
+  repository. A worktree isolates the checkout but not the process. Use a container or another
+  OS-enforced boundary when writes outside the target tree are unacceptable.
+- **Scope creep** — did it change things the brief said to leave untouched? Unasked refactors, renames,
+  "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version? A `stopReason` of `max_turns` in `result.json` is a strong hint of a run that
+  stopped mid-task rather than finishing.
+- **Quiet judgment calls** — sometimes Command Code makes a defensible decision the brief didn't
+  anticipate. Don't just accept it because it looks reasonable; understand it and decide.
+- **A commit it made itself** — the brief forbids it, but nothing enforced that. Compare `HEAD` with
+  the pre-dispatch baseline, then inspect status, staged and unstaged diffs, and the intervening log.
+  If the whole range belongs to the run, `git reset --soft <recorded-baseline>` and review it as a diff.
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If Command Code couldn't implement
+  something, the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to Command Code as a delta brief (below) or gets fixed in the tree
+before commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never Command Code. This
+isn't a workaround for a missing feature; it's the deliberate boundary. Under `--yolo` Command Code is
+perfectly capable of committing, and that is precisely the problem: committing should be the act of the
+party that verified the work, and a self-committed run has to be unpicked before it can be reviewed.
+Write a clear message describing what landed. If your project attributes co-authorship, that's the place
+for it.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points —
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`, `git diff --cached`
+for anything the implementer staged (plain `git diff` is blind to the index), and open any untracked
+files (`??` in `git status`) directly — they are the implementer's new files, and no diff shows their
+contents. The tree is evidence, not clutter. After that inspection the verdict can legitimately be to
+discard — work built on a premise you have since corrected, for example — and then `git checkout`/`clean`
+is the right tool. The ban is on reflexive cleanup before anyone has looked.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same Command Code session
+with just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --session <sessionId> --cd /path/to/repo
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).
+`<sessionId>` is the field of that name from the prior `result.json`.)
+
+`--session <sessionId>` keeps the context from the first run, so a short delta is enough; use
+`--continue-last` only when no session id came back, since "most recent" is global and another run can
+steal it. Then review again — rework gets the same gate-rerun, test check, diff-read, and sweep as the
+original, no shortcuts. Repeat until it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** Command Code made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Report any write outside the brief's paths**, and any `readOnlyViolation: true` on a read-only
+  dispatch, even when the change itself looks harmless. Those say something about the run's containment,
+  which is the human's call to weigh, not yours to normalize.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or Command Code's.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/commandcode-delegate/references/writing-the-brief.md
+++ b/skills/commandcode-delegate/references/writing-the-brief.md
@@ -1,0 +1,147 @@
+# Writing the brief
+
+A brief is the entire task as Command Code will see it. It runs in a fresh process with **no memory of
+your conversation, no access to your prior notes, and no shared context** — only the text you send and
+whatever it can read from the working tree (including the repo's own `AGENTS.md`, which it picks up
+automatically, and any skills it discovers there).
+If a constraint isn't in the brief or discoverable in the repo, it doesn't exist for Command Code. The
+single most common failure is a brief that assumes context it doesn't have.
+
+## The shape that works
+
+Command Code responds best to compact, block-structured prompts with XML tags rather than long prose.
+State the task, what "done" looks like, how to behave by default, and the few constraints that actually
+matter. Add a block only when the task needs it — don't ship empty ceremony.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps Command Code
+from wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
+  inferences) and run with `--read-only` so the write, edit, and shell tools stay withheld.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Path discipline is scope guidance
+
+An implementation run goes out under `--yolo`, which means no filesystem boundary: Command Code can
+write anywhere the process can reach, not just under `--cd`. Name the files or directories it may
+change, say plainly that everything else is off limits, and keep `<action_safety>` in every
+write-capable brief. That is guidance, not a sandbox. A worktree isolates the checkout but does not
+contain the process; use a container or another OS-enforced boundary when writes outside the target
+tree are unacceptable. `touchedFiles` is only a review aid: it cannot show ignored files or writes
+outside the repository.
+
+## `git commit` is not blocked, only forbidden
+
+Sibling delegates can rely on a sandbox refusing to write `.git`. This one cannot: under `--yolo`,
+Command Code can commit, so the brief has to tell it not to. Record `HEAD` before dispatch and keep the
+"do NOT run git add or git commit" line. If `HEAD` changed, inspect status, staged and unstaged diffs,
+and the intervening log first. Only after confirming the whole commit range belongs to the run, use
+`git reset --soft <recorded-baseline>` so you can review that range as a diff.
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`AGENTS.md` / `CLAUDE.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you an implementer that guesses — or skips.
+
+## Honor the repo's conventions
+
+Command Code reads the repo's `AGENTS.md` automatically, so house rules there (style, forbidden
+patterns, commit conventions) already apply. If the project forbids certain things in code — say,
+spec/ticket IDs in comments, process language like "MVP"/"for now"/"phase N", or specific test
+conventions, whatever the repo's own conventions ban — restate the load-bearing ones in the brief too,
+because compliance is only as reliable as what's in front of it.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and
+suggest a roadmap" produces a muddled run; split it into separate dispatches. One brief → one run →
+one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+
+Turns are capped (Command Code's own default is 100; `--max-turns` changes it). A brief bundling four
+jobs is also the brief most likely to hit that cap and stop mid-way, reported as `stopReason:
+max_turns` with a half-finished tree.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## Expect environment preamble in the reply
+
+The final message may carry environment noise on top of your requested report — a banner injected by
+the repo's `AGENTS.md`, extra text from an MCP server or skill you have configured locally, taste
+notes from Command Code's own learning. That comes from your setup, not a relay defect. The
+`<structured_output_contract>` is your defense: ask for a clearly delimited report section so you can
+find the real output regardless of what wraps it.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout (the idempotency key isn't checked before re-submitting). Make the refund
+submission idempotent: check for an existing refund by idempotency key before creating a new one.
+Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes, and the
+data models untouched, and do not write outside services/billing/.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/commandcode-delegate/scripts/relay.mjs
+++ b/skills/commandcode-delegate/scripts/relay.mjs
@@ -1,0 +1,1297 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · commandcode-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Command Code CLI (`cmd -p`), capture
+ * the run, and write a structured result the orchestrating agent can review.
+ * The orchestrator runs this one command and reads the result JSON — every
+ * Command Code-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Shell-capable agents use the same file contract.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `cmd` and `git`. The `cmd` process it launches
+ * does authenticate — exactly as you do at the terminal. Read this file before
+ * you run it.
+ *
+ * Autonomy, in Command Code's own terms: a `-p` run withholds the write, edit,
+ * and shell tools and there is no prompt to grant them mid-run, so the CLI
+ * offers exactly two headless states. Without `--yolo` the agent can read, grep,
+ * and glob but every write is refused by its permission layer. With `--yolo`
+ * (alias `--dangerously-skip-permissions`) every tool is allowed, everywhere the
+ * process can reach. There is no filesystem sandbox and no middle setting:
+ * `--permission-mode auto-accept` and `--tools-all` do NOT lift the headless
+ * write gate (verified — both were refused). So this relay passes `--yolo` for
+ * implementation runs and omits it (adding `--permission-mode plan`) for
+ * `--read-only`. That read-only guarantee is the CLI's own permission layer, not
+ * an OS sandbox. The relay also reports a Git-visible change tripwire through
+ * `readOnlyViolation`; ignored and outside-repository paths remain outside it.
+ *
+ * It deliberately does NOT commit. Committing belongs to the reviewer, after it
+ * reads the diff and re-runs the project gates.
+ *
+ * Windows: the Command Code binary is named `cmd`, which collides with the
+ * system `cmd.exe`. Rather than risk driving a shell with your brief, the relay
+ * refuses to guess there — set COMMANDCODE_BIN to the real binary's absolute path,
+ * never the system command interpreter.
+ * That path must be a real executable: this relay never launches through a
+ * shell, so a `.cmd`/`.bat` wrapper cannot start. Windows is untested here.
+ * The same variable overrides the binary on any platform when several installs
+ * compete.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for Command Code (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Model for this run, e.g. vendor/model (default: Command Code's own).
+ *                           `cmd --list-models` shows what is available to your account.
+ *   --effort <level>        Reasoning effort — low | medium | high, model-dependent
+ *                           (default: Command Code's own configured effort).
+ *   --read-only             Withhold write/edit/shell tools: no --yolo, plus --permission-mode plan.
+ *                           For review and diagnosis. Enforced by the CLI's permission layer, and
+ *                           followed by a Git-visible readOnlyViolation tripwire.
+ *   --tools-all             Also pass --tools-all, so no tool stays withheld. Ignored under
+ *                           --read-only (it does not lift the write gate anyway).
+ *   --max-turns <n>         Cap conversation turns (default: Command Code's own, 100).
+ *                           Command Code may exit 0 at the cap; a complete max_turns result
+ *                           makes the relay report failure and exit 1.
+ *   --session <id>          Continue a specific session by id (the sessionId from a prior
+ *                           result.json); send only the delta brief. Mutually exclusive
+ *                           with --continue-last.
+ *   --continue-last         Continue the most recent Command Code session; send only the delta
+ *                           brief. "Most recent" is global, not per-repo, so another run can
+ *                           steal it — prefer --session.
+ *   --clean-env             Launch Command Code and its version preflight with only runtime basics.
+ *                           Changes inherited variables only; does not protect files or other
+ *                           same-user secrets.
+ *   --keep-env <name>       Keep one additional variable under --clean-env (repeatable).
+ *                           Required for environment-backed auth and other stripped variables.
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the cmd child is killed
+ *                           and result.json gets status "timeout". Command Code has no
+ *                           timeout flag of its own, so the watchdog is relay-only.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, outside the target repository).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, commandCodeVersion, sessionId (for a later --session),
+ *   resultLine plus resultSubtype/stopReason/usage from Command Code's own result
+ *   line, finalMessage (its report), touchedFiles (git porcelain, null if git
+ *   can't report), readOnlyViolation, and the paths to events.jsonl and final.txt.
+ *
+ * A caveat that shapes the parsing: cmd's `run_end` event embeds the entire
+ * conversation, so on a real run the tail of the stream exceeds a pipe buffer and
+ * cmd exits without waiting for it to drain — the tail arrives cut mid-write and
+ * the result line after it is simply lost in live runs. `resultLine`
+ * reports which happened ("complete" | "truncated" | "absent"), and everything
+ * load-bearing is read from the small early events instead: sessionId from
+ * `run_start`, the report from the last `message_end`.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `cmd` binary exits 127;
+ * otherwise the relay preserves Command Code's non-zero exit code. A run that
+ * exits 0 while its own complete result line reports any non-success subtype is
+ * reported failed with exit 1 — Command Code can end a run cleanly with the task unfinished.
+ * Where that line was truncated or lost, exit 0 is taken at face value: cmd still
+ * exits non-zero for the failures that matter.
+ * If the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, timeout (the --timeout watchdog fired), aborted (the relay
+ * itself was killed and forwarded the kill to cmd), or commandcode_unavailable. An
+ * orchestrator that polls for the file must therefore also treat a non-zero exit
+ * with no file as a usage error.
+ */
+
+import { spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { createHash, randomBytes } from "node:crypto";
+import { StringDecoder } from "node:string_decoder";
+import { TextDecoder } from "node:util";
+
+const MAX_BUFFERED_CHARS = 1_048_576;
+// Batch size for the event log; small enough to bound memory, large enough that the
+// stdout pipe keeps draining while we write.
+const EVENT_FLUSH_CHARS = 262_144;
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_TIMER_MS = 2_147_483_647;
+const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+// Command Code model ids are vendor/name slugs. Keep in lockstep
+// with delegate-setup MODEL_TOKEN.shellSafe.
+const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+const PRIVATE_FILE_MODE = 0o600;
+
+const IMPLEMENTER_KEY = "commandcode";
+// `cmd` is Command Code's binary name; COMMANDCODE_BIN overrides it (and is required
+// on Windows, where the name collides with cmd.exe).
+const CONFIGURED_BIN = process.env.COMMANDCODE_BIN || null;
+const BIN = CONFIGURED_BIN && /[\\/]/.test(CONFIGURED_BIN)
+  ? resolve(CONFIGURED_BIN)
+  : CONFIGURED_BIN || "cmd";
+
+// Command Code's documented headless exit codes, for a summary hint that points at the
+// actual cause instead of a bare number.
+const EXIT_HINTS = new Map([
+  [3, "not authenticated — run `cmd login`, then re-dispatch"],
+  [4, "permission denied — an implementation run needs write access; this relay passes --yolo unless --read-only was set"],
+  [5, "rate limit exceeded — wait and re-dispatch, or lower the model tier"],
+  [6, "network failure — check connectivity and re-dispatch"],
+  [7, "Command Code API server error (5xx) — transient; re-dispatch"],
+  [8, "hit the turn cap — raise --max-turns or split the brief into smaller tasks"],
+  [9, "the model produced no response — re-dispatch, and check the brief is not empty of instruction"],
+  [10, "insufficient credits — top up the account, then re-dispatch"],
+]);
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function executablePathKey(path) {
+  try { return realpathSync.native(path).toLowerCase(); }
+  catch { return resolve(path).toLowerCase(); }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    effort: null,
+    readOnly: false,
+    toolsAll: false,
+    maxTurns: null,
+    session: null,
+    continueLast: false,
+    cleanEnv: false,
+    keepEnv: [],
+    timeout: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--effort": opts.effort = next(); flagged.add("effort"); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--tools-all": opts.toolsAll = true; break;
+      case "--max-turns": opts.maxTurns = next(); break;
+      case "--session": opts.session = next(); break;
+      case "--continue-last": opts.continueLast = true; break;
+      case "--clean-env": opts.cleanEnv = true; break;
+      case "--keep-env": opts.keepEnv.push(next()); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.effort !== null && !/^[a-z][a-z0-9-]*$/i.test(opts.effort)) {
+    fail(`invalid --effort "${opts.effort}" (expected a non-empty bare token)`);
+  }
+  if (opts.model !== null && !SAFE_MODEL.test(opts.model)) {
+    fail("--model contains unsupported characters (allowed: letters, digits, . _ : / -)");
+  }
+  if (opts.maxTurns !== null && !/^[1-9][0-9]{0,4}$/.test(String(opts.maxTurns))) {
+    fail(`invalid --max-turns "${opts.maxTurns}" (expected a positive integer up to 99999)`);
+  }
+  if (opts.keepEnv.length && !opts.cleanEnv) {
+    fail("--keep-env requires --clean-env");
+  }
+  const invalidEnvName = opts.keepEnv.find((name) => !SAFE_ENV_NAME.test(name));
+  if (invalidEnvName) {
+    fail(`invalid --keep-env "${invalidEnvName}" (expected an environment variable name)`);
+  }
+  const missingEnvName = opts.keepEnv.find((name) => process.env[name] === undefined);
+  if (missingEnvName) {
+    fail(`--keep-env "${missingEnvName}" is not set`);
+  }
+  // The watchdog is relay-only (Command Code has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  if (opts.session !== null && opts.continueLast) {
+    fail("--session and --continue-last are mutually exclusive; pass only one");
+  }
+  if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
+    fail("--session must be a session id (letters, digits, . _ : -)");
+  }
+  if (process.platform === "win32") {
+    if (!CONFIGURED_BIN || !isAbsolute(CONFIGURED_BIN)) {
+      fail("on Windows COMMANDCODE_BIN must be the absolute path of the Command Code executable");
+    }
+    const comspec = process.env.ComSpec || process.env.COMSPEC;
+    if (comspec && executablePathKey(BIN) === executablePathKey(comspec)) {
+      fail("COMMANDCODE_BIN points to the Windows command interpreter; set it to the Command Code executable");
+    }
+  }
+  return opts;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to cmd -p\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once cmd is running, so the preflight needs a bound of
+  // its own: a `cmd --version` that never returns would wedge the relay here, before
+  // any result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function commandCodeEnv(opts) {
+  if (!opts.cleanEnv) return process.env;
+  const keep = ["PATH", "HOME", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "LC_CTYPE", "TERM",
+    "TMPDIR", "COMMANDCODE_BIN", "SystemRoot", "SystemDrive", "USERPROFILE", "APPDATA", "LOCALAPPDATA",
+    "TEMP", "TMP", "PATHEXT", "COMSPEC", ...opts.keepEnv];
+  return Object.fromEntries(keep.filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]]));
+}
+
+async function commandCodeVersion(probeTimeoutMs, env, onChild) {
+  // Never launched through a shell — on Windows that would route the name `cmd` straight
+  // to cmd.exe. parseArgs requires COMMANDCODE_BIN there, and it must name a real
+  // executable: a .cmd/.bat wrapper cannot be started without the shell this relay refuses.
+  const probe = await new Promise((resolveProbe) => {
+    const child = spawn(BIN, ["--version"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+      detached: process.platform !== "win32",
+      env,
+    });
+    onChild(child);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let timer = null;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolveProbe({ stdout, stderr, ...result });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => finish({ code: null, error, timedOut: false }));
+    child.on("close", (code) => finish({ code, error: null, timedOut }));
+    timer = setTimeout(() => {
+      timedOut = true;
+      killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+    }, probeTimeoutMs);
+  });
+  if (probe.timedOut) {
+    return { version: null, error: Object.assign(new Error(`${BIN} --version timed out`), { code: "ETIMEDOUT", stderr: probe.stderr }) };
+  }
+  if (probe.error?.code === "ENOENT") return { version: null, error: null };
+  if (probe.error) return { version: null, error: probe.error };
+  if (probe.code !== 0) {
+    return { version: null, error: Object.assign(new Error(`${BIN} --version failed`), { status: probe.code, stderr: probe.stderr }) };
+  }
+  return { version: probe.stdout.trim() || "unknown", error: null };
+}
+
+// Command Code's read-only state is its own permission layer, not an OS sandbox, so the
+// claim gets checked rather than trusted — the same tripwire claude-delegate and
+// grok-delegate carry, and byte-identical to theirs by contract.
+// Porcelain status alone cannot see every write. A path that is " M file" before a run and
+// " M file" after it produces an identical line, so comparing status lines proves nothing about
+// its contents — which is why the read-only tripwire below fingerprints the already-dirty paths
+// as well. Two sentinels stand for "could not fingerprint"; they are never treated as unchanged.
+const FINGERPRINT_UNREADABLE = "<unreadable>";
+const FINGERPRINT_DIRECTORY = "<directory>";
+
+function gitRepoRoot(cwd) {
+  // Porcelain paths are relative to the repository ROOT, not to the directory git ran in
+  // (--porcelain forces status.relativePaths off). Joining them against a --cd that is a
+  // subdirectory would look for <repo>/src/src/file and find nothing at either end.
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).replace(/\n$/, "") || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitStatusEntries(cwd) {
+  // -z so a path containing a space, a quote, or a newline stays one field rather than being
+  // quoted and escaped; -uall so an untracked directory is expanded into its files, because a
+  // collapsed "?? dir/" line never changes when a file inside it does.
+  try {
+    const output = execFileSync("git", ["status", "--porcelain", "-z", "-uall"], {
+      cwd,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const fields = new TextDecoder("utf-8", { fatal: true }).decode(output)
+      .split("\0").filter((field) => field.length > 0);
+    const entries = [];
+    for (let i = 0; i < fields.length; i += 1) {
+      const entry = fields[i];
+      const status = entry.slice(0, 2);
+      const path = entry.slice(3);
+      // R and C can sit in EITHER status column, and under -z such an entry is followed by its
+      // origin path as its own unprefixed field. Consume that field in both cases. A rename
+      // origin belongs in the dirty set (the file moved away from it); a copy origin does not,
+      // since a copy source can be a perfectly clean file.
+      const renamed = status.includes("R");
+      const copied = status.includes("C");
+      let origin = null;
+      if (renamed || copied) {
+        i += 1;
+        origin = fields[i] ?? null;
+      }
+      entries.push({ status, path, origin });
+    }
+    return entries;
+  } catch {
+    return null;
+  }
+}
+
+function dirtyPaths(cwd) {
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const paths = [];
+  for (const entry of entries) {
+    paths.push(entry.path);
+    if (entry.status.includes("R") && entry.origin !== null) paths.push(entry.origin);
+  }
+  return paths;
+}
+
+function asciiFold(value) {
+  return value.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+}
+
+function canonicalFilePath(path) {
+  const absolute = resolve(path);
+  let parent;
+  try { parent = realpathSync.native(dirname(absolute)); } catch { return absolute; }
+  const leaf = basename(absolute);
+  const canonical = join(parent, leaf);
+  try { lstatSync(canonical); } catch { return canonical; }
+  try {
+    const entries = readdirSync(parent);
+    if (entries.includes(leaf)) return canonical;
+    const matches = entries.filter((entry) => asciiFold(entry) === asciiFold(leaf));
+    return join(parent, matches.length === 1 ? matches[0] : leaf);
+  } catch {
+    return canonical;
+  }
+}
+
+function gitPathKey(root, path) {
+  let canonicalRoot;
+  try { canonicalRoot = realpathSync.native(root); } catch { canonicalRoot = resolve(root); }
+  const key = relative(canonicalRoot, canonicalFilePath(path));
+  return process.platform === "win32" ? key.replaceAll("\\", "/") : key;
+}
+
+function gitPathIsExcluded(root, path, excluded, foldedExcluded) {
+  return excluded.has(path) ||
+    (foldedExcluded.has(asciiFold(path)) && excluded.has(gitPathKey(root, join(root, path))));
+}
+
+function gitTripwireState(cwd, excludedPaths) {
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return entries.flatMap((entry) => [
+    [entry.status, "path", entry.path],
+    ...(entry.origin === null ? [] : [[entry.status.replace(/[^RC]/g, " "), "origin", entry.origin]]),
+  ]
+    .filter(([, , path]) => !gitPathIsExcluded(root, path, excluded, foldedExcluded)));
+}
+
+function pathFingerprint(absolutePath) {
+  // Identity, not just bytes: a retargeted symlink, a flipped mode bit, or a file replaced by a
+  // directory are all writes, and none of them change file contents.
+  let stats;
+  try {
+    stats = lstatSync(absolutePath);
+  } catch (error) {
+    // Absence is a state, not a failure - it differs from every real fingerprint, so a deletion
+    // or a re-creation still registers. Any other errno means we genuinely cannot tell.
+    return error && error.code === "ENOENT" ? "absent" : FINGERPRINT_UNREADABLE;
+  }
+  if (stats.isSymbolicLink()) {
+    try {
+      return `symlink:${readlinkSync(absolutePath, { encoding: "buffer" }).toString("hex")}`;
+    } catch {
+      return FINGERPRINT_UNREADABLE;
+    }
+  }
+  // A directory in the dirty set is a submodule, whose contents belong to another repository.
+  // Reported as unknown coverage rather than silently passed off as unchanged.
+  if (stats.isDirectory()) return FINGERPRINT_DIRECTORY;
+  if (!stats.isFile()) return FINGERPRINT_UNREADABLE;
+  let fd;
+  try {
+    // Streamed rather than read whole: an unignored multi-gigabyte artifact must not be pulled
+    // into memory just to answer whether it changed.
+    const hash = createHash("sha256");
+    fd = openSync(absolutePath, "r");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    for (;;) {
+      const read = readSync(fd, buffer, 0, buffer.length, null);
+      if (read <= 0) break;
+      hash.update(buffer.subarray(0, read));
+    }
+    return `file:${(stats.mode & 0o7777).toString(8)}:${hash.digest("hex")}`;
+  } catch {
+    return FINGERPRINT_UNREADABLE;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* already closed */ }
+    }
+  }
+}
+
+function gitIndexFingerprints(root, paths) {
+  if (paths.length === 0) return new Map();
+  try {
+    const output = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const wanted = new Set(paths);
+    const prints = new Map(paths.map((path) => [path, []]));
+    for (const field of new TextDecoder("utf-8", { fatal: true }).decode(output).split("\0")) {
+      if (!field) continue;
+      const separator = field.indexOf("\t");
+      if (separator === -1) return null;
+      const path = field.slice(separator + 1);
+      if (wanted.has(path)) prints.get(path).push(field.slice(0, separator));
+    }
+    return prints;
+  } catch {
+    return null;
+  }
+}
+
+function fingerprintPaths(root, paths) {
+  // `complete` goes false the moment one path cannot be fingerprinted, so the caller reports
+  // "unknown" instead of an unearned clean bill of health.
+  const indexPrints = gitIndexFingerprints(root, paths);
+  const prints = new Map();
+  let complete = indexPrints !== null;
+  for (const path of paths) {
+    const file = pathFingerprint(join(root, path));
+    if (file === FINGERPRINT_UNREADABLE || file === FINGERPRINT_DIRECTORY) complete = false;
+    prints.set(path, { file, index: indexPrints?.get(path) ?? null });
+  }
+  return { prints, complete };
+}
+
+function fingerprintDirtyPaths(cwd, excludedPaths) {
+  // Only the already-dirty set is covered. A path that is clean at dispatch and gets written
+  // surfaces as a brand-new porcelain line anyway, and fingerprinting a whole repository per run
+  // would cost far more than the case it covers.
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const paths = dirtyPaths(cwd);
+  if (paths === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return {
+    root,
+    ...fingerprintPaths(root, paths.filter((path) => !gitPathIsExcluded(root, path, excluded, foldedExcluded))),
+  };
+}
+
+function changedDirtyPaths(before) {
+  // Re-fingerprint exactly the baseline paths, not whatever happens to be dirty now: a path the
+  // run newly dirtied is already reported by the porcelain comparison, and letting an unreadable
+  // one of those blind this signal would be a regression, not caution.
+  if (!before) return { changed: [], complete: false };
+  const now = fingerprintPaths(before.root, [...before.prints.keys()]);
+  const changed = [];
+  for (const [path, print] of before.prints) {
+    const current = now.prints.get(path);
+    const fileKnown = print.file !== FINGERPRINT_UNREADABLE && current.file !== FINGERPRINT_UNREADABLE;
+    const fileChanged = fileKnown &&
+      !(print.file === FINGERPRINT_DIRECTORY && current.file === FINGERPRINT_DIRECTORY) &&
+      current.file !== print.file;
+    const indexChanged = print.index !== null && current.index !== null &&
+      JSON.stringify(current.index) !== JSON.stringify(print.index);
+    if (fileChanged || indexChanged) changed.push(path);
+  }
+  return { changed: changed.sort(), complete: before.complete && now.complete };
+}
+
+function readOnlyVerdict(beforeTree, afterTree, beforeFingerprints) {
+  // Three-valued on purpose. Proof of a write settles it even when the other signal is unknown;
+  // only when nothing is proven AND coverage is incomplete is the answer genuinely unknown.
+  // Collapsing that last case to false is the false assurance a tripwire must never give.
+  const changed = changedDirtyPaths(beforeFingerprints);
+  const porcelainMoved =
+    beforeTree !== null && afterTree !== null && JSON.stringify(beforeTree) !== JSON.stringify(afterTree);
+  if (porcelainMoved || changed.changed.length > 0) return true;
+  if (beforeTree === null || afterTree === null || !changed.complete) return null;
+  return false;
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function buildArgv(opts) {
+  // -p with no query argument: Command Code auto-detects the piped brief on stdin.
+  // Order matters — an unrecognized flag is read as the optional -p query and the CLI
+  // rejects the run with "too many arguments", so only known flags go in here.
+  const argv = ["-p", "--output-format", "json", "--skip-onboarding", "--no-auto-update", "-t"];
+  if (opts.readOnly) {
+    // No --yolo: the write, edit, and shell tools stay withheld. Plan mode is the
+    // CLI's own name for read-only and makes the intent visible in its transcript.
+    argv.push("--permission-mode", "plan");
+  } else {
+    // The only headless setting that enables edits. --permission-mode auto-accept and
+    // --tools-all do not lift the gate; verified in direct CLI probes.
+    argv.push("--yolo");
+    if (opts.toolsAll) argv.push("--tools-all");
+  }
+  if (opts.session) argv.push("--resume", opts.session);
+  else if (opts.continueLast) argv.push("--continue");
+  if (opts.model) argv.push("-m", opts.model);
+  if (opts.effort !== null) argv.push("--effort", opts.effort);
+  if (opts.maxTurns !== null) argv.push("--max-turns", String(opts.maxTurns));
+  return argv;
+}
+
+/**
+ * Command Code streams NDJSON: `{"type":"event",…}` lines, then one
+ * `{"type":"result",…}` line carrying finalText, sessionId, subtype, stopReason,
+ * and usage.
+ *
+ * That tail cannot be relied on. The `run_end` event just before it embeds the
+ * entire conversation — every tool call, argument, and result — so on a real run
+ * it is far larger than a pipe buffer, and cmd exits without waiting for the
+ * write to drain: the tail arrives cut mid-string and the result line never
+ * lands at all, as observed in live runs.
+ * So everything load-bearing is taken from the small early events instead —
+ * `run_start` carries the sessionId as the very first line, and each
+ * `message_end` carries that message's text blocks, the last of which is the
+ * report. The result line is still parsed when it survives, because its subtype
+ * is the only place a clean-exit failure is named.
+ */
+function scanEventLine(line, state) {
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    return; // progress noise, or a partial line; events.jsonl keeps it either way
+  }
+  const inner = event?.event;
+  for (const candidate of [event?.sessionId, inner?.sessionId, inner?.result?.nextState?.sessionId]) {
+    if (typeof candidate === "string" && candidate) state.sessionId = candidate;
+  }
+  // Streamed text, kept per message: the report often arrives as deltas long before
+  // the message_end that collects them, and on a cut stream the deltas are all there is.
+  if (inner?.type === "message_start") state.deltas = [];
+  if (inner?.type === "text_delta" && typeof inner.delta === "string") state.deltas.push(inner.delta);
+  if (inner?.type === "text_end" && typeof inner.text === "string" && inner.text.trim()) {
+    state.lastText = inner.text.trim();
+  }
+  // The report as the model actually sent it, before the oversized tail.
+  if (inner?.type === "message_end" && Array.isArray(inner.content)) {
+    const text = inner.content
+      .filter((block) => block?.type === "text" && typeof block.text === "string")
+      .map((block) => block.text)
+      .join("\n")
+      .trim();
+    if (text) state.lastText = text;
+  }
+  if (event?.type !== "result") return;
+  state.result = {
+    subtype: typeof event.subtype === "string" ? event.subtype : null,
+    stopReason: typeof event.stopReason === "string" ? event.stopReason : null,
+    usage: event.usage ?? null,
+    durationMs: Number.isFinite(event.durationMs) ? event.durationMs : null,
+    finalText: typeof event.finalText === "string" ? event.finalText : "",
+    error: typeof event.error === "string" ? event.error : null,
+  };
+}
+
+/**
+ * Buffer the event log instead of appending per line, because reading speed decides
+ * how much of the stream survives. cmd ends with `process.exit`, which discards
+ * whatever is still queued in the stdout pipe, so a relay that blocks on a
+ * synchronous write for every line loses the tail: appending each of ~2000 lines
+ * individually kept only 51 of them in a reproduction, while buffering keeps the
+ * whole stream. Lines are parsed in memory as they arrive and flushed in batches.
+ */
+function recordEventLine(run, line, state) {
+  state.pending.push(line, "\n");
+  state.pendingChars += line.length + 1;
+  if (state.pendingChars >= EVENT_FLUSH_CHARS) flushEvents(run, state);
+  scanEventLine(line, state);
+}
+
+function flushEvents(run, state) {
+  if (state.pending.length === 0) return;
+  const batch = state.pending.join("");
+  state.pending = [];
+  state.pendingChars = 0;
+  try {
+    appendFileSync(run.eventsPath, batch, "utf8");
+  } catch {
+    // The log is a diagnostic aid; losing it must not lose the run's result.
+  }
+}
+
+/** The relay's own files, excluded from the read-only tripwire: --out-dir may sit inside the repo. */
+function relayArtifacts(run) {
+  return [run.briefPath, run.eventsPath, run.finalPath, run.resultPath];
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Keep relay artifacts outside the target repository so touchedFiles reports
+  // Command Code's Git-visible edits without the helper's own files.
+  const outDir = opts.outDir || mkdtempSync(join(tmpdir(), "delegate-relay-"));
+  if (opts.outDir) mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    eventsPath: join(outDir, "events.jsonl"),
+    finalPath: join(outDir, "final.txt"),
+    briefPath: join(outDir, "brief.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  const paths = [run.finalPath, run.resultPath, run.briefPath, run.eventsPath];
+  if (basename(canonicalFilePath(run.resultPath)) !== basename(run.resultPath)) {
+    fail("--out-dir contains a case-aliased result.json artifact");
+  }
+  let entries = [];
+  try { entries = readdirSync(outDir); } catch { /* the writers report an unusable output directory */ }
+  const collides = paths.some((path) => entries.includes(basename(path)));
+  if (collides) {
+    let priorRun = false;
+    try {
+      priorRun = lstatSync(run.resultPath).isFile() &&
+        JSON.parse(readFileSync(run.resultPath, "utf8")).schema === "delegate-relay.result.v1";
+    } catch { /* an absent, malformed, or linked marker is not reusable */ }
+    if (!priorRun) fail("--out-dir contains relay artifacts without a prior delegate-relay.result.v1 result");
+  }
+  // Exact relay files may be reused, but no stale artifact endpoint may survive:
+  // final.txt is written after dispatch and would otherwise follow its symlink.
+  for (const path of paths) {
+    if (!entries.includes(basename(path))) continue;
+    try {
+      const artifact = lstatSync(path);
+      if (artifact.isFile() || artifact.isSymbolicLink()) {
+        rmSync(path, { force: true });
+      }
+    } catch { /* the writer will report an unusable artifact path */ }
+  }
+  // Exclusive creation closes the cleanup-to-write race and refuses a
+  // differently cased endpoint on case-insensitive filesystems.
+  writeFileSync(run.briefPath, brief, { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
+  writeFileSync(run.eventsPath, "", { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
+  return run;
+}
+
+function makeResultWriter(opts, version, run, beforeTree, beforeFingerprints) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary. It also owns the
+  // read-only verdict, so every outcome path — completed, failed, timeout,
+  // aborted — gets a freshly measured one without threading it through.
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      workdir: opts.cd,
+      readOnly: opts.readOnly,
+      autonomy: opts.readOnly ? "plan (write/edit/shell withheld)" : "--yolo (all permissions bypassed)",
+      toolsAll: opts.readOnly ? false : opts.toolsAll,
+      model: opts.model,
+      effort: opts.effort,
+      maxTurns: opts.maxTurns === null ? null : Number(opts.maxTurns),
+      session: opts.session,
+      continueLast: opts.continueLast,
+      cleanEnv: opts.cleanEnv,
+      keepEnv: opts.keepEnv,
+      commandCodeVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      eventsPath: run.eventsPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      // Absent on write-capable runs would read as "not checked"; null says the
+      // question does not apply, and only --read-only replaces it with a verdict.
+      resultLine: null,
+      readOnlyViolation: null,
+      ...extra,
+    };
+    if (opts.readOnly) {
+      result.readOnlyViolation = readOnlyVerdict(
+        beforeTree,
+        gitTripwireState(opts.cd, relayArtifacts(run)),
+        beforeFingerprints,
+      );
+    }
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const resultContents = `${JSON.stringify(result, null, 2)}\n`;
+    let resultTemporary = null;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const resultCandidate = `${run.resultPath}.${process.pid}.${randomBytes(12).toString("hex")}.tmp`;
+      try {
+        writeFileSync(resultCandidate, resultContents, { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
+        resultTemporary = resultCandidate;
+        break;
+      } catch (error) {
+        if (error?.code !== "EEXIST") throw error;
+      }
+    }
+    if (resultTemporary === null) throw new Error("could not reserve a result.json temporary file");
+    try {
+      renameSync(resultTemporary, run.resultPath);
+    } catch (error) {
+      rmSync(resultTemporary, { force: true });
+      throw error;
+    }
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "commandcode_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    resultSubtype: null,
+    stopReason: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write(`relay: \`${BIN}\` not found on PATH. Install Command Code, run \`cmd login\`, or point COMMANDCODE_BIN at the binary.\n`);
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `${BIN} --version preflight timed out after ${probeTimeoutMs}ms; Command Code was not dispatched`
+    : `${BIN} --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Command Code was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    resultSubtype: null,
+    stopReason: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const child = getChild();
+      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: null,
+        resultSubtype: null,
+        stopReason: null,
+        usage: null,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the cmd version preflight; Command Code was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
+}
+
+function dispatchToCommandCode(opts, brief, run, writeResult, env) {
+  const argv = buildArgv(opts);
+  // detached on POSIX: the child leads a new process group so killChild can fell the whole tree.
+  const child = spawn(BIN, argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: false, detached: process.platform !== "win32", env });
+
+  const state = { sessionId: null, result: null, lastText: null, truncatedTail: false, deltas: [], pending: [], pendingChars: 0 };
+  let stdoutBuf = "";
+  const stderrTail = [];
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    stdoutBuf += stdoutDecoder.write(chunk);
+    let nl;
+    while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+      const line = stdoutBuf.slice(0, nl);
+      stdoutBuf = stdoutBuf.slice(nl + 1);
+      if (!line.trim()) continue;
+      recordEventLine(run, line, state);
+    }
+    // A run_end event embeds the whole transcript, so one line can be arbitrarily
+    // large. Flush it as a fragment rather than growing the buffer without bound;
+    // the fragment cannot be parsed, which is exactly what a truncated tail is.
+    if (stdoutBuf.length > MAX_BUFFERED_CHARS) {
+      recordEventLine(run, stdoutBuf, state);
+      stdoutBuf = "";
+      state.truncatedTail = true;
+    }
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk); // surface Command Code progress live for the orchestrator
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  // Command Code has no -o flag, so the report exists only in the event stream and
+  // the relay writes final.txt itself. Prefer the result line's finalText, and fall
+  // back to the last message_end text — which is the same report, delivered earlier
+  // and small enough to survive a truncated tail.
+  const persistFinal = () => {
+    // Last resort: the deltas of a message whose message_end never arrived.
+    const streamed = state.deltas.join("").trim();
+    const text = (state.result?.finalText || state.lastText || streamed || "").trim();
+    if (!text) return { text: "", error: null };
+    try {
+      // final.txt is deliberately created only once. This refuses a symlink or
+      // case-aliased endpoint introduced after prepareRunDir completed.
+      writeFileSync(run.finalPath, `${text}\n`, { encoding: "utf8", mode: PRIVATE_FILE_MODE, flag: "wx" });
+      return { text, error: null };
+    } catch (error) {
+      return { text, error: `could not safely create final.txt: ${error.code || error.message}` };
+    }
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        if (!settled) killChild(child, "SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the cmd child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      killChild(child);
+      try {
+        const touched = gitTouchedFiles(opts.cd);
+        flushEvents(run, state);
+        const final = persistFinal();
+        const abortedFields = {
+          status: "aborted",
+          exitCode: 128 + (constants.signals[sig] || 15),
+          signal: sig,
+          sessionId: state.sessionId,
+          resultSubtype: state.result?.subtype ?? null,
+          stopReason: state.result?.stopReason ?? null,
+          usage: state.result?.usage ?? null,
+          finalMessage: final.text,
+          touchedFiles: touched,
+          stderrTail: stderrTail.slice(-20),
+          error: final.error || `the relay was killed by ${sig}; cmd was terminated with it — inspect the working tree before re-dispatching`,
+        };
+        const result = writeResult(abortedFields);
+        printSummary(result, run.resultPath);
+        setTimeout(() => {
+          killChild(child, "SIGKILL");
+          // the child may flush files during the grace window; refresh the snapshot so the
+          // artifact matches the tree the orchestrator will actually find
+          const late = gitTouchedFiles(opts.cd);
+          writeResult({ ...abortedFields, touchedFiles: late });
+          process.exit(result.exitCode);
+        }, 2000);
+      } catch (error) {
+        killChild(child, "SIGKILL");
+        throw error;
+      }
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const touched = gitTouchedFiles(opts.cd);
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId: state.sessionId,
+      resultSubtype: null,
+      stopReason: null,
+      usage: null,
+      finalMessage: "",
+      touchedFiles: touched,
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    if (stdoutBuf.trim()) {
+      recordEventLine(run, stdoutBuf, state);
+      // Leftover bytes with no closing newline are a cut-off write, not a final line.
+      state.truncatedTail = true;
+    }
+    flushEvents(run, state);
+    const final = persistFinal();
+    // Command Code can exit 0 with its own result line reporting an error or a turn cap,
+    // so a clean process exit is not proof of a completed task where that line exists.
+    // Where it does NOT, the exit code is the authority: cmd truncates its oversized tail
+    // on exit, and treating that lost line as a failure would fail every large successful
+    // run. Non-zero child failures are still preserved, so nothing is waved through.
+    const cliOk = code === 0 && (state.result === null || state.result.subtype === "success");
+    const succeeded = cliOk && !watchdogFired && final.error === null;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const touched = gitTouchedFiles(opts.cd);
+    const cliError = state.result?.error
+      ? `Command Code reported ${state.result.subtype ?? "an error"}: ${state.result.error}`
+      : code === 0 && !cliOk
+        ? `Command Code exited 0 but reported subtype "${state.result.subtype}" (stopReason ${state.result.stopReason ?? "unknown"})`
+        : null;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
+      sessionId: state.sessionId,
+      // How much of the tail survived, so a consumer knows which fields are trustworthy:
+      // "complete" = the result line landed, "truncated" = it was cut off mid-write,
+      // "absent" = it never arrived. Under the last two, subtype/stopReason/usage are
+      // null because cmd never delivered them — not because the run lacked them.
+      resultLine: state.result !== null ? "complete" : state.truncatedTail ? "truncated" : "absent",
+      resultSubtype: state.result?.subtype ?? null,
+      stopReason: state.result?.stopReason ?? null,
+      usage: state.result?.usage ?? null,
+      durationMs: state.result?.durationMs ?? null,
+      finalMessage: final.text,
+      touchedFiles: touched,
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(final.error
+        ? { error: final.error }
+        : watchdogFired
+        ? { error: `cmd did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` }
+        : cliError
+          ? { error: cliError }
+          : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+
+  // If the child failed to launch, writing to its stdin can emit a stray 'error'
+  // on the pipe; the 'error' handler above owns that outcome, so swallow it here.
+  // Command Code caps its wait for piped stdin at 30s, so the brief goes in at once.
+  child.stdin.on("error", () => {});
+  child.stdin.write(brief);
+  child.stdin.end();
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
+  const run = prepareRunDir(opts, brief);
+  // Keep the preflight handler live while synchronous Git snapshots run. Node queues
+  // signals during those calls, so yield before publishing a completed baseline; an
+  // abort in that window must honestly report the read-only verdict as unknown.
+  let resultWriter = makeResultWriter(opts, null, run, null, null);
+  const writeResult = (extra) => resultWriter(extra);
+  let preflightChild = null;
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult, () => preflightChild);
+  const beforeTree = opts.readOnly ? gitTripwireState(opts.cd, relayArtifacts(run)) : null;
+  const beforeFingerprints = opts.readOnly ? fingerprintDirtyPaths(opts.cd, relayArtifacts(run)) : null;
+  await new Promise((resolveYield) => setImmediate(resolveYield));
+  resultWriter = makeResultWriter(opts, null, run, beforeTree, beforeFingerprints);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const env = commandCodeEnv(opts);
+  const probe = await commandCodeVersion(probeTimeoutMs, env, (child) => { preflightChild = child; });
+  resultWriter = makeResultWriter(opts, probe.version, run, beforeTree, beforeFingerprints);
+
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    clearPreflightSignals();
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+
+  clearPreflightSignals();
+  dispatchToCommandCode(opts, brief, run, writeResult, env);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  cmd ${result.commandCodeVersion ?? "?"}`);
+  const hint = EXIT_HINTS.get(result.exitCode);
+  if (hint && result.status === "failed") lines.push(`hint: ${hint}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a Command Code error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated cmd (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  lines.push(`autonomy: ${result.autonomy}`);
+  if (result.continueLast) lines.push("mode: continued most recent session");
+  if (result.session) lines.push(`mode: resumed session ${result.session}`);
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId})`);
+  if (result.resultLine === "truncated" || result.resultLine === "absent") {
+    lines.push(`note: cmd's result line was ${result.resultLine} (its oversized run_end tail is not flushed on exit), so subtype/usage are unavailable; the report and session id come from the earlier events.`);
+  }
+  if (result.resultSubtype && result.resultSubtype !== "success") {
+    lines.push(`Command Code result: ${result.resultSubtype}${result.stopReason ? ` (stopReason ${result.stopReason})` : ""}`);
+  }
+  if (result.readOnly) {
+    lines.push(result.readOnlyViolation === null
+      ? "read-only check: not verifiable (git could not report) — inspect the working tree directly"
+      : result.readOnlyViolation
+        ? "read-only check: FAILED — the tree changed beyond this relay's artifacts; treat the run as write-capable and review the diff"
+        : "read-only check: no Git-visible change detected (ignored or outside-repository paths are not covered)");
+  }
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- Command Code final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/copilot-delegate/SKILL.md
+++ b/skills/copilot-delegate/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: copilot-delegate
+description: Delegate a coding task to the GitHub Copilot CLI (`copilot`) as a background
+  implementer, then review its diff and land it yourself. Use this whenever the user
+  wants to delegate implementation work to Copilot - phrasings like "have Copilot
+  implement X", "delegate this to...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `copilot` CLI installed and authenticated (`copilot login`),
+  Node 18+ to run the relay (the copilot CLI itself requires Node 22+), and git. The
+  orchestrator must be able to run shell commands and read files.
+metadata:
+  version: 0.5.0
+---
+# Copilot Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `copilot` implementer (`GitHub Copilot CLI`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Delegate a bounded coding task to a separate **implementer** — the
+GitHub Copilot CLI — then review what it produced and land it yourself. You write the brief and own
+the judgment; the implementer makes changes in its own session in a clean working tree; you verify
+and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `copilot` CLI is not installed or authenticated.
+- You need a hard sandbox. Copilot exposes sandbox controls, but they are upstream-experimental
+  (MXC-based, controlled via the `/sandbox` command and settings, disabled by default) — this relay
+  does not configure them. `--read-only` only disables edit tools (`--mode plan`); shell commands
+  still run. If project files must not change at all, dispatch against a clean or isolated worktree.
+
+## Prerequisites (check once)
+
+1. Install `copilot` (`npm install -g @github/copilot`; the CLI requires Node 22+, the relay
+   itself runs on Node 18+ — the relay probes `copilot version`).
+2. Authenticate: run `copilot login` (interactive web/device flow), or set
+   `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` in the environment.
+3. Confirm `copilot version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the model (optional)
+
+Copilot picks a default model (`auto`). To choose another, pass `--model <name>`.
+The relay accepts letters, digits, and `. _ : / -` only (the value reaches a shell on Windows).
+
+## Choose the effort (optional)
+
+Copilot supports a reasoning effort dial: `--effort <level>` with values
+`low`, `medium`, `high`, `xhigh`, or `max`. The relay rejects any other value
+before dispatch.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write a brief
+
+Copilot sees only the text you send. It cannot read your conversation: the brief must stand alone
+with the goal, current state, what to change, what to leave untouched, the project's **real**
+gates, and a report contract. Keep each brief to a single task. Write it to a file and pass it as
+the relay's `--brief`. See [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled relay. It runs `copilot -p` with `--output-format json --no-color --stream off`,
+captures the JSONL event stream, and writes `result.json`.
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a model:                    add --model <name>
+# set reasoning effort:              add --effort <level>
+# read-only planning pass:           add --read-only  (forces --mode plan)
+# full tool autonomy:                add --allow-all-tools
+# hard time limit (watchdog):        add --timeout 2h   (the 30m default suits brief runs)
+# resume a session:                  add --session <id>  or  --resume-last
+# see all options:                   node .../relay.mjs --help
+```
+
+The child's cwd pins the workspace. The relay writes artifacts under the system temp dir by
+default and never commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until copilot finishes. Run it with the orchestrator's background-command
+facility, or background it in the shell and poll for `result.json`. A pre-run usage error exits 2
+and writes no result; a missing `copilot` exits 127 and writes `status: "copilot_unavailable"`.
+
+Completion means the process exited and `result.json` exists — trust process state and the
+working tree, not the progress display. Copilot's final assistant message is the `finalMessage`
+field of `result.json`.
+
+### 4. Review — do not trust the self-report
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+If the work is good, commit it. The relay never commits — the diff and `result.json` are the
+record; run `git status` and `git diff` first to confirm exactly what changed. If the group has a
+PR flow, make the commit and push a branch; let human review happen. If the diff is wrong or
+incomplete, re-dispatch a corrected brief in a fresh run and review again.
+
+## Autonomy and permissions
+
+Without `--allow-all-tools`, copilot auto-denies tool calls in headless mode: the process exits 0
+but the relay detects the denial events and reports `status: "failed"` with the CLI's own error
+message and a hint to pass `--allow-all-tools`. This is the honest default — the orchestrator sees
+the failure rather than a silent no-op.
+
+`--allow-all-tools` explicitly grants full tool autonomy. `--read-only` selects `--mode plan`,
+which disables edit tools so project files can't be changed by direct edits; it works without
+`--allow-all-tools`. Shell commands still run in plan mode, so it guards against edits, not
+against everything. The two flags are mutually exclusive.
+
+Copilot also exposes sandbox controls, but they are upstream-experimental (MXC-based, controlled
+via the `/sandbox` command and settings, disabled by default). This relay does not configure them.
+
+## Authorization model
+
+Delegation is something the human opts into. Once briefed, copilot works as a tool you approved use
+of. The boundary is: **do not accept conclusions from the self-report**; verify everything on
+disk. For anything touching credentials, production data, or irreversible operations, stop and ask
+the human first instead of encoding it in a brief.
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — structure, scope, gates,
+  brief delivery.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — flags, artifacts,
+  `result.json`, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) — what to verify before calling
+  the diff done, at the end of a run.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — sequential queues,
+  constraint carry-forward, progress tracking, and the final coherence pass.
+
+
+## Limitations
+
+- Requires the `copilot` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/copilot-delegate/references/dispatch-and-poll.md
+++ b/skills/copilot-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,143 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps copilot's headless JSONL mode, captures its event stream, and writes
+a `result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v copilot
+copilot version
+```
+
+Install `copilot` (`npm install -g @github/copilot`; the CLI requires Node 22+, the relay itself
+runs on Node 18+); on Windows it installs as an npm `.cmd` shim
+(the relay launches it with `shell:true`). Authenticate with `copilot login` or set
+`COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`. A headless run that is not authenticated
+fails with `status: "failed"` (exit 1).
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Copilot model (default: copilot's own default, `auto`). Token-validated: letters, digits, `. _ : / -`. |
+| `--effort <level>` | Reasoning effort (`low`\|`medium`\|`high`\|`xhigh`\|`max`). Rejected before dispatch if unknown. |
+| `--read-only` | Read-only plan mode (`--mode plan`); works without `--allow-all-tools`. Mutually exclusive with `--allow-all-tools`. |
+| `--allow-all-tools` | Full tool autonomy. Without this, headless tool calls are auto-denied and the relay reports `status: "failed"`. Mutually exclusive with `--read-only`. |
+| `--resume-last` | Resume the most recent session (`--continue`). |
+| `--session <id>` | Resume a specific session (`--resume=<id>`). Mutually exclusive with `--resume-last`. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Copilot has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+The child cwd pins the workspace. The relay does not pass copilot's `--add-dir`.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an
+`--out-dir` inside the worktree can make the artifacts appear there:
+
+- `brief.txt` — the exact brief.
+- `events.jsonl` — raw copilot stdout events (every JSONL event copilot emitted).
+- `final.txt` — the last non-ephemeral `assistant.message` content; absent if none was emitted.
+- `stderr.txt` — complete stderr.
+- `result.json` — the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"copilot"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `copilot_unavailable`), `exitCode`, and `signal` (`null` unless the child died on a signal).
+- `workdir`, `model`, `effort`, `readOnly`, `allowAllTools`, `resumed`, `copilotVersion`,
+  `startedAt`, and `finishedAt`.
+- `sessionId` — parsed from the `result` event's `sessionId` field; available for resume.
+- `finalMessage` — text of the last non-ephemeral `assistant.message` event.
+- `touchedFiles` — `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of copilot's edits: anything already dirty before dispatch shows up too.
+  Dispatch from a clean tree when you want the list to read as "what copilot changed". `null` means
+  git could not report; `[]` means git ran and the tree is clean.
+- `briefPath`, nullable `finalPath`, `eventsPath`, and `stderrPath`. `finalPath` is `null` when
+  copilot emitted no non-ephemeral assistant message and `final.txt` was not created.
+- `stderrTail` — the last 20 non-empty stderr lines on any run that did not complete (`failed`,
+  `timeout`, `aborted`).
+- `error` — present on denial failures (with the CLI's own denial message plus a hint to pass
+  `--allow-all-tools`), preflight failures, when the relay watchdog fires (`timeout`), and on an
+  `aborted` run.
+
+## Waiting for completion
+
+The relay blocks. Use the orchestrator's background-command facility, or background it in a shell
+and poll for `result.json`. The run is done only when the process exits and the file contains a
+`status`. The result file is written atomically, so a partial read is impossible.
+
+A pre-run usage error exits 2 and writes no result. A missing `copilot` exits 127 and writes
+`status: "copilot_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "copilot_unavailable"` (exit 127):** copilot is not on PATH. Install it, authenticate,
+  and re-dispatch.
+- **`status: "failed"` with a denial error:** copilot auto-denied a tool call in headless mode.
+  The error message includes the CLI's own denial text and a hint to pass `--allow-all-tools`.
+  Re-dispatch with `--allow-all-tools` to grant full tool permissions.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
+  causes: an unknown `--model`, expired credentials, or a provider error.
+- **`status: "failed"` with an `error` mentioning `version preflight`:** the bounded
+  `copilot version` probe failed or hung, so copilot was never dispatched. Check the install
+  (`copilot version` yourself).
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to copilot. The result is written before the relay exits;
+  inspect the working tree before re-dispatching.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `copilot did not finish within --timeout <dur>; killed by the relay watchdog`. Increase
+  `--timeout` or split the task.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every JSONL event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing.
+
+## What the relay runs
+
+The launch is equivalent to:
+
+```bash
+copilot --output-format json --no-color --stream off \
+  [--mode plan] [--allow-all-tools] \
+  [--continue | --resume=<id>] \
+  [--model <name>] [--effort <level>] \
+  -p @<brief.txt>
+```
+
+The child process cwd pins the workspace. Only token-validated model/effort/session values and
+fixed text reach the `shell:true` launch on native Windows; the brief is delivered via `-p @<file>`
+(the CLI's @-prefixed file prompt channel), with the brief path quoted for the shell on Windows.
+On resume (`--continue` / `--resume=<id>`) the relay wraps the reference in a fixed directive —
+`Execute the instructions in the referenced file, then report what you did. Do not just summarize
+the file: @<file>` — because a bare `@<file>` reference in a resumed session is echoed back instead
+of executed (verified on copilot 1.0.78). The directive is relay-authored fixed text, so no user
+content ever reaches the shell-quoted value on Windows. Fresh runs deliver the bare `@<file>`,
+which copilot executes correctly.
+Before dispatch the relay runs a bounded `copilot version` preflight (10s cap) so a
+hung or crashing CLI fails fast and explicitly instead of hanging the run.
+
+Copilot's JSONL events include ephemeral events (mcp status, skills_loaded, etc.) which the relay
+skips, `assistant.message` events whose `data.content` becomes `finalMessage`, and a final
+`result` event carrying `sessionId` and `usage.codeChanges`. Tool execution events with
+`success: false` and `error.code: "denied"` trigger the denial-detection path.
+
+## The commit boundary
+
+The relay never commits. Copilot edits the working tree; the orchestrator reviews, re-runs the
+gates, and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/copilot-delegate/references/multi-task-queues.md
+++ b/skills/copilot-delegate/references/multi-task-queues.md
@@ -1,0 +1,58 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo --allow-all-tools
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is
+the default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh copilot sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture
+location, or interface that task 5 needs, write that fact into task 5's brief.
+
+Use `--session <id>` to resume a previous session with a delta brief when continuity matters.
+`--resume-last` resumes the most recent session.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** — queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** — what landed, what you verified, and gate outcomes.
+- **Needs your eyes** — design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** — the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/copilot-delegate/references/review-and-land.md
+++ b/skills/copilot-delegate/references/review-and-land.md
@@ -1,0 +1,80 @@
+# Review and land
+
+The implementer made the changes; you own the judgment. Verify against reality, never the
+self-report, and read the diff as generated code because a green gate cannot catch every failure
+mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened
+  error types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries copilot's claims, not evidence. Re-run the project's actual test, lint, and
+build commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** — changes the brief excluded.
+- **Scope shortfall** — missed behavior, edges, or cleanup.
+- **Quiet judgment calls** — defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to copilot as a delta brief, or fix it in the tree, and report either
+choice to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer.
+Write a clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points —
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`,
+`git diff --cached` for anything the implementer staged (plain `git diff` is blind to the index),
+and commit the intended files explicitly.
+
+## Rework: re-dispatch a corrected brief
+
+Re-dispatch the correction with the needed context:
+
+```bash
+echo "The fix is right, but the tests mock the DB session: use the real migrated fixture and
+remove the unused import." | node "<skill-dir>/scripts/relay.mjs" --cd /path/to/repo --allow-all-tools
+```
+
+Use `--session <id>` from the previous run's `result.json` to resume the session with the delta
+brief, or dispatch a fresh run. Each correction gets the same test review, diff review, and
+implementer sweep.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep
+them in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/copilot-delegate/references/writing-the-brief.md
+++ b/skills/copilot-delegate/references/writing-the-brief.md
@@ -1,0 +1,140 @@
+# Writing the brief
+
+A brief is the entire task as copilot will see it. It runs in a separate process with **no memory of
+your conversation and no shared context** — only the text you send and whatever it can inspect in
+the workspace. If a constraint is not in the brief or discoverable in the repo, it does not exist
+for copilot.
+
+Copilot can auto-discover the workspace's `AGENTS.md`. Still restate load-bearing repo constraints in
+the brief so the implementer does not have to infer which rules matter for this task.
+
+## Model and effort choice
+
+Copilot picks a default model when `--model` is omitted, so a fresh dispatch does not require it.
+Pass `--model <name>` only when the human asked for a specific model. `--effort <level>` sets the
+reasoning effort (`low`, `medium`, `high`, `xhigh`, `max`). The relay rejects any other effort
+value before dispatch. Model values still accept letters, digits, and `. _ : / -` only.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report copilot must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** — add `<completeness_contract>` (resolve fully, not just the
+  first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
+  unknown).
+- **Research or recommendations** — add `<research_mode>` (separate observed facts, inferences,
+  and open questions), and dispatch with `--read-only`; copilot runs in `--mode plan`, which
+  disables edit tools so project files can't be changed by direct edits (shell commands still
+  run). If the repository must not change at all, dispatch against a clean or isolated worktree.
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from the last non-ephemeral `assistant.message` event. Without a
+closing summary, the edits may exist but the result is hard to review. The
+`<structured_output_contract>` block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy
+the actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Copilot can inspect the workspace, but the
+important constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one copilot run -> one reviewed commit keeps the diff and
+rollback clean. Split mixed implementation, review, documentation, and roadmap requests into
+separate dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; inspect the working tree and reconcile any
+partial or premise-contaminated edits — keep or revert them — before the re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Brief delivery
+
+The relay hands the brief to copilot via `-p @<brief.txt>` — the CLI's
+`@`-prefixed file prompt channel (verified on copilot 1.0.78), the same shape
+grok's relay uses with `--prompt-file`. The brief content never rides argv —
+only the `@<brief.txt>` reference does, plus a fixed execution directive on
+resume. The content stays out of the host process list, isn't bounded by the
+OS arg-length cap, and a brief that starts with "-" cannot be misread as a
+flag. On a shared machine keep secrets out of the brief anyway — reference
+them by a path or environment variable the workspace can read. The brief is
+also preserved in the run's `brief.txt` artifact.
+
+On resume (`--session` / `--resume-last` with a delta brief) the relay wraps
+the reference in a fixed directive so the resumed session executes it rather
+than echoing the file back (see [dispatch-and-poll.md](dispatch-and-poll.md)).
+The delta brief itself is unchanged; write it exactly as you would for a fresh
+dispatch.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/copilot-delegate/scripts/relay.mjs
+++ b/skills/copilot-delegate/scripts/relay.mjs
@@ -1,0 +1,782 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · copilot-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the GitHub Copilot CLI (`copilot -p`),
+ * capture the JSONL event stream, and write a structured result the
+ * orchestrating agent can review. The orchestrator runs this one command and
+ * reads the result JSON — every copilot-specific mechanic lives in here, which
+ * keeps the skill orchestrator-agnostic.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `copilot`, `git`, and Windows `taskkill` for
+ * process-tree termination. The `copilot` process it launches does
+ * authenticate — exactly as you do at the terminal. Read this file before you
+ * run it.
+ *
+ * The brief is handed to copilot via `-p @<file>` (the CLI's @-prefixed file
+ * prompt channel, verified on copilot 1.0.78), never argv: it stays out of
+ * the host process list, isn't bounded by the OS arg-length cap, and a brief
+ * that begins with "-" can't be misread as a flag.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Default mode runs without `--allow-all-tools`: headless tool calls are
+ * auto-denied by copilot, and the relay detects denial events and reports
+ * `status: "failed"` with the CLI's own error message plus a hint to pass
+ * `--allow-all-tools`. `--allow-all-tools` explicitly opts in to full tool
+ * autonomy. `--read-only` selects `--mode plan`, which disables edit tools so
+ * project files can't be changed by direct edits (shell commands still run),
+ * and works without `--allow-all-tools`. `--read-only` and `--allow-all-tools`
+ * are mutually exclusive.
+ *
+ * On native Windows `copilot` is an npm-installed `.cmd` shim this relay
+ * launches with shell:true. Model and effort values therefore accept only
+ * shell-safe tokens; the working directory is the child process cwd; and the
+ * brief path is quoted for the shell.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for copilot (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Copilot model (default: copilot's own default, `auto`).
+ *                           Letters, digits, and . _ : / - only.
+ *   --effort <level>        Reasoning effort for this run (low|medium|high|xhigh|max).
+ *   --read-only             Read-only plan mode (`--mode plan`); works without
+ *                           `--allow-all-tools`. Mutually exclusive with
+ *                           `--allow-all-tools`.
+ *   --allow-all-tools       Pass copilot's `--allow-all-tools` for full tool
+ *                           autonomy in headless mode. Without this, headless
+ *                           tool calls are auto-denied. Mutually exclusive with
+ *                           `--read-only`.
+ *   --resume-last           Continue the most recent copilot session for this
+ *                           cwd (`--continue`); send only the delta brief.
+ *   --session <id>          Continue a specific session id (`--resume=<id>`);
+ *                           send only the delta brief. Mutually exclusive with
+ *                           --resume-last.
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). Copilot has no
+ *                           timeout flag; durations use h/m/s strings.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, copilotVersion, model, effort, readOnly,
+ *   allowAllTools, resumed, sessionId, finalMessage (the last non-ephemeral
+ *   assistant message), touchedFiles (git porcelain, null if git cannot
+ *   report), and paths to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `copilot` binary exits
+ * 127; otherwise the exit code mirrors copilot's own (0 success, non-zero
+ * failure), except a run whose event stream contains a tool denial exits 1
+ * even if copilot exits 0. If the child dies on a signal, the exit code is 128
+ * plus the signal number and `result.json` records the signal. Once the brief
+ * validates, `result.json` is written on every outcome — completed, failed,
+ * timeout (the --timeout watchdog fired), aborted (the relay itself was killed
+ * and forwarded the kill to copilot), or copilot_unavailable.
+ */
+
+import { spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const PROBE_TIMEOUT_MS = 10_000;
+
+// --model and --effort values reach a shell on win32 (shell:true for the .cmd
+// shim), so they are restricted to safe tokens. Effort is then checked against
+// Copilot's documented enum (low|medium|high|xhigh|max).
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+const EFFORT_LEVELS = new Set(["low", "medium", "high", "xhigh", "max"]);
+
+const IMPLEMENTER_KEY = "copilot";
+
+// On resume (--resume=<id> / --continue), a bare @file reference in the resumed
+// session is echoed back instead of executed (verified on copilot 1.0.78); the
+// relay wraps the reference in this fixed directive so the delta is acted on.
+// The directive is relay-authored text, so the win32 value has no user content
+// to mangle inside its shell quotes. Deliberately not appended on fresh runs,
+// which execute a bare @file reference correctly.
+const RESUME_DIRECTIVE =
+  "Execute the instructions in the referenced file, then report what you did. Do not just summarize the file: ";
+
+function makeLineScanner(onObject) {
+  let buf = "";
+  return (chunk) => {
+    if (!chunk) return;
+    let start = 0;
+    for (;;) {
+      const end = chunk.indexOf("\n", start);
+      if (end === -1) break;
+      const line = buf + chunk.slice(start, end);
+      buf = "";
+      const trimmed = line.trim();
+      if (trimmed) {
+        try { onObject(JSON.parse(trimmed)); } catch { /* skip non-JSON lines */ }
+      }
+      start = end + 1;
+    }
+    buf += chunk.slice(start);
+    if (buf.length > MAX_BUFFERED_CHARS) buf = "";
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && (flagged.has("readOnly") || flagged.has("allowAllTools"))) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    effort: null,
+    readOnly: false,
+    allowAllTools: false,
+    resumeLast: false,
+    session: null,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--effort": opts.effort = next(); flagged.add("effort"); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--allow-all-tools": opts.allowAllTools = true; flagged.add("allowAllTools"); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.readOnly && opts.allowAllTools) {
+    fail("--read-only and --allow-all-tools are mutually exclusive; plan mode works without tool permissions");
+  }
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  if (opts.session !== null && !opts.session.trim()) fail("--session must not be empty");
+  for (const flag of ["model", "effort", "session"]) {
+    if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  if (opts.effort !== null && !EFFORT_LEVELS.has(opts.effort)) {
+    fail(`invalid --effort "${opts.effort}" (expected: ${[...EFFORT_LEVELS].join(", ")})`);
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a positive schedulable duration; use h/m/s strings like 30m, 90s, or 1h30m (maximum ~24.8 days)`);
+  }
+  try {
+    if (!statSync(opts.cd).isDirectory()) fail(`--cd is not a directory: ${opts.cd}`);
+  } catch {
+    fail(`--cd directory not found: ${opts.cd}`);
+  }
+  if (opts.outDir && existsSync(opts.outDir)) {
+    try {
+      if (!statSync(opts.outDir).isDirectory()) fail(`--out-dir is not a directory: ${opts.outDir}`);
+    } catch {
+      fail(`cannot inspect --out-dir: ${opts.outDir}`);
+    }
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to copilot -p\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function copilotVersion(timeoutMs) {
+  const limit = Math.min(timeoutMs, PROBE_TIMEOUT_MS);
+  // On Windows, npm installs `copilot` as a .cmd shim; shell:true resolves it.
+  // `copilot version` (subcommand) prints "GitHub Copilot CLI X.Y.Z" as the
+  // first line, followed by an optional update notice — parse only the first line.
+  try {
+    const raw = execFileSync("copilot", ["version"], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      timeout: limit,
+      killSignal: "SIGKILL",
+    }).trim();
+    const firstLine = raw.split("\n")[0].trim();
+    // Extract version from "GitHub Copilot CLI 1.0.78"
+    const versionMatch = firstLine.match(/(\d+\.\d+\.\d+(?:-[A-Za-z0-9._-]+)?)/);
+    return { version: versionMatch ? versionMatch[1] : firstLine || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    // shell:true routes a missing binary through cmd.exe, which reports it as a
+    // non-zero exit rather than ENOENT; that is still "not installed".
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    return { version: null, error };
+  }
+}
+
+function buildArgv(opts, briefPath) {
+  // shell:true on win32 (needed for the copilot.cmd shim) doesn't quote
+  // args, so a path with spaces splits. Quote the spaceable path args;
+  // --model/--effort/--session are already restricted to safe tokens at parse time.
+  const quotePath = (p) => (process.platform === "win32" ? `"${p}"` : p);
+  const argv = [
+    "--output-format", "json",
+    "--no-color",
+    "--stream", "off",
+  ];
+
+  if (opts.readOnly) {
+    argv.push("--mode", "plan");
+  }
+
+  if (opts.allowAllTools) {
+    argv.push("--allow-all-tools");
+  }
+
+  if (opts.resumeLast) argv.push("--continue");
+  else if (opts.session) argv.push(`--resume=${opts.session}`);
+
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.effort) argv.push("--effort", opts.effort);
+
+  // Deliver the brief via a file, not argv: keeps it out of the host process
+  // list, isn't bounded by the OS arg-length cap, and a brief that begins with
+  // "-" can't be misread as a flag. prepareRunDir already wrote run.briefPath.
+  // On resume the reference gets the RESUME_DIRECTIVE wrapper (see above); its
+  // value contains spaces, so on win32 the whole value is outer-quoted for cmd
+  // (the path then needs no inner quotes of its own).
+  let delivery;
+  if (opts.resumeLast || opts.session) {
+    delivery = process.platform === "win32"
+      ? `"${RESUME_DIRECTIVE}@${briefPath}"`
+      : `${RESUME_DIRECTIVE}@${briefPath}`;
+  } else {
+    delivery = `@${quotePath(briefPath)}`;
+  }
+  argv.push("-p", delivery);
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir =
+    opts.outDir ||
+    join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "copilot",
+      workdir: opts.cd,
+      model: opts.model,
+      effort: opts.effort,
+      readOnly: opts.readOnly,
+      allowAllTools: opts.allowAllTools,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      sessionId: null,
+      copilotVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(opts, writeResult, resultPath) {
+  const result = writeResult({
+    status: "copilot_unavailable",
+    exitCode: 127,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+  });
+  printSummary(result, resultPath);
+  process.stderr.write(
+    "relay: `copilot` not found on PATH. Install with `npm install -g @github/copilot` and run `copilot login`.\n",
+  );
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, timeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `copilot version preflight timed out after ${Math.min(timeoutMs, PROBE_TIMEOUT_MS)}ms; copilot was not dispatched`
+    : `copilot version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; copilot was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the copilot version preflight; copilot was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.off(sig, handler);
+  };
+}
+
+function dispatchToCopilot(opts, run, writeResult, onReady) {
+  const child = spawn("copilot", buildArgv(opts, run.briefPath), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    // shell:true on win32 so the copilot.cmd shim resolves. Safe: the brief
+    // rides `-p @<briefPath>` as a quoted file path, --model/--effort/--session
+    // are restricted to safe tokens at parse time.
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = null;
+  let lastAssistantMessage = "";
+  let denied = false;
+  let denialMessage = "";
+  const stderrTail = [];
+
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  const scan = makeLineScanner((event) => {
+    // Skip ephemeral events (mcp status, skills_loaded, tool.execution_start, etc.)
+    if (event.ephemeral) return;
+
+    // assistant.message — capture the last non-ephemeral one as finalMessage
+    if (event.type === "assistant.message" && event.data && typeof event.data.content === "string") {
+      lastAssistantMessage = event.data.content;
+    }
+
+    // result — carries sessionId and usage
+    if (event.type === "result") {
+      if (event.sessionId) sessionId = event.sessionId;
+    }
+
+    // tool.execution_complete with success:false and error.code:"denied" — the
+    // headless auto-deny trap. copilot exits 0 but the run is a failure.
+    // Copilot wraps the outcome in `data` (event.data.success, event.data.error).
+    if (event.type === "tool.execution_complete" && event.data?.success === false) {
+      if (event.data.error && event.data.error.code === "denied") {
+        denied = true;
+        denialMessage = event.data.error.message || "Permission denied";
+      }
+    }
+  });
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = lastAssistantMessage;
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const exitCode = 128 + (constants.signals[sig] || 15);
+      let finalized = false;
+      const finishAbort = () => {
+        if (finalized) return;
+        finalized = true;
+        if (sigkillTimer) clearTimeout(sigkillTimer);
+        killChild(child, "SIGKILL");
+        const result = writeResult({
+          status: "aborted",
+          exitCode,
+          signal: sig,
+          sessionId,
+          finalMessage: assembleFinal(),
+          touchedFiles: gitTouchedFiles(opts.cd),
+          stderrTail: stderrTail.slice(-20),
+          error: `the relay was killed by ${sig}; copilot was terminated with it — inspect the working tree before re-dispatching`,
+        });
+        printSummary(result, run.resultPath);
+        process.exit(exitCode);
+      };
+      child.once("exit", finishAbort);
+      killChild(child);
+      sigkillTimer = setTimeout(finishAbort, 2000);
+    });
+  }
+  onReady();
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // Force a delimiter so a final event without a trailing newline still parses.
+    scan(`${stdoutDecoder.end()}\n`);
+    const stderrEnd = stderrDecoder.end();
+    if (stderrEnd.trim()) stderrTail.push(stderrEnd.trimEnd());
+    const finalMessage = assembleFinal();
+    const touchedFiles = gitTouchedFiles(opts.cd);
+    // Denial trap: copilot exits 0 even when tool calls are denied headlessly.
+    // The relay catches the denial event and reports failed.
+    const deniedRun = denied && !watchdogFired;
+    const succeeded = code === 0 && !watchdogFired && !deniedRun;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const denialError = deniedRun
+      ? `copilot auto-denied a tool call in headless mode: ${denialMessage}. Pass --allow-all-tools to grant full tool permissions`
+      : null;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      finalMessage,
+      touchedFiles,
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired
+        ? {
+            error: `copilot did not finish within --timeout ${opts.timeout}; killed by the relay watchdog`,
+          }
+        : {}),
+      ...(denialError ? { error: denialError } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const run = prepareRunDir(opts, brief);
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  let writeResult = makeResultWriter(opts, null, run);
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult);
+  const probe = copilotVersion(timeoutMs);
+  // execFileSync defers JS signal handlers; yield once so a signal received
+  // during the bounded preflight becomes "aborted" before any dispatch.
+  await new Promise((resolve) => setImmediate(resolve));
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    return reportUnavailable(opts, writeResult, run.resultPath);
+  }
+  if (probe.error) {
+    clearPreflightSignals();
+    return reportVersionFailure(opts, writeResult, run, probe.error, timeoutMs);
+  }
+  dispatchToCopilot(opts, run, writeResult, clearPreflightSignals);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(
+    `relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  copilot ${result.copilotVersion ?? "?"}`,
+  );
+  if (result.signal === "SIGKILL" && result.status === "failed") {
+    lines.push(
+      "hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a copilot error; check host memory and re-dispatch, or split the task into smaller briefs.",
+    );
+  }
+  if (result.signal === "SIGTERM" && result.status === "failed") {
+    lines.push(
+      "hint: something outside the relay terminated copilot; relay watchdogs and relay signals report timeout or aborted instead.",
+    );
+  }
+  if (result.readOnly) lines.push("mode: plan (read-only)");
+  if (result.allowAllTools) lines.push("autonomy: --allow-all-tools");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- copilot final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push(
+    "relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.",
+  );
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: cursor-delegate
+description: Delegate a coding task to the Cursor Agent CLI (`cursor-agent`) as a
+  background implementer, then review its diff and land it yourself. Use this whenever
+  the user wants to hand implementation work to Cursor — phrasings like "have Cursor
+  implement X", "delegate this to...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `cursor-agent` CLI installed and authenticated, Node 18+,
+  and git. The optional `--add-dir` flag requires cursor-agent 2026.07.23 or newer.
+  The orchestrating agent must be able to run shell commands and read files. Shell
+  examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+# Cursor Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `cursor` implementer (`Cursor Agent`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Hand a bounded coding task to a separate **implementer** — the Cursor
+Agent CLI — then review what it produced and land it yourself. You write the brief and own the
+judgment; Cursor does the typing in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `cursor-agent` CLI is not installed or authenticated (run `cursor-agent login`).
+- You want to write the code yourself, or you only need Cursor's opinion on code you wrote (a
+  `--read-only` dispatch covers that — see below — but a plain review may not need delegation at all).
+
+## Prerequisites (check once)
+
+1. `cursor-agent --version` succeeds. If not, follow the installer for your platform at
+   [cursor.com/cli](https://cursor.com/cli), inspect what it will run, and authenticate with
+   `cursor-agent login`.
+2. `cursor-agent status` shows you logged in.
+3. You are in (or will point `--cd` at) the target git repository. The relay passes `--trust`, so
+   point it only at repositories you trust.
+
+## Choose the model
+
+Omitting `--model` uses your Cursor default (usually `auto` — Cursor picks). To pin one, pass
+`--model <name>` with a name from the account's live `cursor-agent models` output — select from that
+list rather than inventing a name. Parameterized forms like `<name>[context=1m,effort=high]` are
+forwarded as-is. The model that actually served the run is recorded as `resolvedModel` in
+`result.json`.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Cursor sees only the text you send plus what it can inspect in the workspace — no chat history or
+shared context. Include the goal, current state, what to change, what to leave untouched, the
+project's **actual** gates, and a report contract. Tell Cursor not to commit. Keep one task per
+brief. See [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled helper. It wraps `cursor-agent -p`, feeds the brief on stdin, captures the
+structured event stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing
+this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only (plan mode — review/diagnosis, no edits):  add --read-only
+# write-capable without automatic command approval:   add --no-force
+# explicitly override Cursor's sandbox for this run:  add --sandbox enabled|disabled
+# pin a model from `cursor-agent models`:              add --model <name>
+# resume the most recent session:                      add --resume-last  (delta brief only)
+# resume a specific session:                           add --session <id> (delta brief only)
+# hard time limit (watchdog):                          add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
+# see all options:                                     node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. On Cursor `2026.07.23` or newer, use repeatable
+`--add-dir` flags only for extra workspace directories. The relay writes artifacts under the system
+temp dir by default and never commits. See
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Cursor finishes. Run it with the orchestrator's background-command facility,
+or background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
+result; a missing `cursor-agent` exits 127 and writes `status: "cursor_agent_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process exited
+and `result.json` exists. Cursor's full report is the `finalMessage` field in `result.json` (also
+printed in full on stdout between the report markers).
+
+**Windows + hooks caveat:** if the user has Cursor hooks configured (`~/.cursor/hooks.json`, or
+Claude Code `PreToolUse` hooks, which cursor-agent imports), dispatching from a Git Bash (MSYS)
+console makes cursor-agent feed PowerShell-syntax hook wrappers to bash, so every command Cursor
+tries to run is blocked — edits still land, gates do not run. Dispatch from a PowerShell or cmd
+console instead. Details: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 4. Review — do not trust the self-report
+
+Treat Cursor's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates
+pass and the diff holds. If rework is needed, send a delta brief with `--resume-last` or
+`--session <id>`, then review again.
+
+## Autonomy and permissions
+
+A fresh run defaults to **write-capable with `--force`**: Cursor runs commands without approval
+unless your Cursor config explicitly denies them, so ordinary gates (tests, linters, builds) run
+headlessly. `--no-force` keeps the run write-capable but withholds automatic command approval;
+commands that require approval are refused because a headless run cannot prompt. `--read-only`
+switches to Cursor's **plan mode** (read-only analysis, no edits, no `--force`). The relay always
+passes `--trust` to keep headless runs from stalling on the workspace-trust prompt, which is why
+`--cd` must only ever point at repositories you trust. Pass `--sandbox enabled` or `--sandbox
+disabled` only when you need to override Cursor's sandbox for that dispatch. The requested value is
+recorded as `sandbox` in `result.json`; it does not claim what Cursor actually applied. The permission
+mode Cursor reports is recorded as `permissionMode`; inspect `touchedFiles` and the diff after every
+run.
+
+## Read-only second opinions
+
+`--read-only` doubles as a clean way to get an adversarial second opinion with no write risk:
+dispatch a brief that lists the agreed points, then each contested point with both positions, and ask
+Cursor to defend or concede each — deliverable in its final message, touching no files.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't absorb**
+(report Cursor's design decisions, defensible-but-unasked turns, and non-blocking nitpicks) and
+**stop for scope changes** (if correct completion needs going beyond the brief, ask instead of
+expanding the mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — structure, report contract,
+  real gates, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) — review checklist, commit boundary,
+  and rework through Cursor sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — sequential queues, constraint
+  carry-forward, progress tracking, and the final coherence pass.
+
+
+## Limitations
+
+- Requires the `cursor` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/cursor-delegate/references/dispatch-and-poll.md
+++ b/skills/cursor-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,162 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps Cursor's headless print mode (`cursor-agent -p`), captures its structured
+stream, and writes a `result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v cursor-agent
+cursor-agent --version
+cursor-agent status
+```
+
+Follow the installer for your platform at [cursor.com/cli](https://cursor.com/cli), inspect what it
+will run, then authenticate with `cursor-agent login`. On Windows the CLI installs as a `.cmd` shim;
+the relay handles that launch itself, no setup needed.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Cursor model for this run (default: your Cursor default, usually `auto`). Names come from `cursor-agent models`. |
+| `--read-only` | Run in Cursor's plan mode: read-only analysis, no edits, no `--force`. |
+| `--sandbox <mode>` | Override Cursor's sandbox for this dispatch: `enabled` or `disabled`. |
+| `--no-force` | Keep the run write-capable but withhold `--force`; commands requiring approval are refused. |
+| `--session <id>` | Resume a specific Cursor chat (`--resume <id>`); send only the delta brief. |
+| `--resume-last` | Resume the most recent Cursor chat (`--continue`); send only the delta brief. |
+| `--add-dir <dir>` | Add an extra workspace root on Cursor `2026.07.23` or newer. Repeatable. Edits there are not reported in `touchedFiles`. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). cursor-agent has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive. The child cwd pins the primary workspace;
+`--add-dir` adds extra workspace roots only.
+
+A fresh run defaults to write-capable with `--force` (commands run without approval unless your
+Cursor config denies them). `--no-force` withholds automatic command approval while retaining file
+edits; `--read-only` switches to plan mode instead. The relay always passes `--trust` so a headless
+run never stalls on the workspace-trust prompt — point `--cd` only at repositories you trust.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an `--out-dir`
+inside the worktree can make the artifacts appear there:
+
+- `brief.txt` — the exact brief.
+- `events.jsonl` — raw cursor-agent stdout events.
+- `final.txt` — the final report; absent if none was emitted.
+- `stderr.txt` — complete stderr.
+- `result.json` — the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"cursor-agent"`), `status` (`completed` | `failed` | `timeout` | `aborted` |
+  `cursor_agent_unavailable`), `exitCode`, and `signal` (`null` unless the child died on a signal).
+- `workdir`, `model` (the requested name or `null`), `resolvedModel` (the model Cursor actually
+  served, from its init event), `permissionMode` (the mode Cursor reported applying), `readOnly`,
+  `force`, `sandbox` (the requested value or `null`, not a claim about what Cursor applied),
+  `resumed`, `cursorAgentVersion`, `sessionId`, `startedAt`, and `finishedAt`.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `finalMessage` — the `result` field of Cursor's closing event; when the run died before emitting
+  one, the assistant text chunks joined with `"\n\n"` instead. Tool calls and tool results are
+  excluded.
+- `touchedFiles` — `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of Cursor's edits: anything already dirty before dispatch shows up too, and
+  edits Cursor makes inside `--add-dir` roots do not show up at all — inspect those trees yourself.
+  Dispatch from a clean tree when you want the list to read as "what Cursor changed". `null` means
+  git could not report; `[]` means git ran and the tree is clean.
+- `usage` — Cursor's token-usage object from the closing result event, or `null` if no result event
+  supplied one.
+- `stderrTail` — the last 20 non-empty stderr lines on any run that did not complete (`failed`,
+  `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`.
+- `error` — present for launch failures, when the relay watchdog fires (`timeout`), on an `aborted`
+  run, and when Cursor's own result event carries `is_error: true`.
+
+## Waiting for completion
+
+The helper blocks. Use the orchestrator's background-command facility, or background it in a shell
+and poll for `result.json`. The run is done only when the process exits and the file contains a
+`status`.
+
+A pre-run usage error exits 2 and writes no result. A missing `cursor-agent` exits 127 and writes
+`status: "cursor_agent_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "cursor_agent_unavailable"` (exit 127):** install the Cursor CLI, authenticate with
+  `cursor-agent login`, and re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. If the
+  result event carried `is_error: true` the relay reports `failed` even on a zero exit; Cursor's own
+  message is in `finalMessage`. An unknown `--model` name fails fast — re-check against
+  `cursor-agent models`.
+- **A version-preflight failure:** the relay writes `failed` with the probe's exit code, or `timeout`
+  with exit 124 when the probe exceeds the smaller of the run watchdog and 10 seconds. Cursor is not
+  dispatched.
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to cursor-agent. The result is written before the relay
+  exits; inspect the working tree before re-dispatching. On native Windows a hard kill of the relay
+  is uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written —
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working tree
+  and `events.jsonl` directly.
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through the
+  OOM killer or a supervisor timeout. This is not a Cursor error; check host memory and re-dispatch,
+  or split the task into smaller briefs.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `cursor-agent did not finish within --timeout <dur>; killed by the relay watchdog`. Increase
+  `--timeout` or split the task. The relay sends SIGTERM, waits 10 seconds, then sends SIGKILL if
+  needed (on Windows a single process-tree kill).
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+- **Every command Cursor runs is rejected with "Hook blocked with message: … eval: … syntax error
+  near unexpected token `&`" (or Cursor reports "the terminal hook failed"):** a cursor-agent bug,
+  not a hook bug. When cursor-agent is launched from a Git Bash (MSYS) console on Windows — which
+  is what an orchestrator's bash tool uses — it selects `bash.exe` as its persistent shell while
+  still generating its hook wrappers in PowerShell syntax, so every configured hook (its own
+  `~/.cursor/hooks.json` and any imported Claude Code `PreToolUse` hooks) errors and Cursor blocks
+  the command, fail-closed. File edits still work; command execution does not — which also means
+  Cursor cannot run the gates, only claim it could not. Workaround: dispatch the relay from a
+  PowerShell or cmd console instead (observed fixed there); or temporarily remove the hook entries
+  for the run. Verified on cursor-agent 2026.07.23.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Whether it also carries the edit contents depends on what the CLI streams,
+so treat any reconstruction as unverified until it matches a working-tree diff — when the tree
+still holds the work, preserve the tree rather than replaying the log.
+
+## What the relay runs
+
+The argv is equivalent to:
+
+```bash
+cursor-agent --print --output-format stream-json --trust \
+  [--force | --mode plan] [--sandbox enabled|disabled] [--model <name>] \
+  [--resume <id> | --continue] \
+  [--add-dir <dir> ...]   # brief on stdin
+```
+
+`--no-force` omits both `--force` and `--mode plan`; the run can edit files, but approval-gated
+commands are refused.
+
+The brief rides stdin, so it is not visible in the host process list and has no OS argument-size
+cap. On Windows the launch goes through the shell so the `cursor-agent.cmd` shim resolves; the brief
+still travels on stdin, sandbox, model, session, and directory values are validated, and spaceable
+values are quoted.
+
+## The commit boundary
+
+The relay never commits. Cursor edits the working tree; the orchestrator reviews, re-runs the gates,
+and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/cursor-delegate/references/multi-task-queues.md
+++ b/skills/cursor-delegate/references/multi-task-queues.md
@@ -1,0 +1,59 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is the
+default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh Cursor sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture
+location, or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed Cursor session only for rework on the same task. Send a delta brief with
+`--resume-last`, or with `--session <id>` from that task's `result.json`. Start unrelated queue items
+in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** — queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** — what landed, what you verified, and gate outcomes.
+- **Needs your eyes** — design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** — the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/cursor-delegate/references/review-and-land.md
+++ b/skills/cursor-delegate/references/review-and-land.md
@@ -1,0 +1,93 @@
+# Review and land
+
+Cursor did the typing; you own the judgment. Verify against reality, never the self-report, and read
+the diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries Cursor's claims, not evidence. Re-run the project's actual test, lint, and
+build commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** — changes the brief excluded.
+- **Scope shortfall** — missed behavior, edges, or cleanup.
+- **Quiet judgment calls** — defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to Cursor as a delta brief, or fix it in the tree, and report either
+choice to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer. Write a
+clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove the
+unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--session <id>` instead when resuming the specific id recorded in `result.json`. The relay
+rejects `--resume-last` plus `--session` before launch. Rework gets the same gate rerun, test
+review, diff review, and implementer sweep.
+
+A resumed run carries the same autonomy flags as a fresh one — write-capable with `--force` by
+default, write-capable without automatic command approval under `--no-force`, or plan mode under
+`--read-only`. Confirm `touchedFiles` after every fresh or resumed run.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep them
+in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/cursor-delegate/references/writing-the-brief.md
+++ b/skills/cursor-delegate/references/writing-the-brief.md
@@ -1,0 +1,126 @@
+# Writing the brief
+
+A brief is the entire task as Cursor will see it. It runs in a separate session with **no memory of
+your conversation, no access to prior notes, and no shared context** — only the text you send and
+whatever it can inspect in the workspace. If a constraint is not in the brief or discoverable in the
+repo, it does not exist for Cursor.
+
+## Model choice and resumed sessions
+
+Omitting `--model` uses your Cursor default (usually `auto` — Cursor picks the model). Pass
+`--model <name>` only with a name from the account's live `cursor-agent models` output. Do not
+invent a name.
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report Cursor must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** — add `<completeness_contract>` (resolve fully, not just the first
+  plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is unknown).
+- **Research or recommendations** — add `<research_mode>` (separate observed facts, inferences, and
+  open questions).
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from Cursor's closing result event, falling back to its assistant
+text stream. Without a closing summary, the edits may exist but the result is hard to review. The
+`<structured_output_contract>` block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy the
+actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Cursor reads the repo's `.cursor/rules` and can
+inspect the workspace, but the important constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one Cursor run -> one reviewed commit keeps the diff and
+rollback clean. Split mixed implementation, review, documentation, and roadmap requests into separate
+dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Delivery
+
+The relay reads the brief from a file or stdin and feeds it to `cursor-agent` on stdin — it never
+rides argv, so it is not visible in the host process list and has no OS argument-size cap. Large
+context is still better referenced than inlined: put it in the workspace and tell Cursor which file
+to read.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/cursor-delegate/scripts/relay.mjs
+++ b/skills/cursor-delegate/scripts/relay.mjs
@@ -1,0 +1,769 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · cursor-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Cursor Agent CLI (`cursor-agent -p`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every Cursor-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified against cursor-agent 2026.07.23 on Windows.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `cursor-agent` and `git` (plus taskkill on
+ * Windows for process-tree termination). The `cursor-agent` process it
+ * launches does authenticate — exactly as you do at the terminal. Read this
+ * file before you run it.
+ *
+ * The brief is fed on the child's stdin, never argv, so it is not visible in
+ * the host process list and has no OS argument-size cap.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Autonomy: a fresh run defaults to write-capable with `--force` (Cursor runs
+ * commands without approval unless your Cursor config denies them). Pass
+ * `--read-only` to run in Cursor's plan mode (read-only/planning, no edits)
+ * instead. The relay always passes `--trust` so a headless run never stalls
+ * on the workspace-trust prompt — point --cd only at repositories you trust.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for Cursor (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Cursor model (default: your Cursor default, usually
+ *                           auto). List names with `cursor-agent models`.
+ *   --read-only             Run in Cursor's plan mode: read-only analysis, no
+ *                           edits, no --force.
+ *   --sandbox <mode>        Explicitly enable or disable Cursor's sandbox for
+ *                           this dispatch (enabled | disabled).
+ *   --no-force              Withhold --force on a write-capable run; commands
+ *                           that require approval are refused instead of run.
+ *   --session <id>          Resume a specific Cursor chat (`--resume <id>`);
+ *                           send only the delta brief.
+ *   --resume-last           Resume the most recent Cursor chat (`--continue`);
+ *                           send only the delta brief.
+ *   --add-dir <dir>         Add an extra workspace root. Repeatable; requires
+ *                           cursor-agent 2026.07.23 or newer.
+ *   --timeout <dur>         Relay-side watchdog (default: 30m; h/m/s strings
+ *                           like 90s, 45m, 2h). cursor-agent has no timeout flag.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, cursorAgentVersion, sessionId, resolvedModel,
+ *   permissionMode, force, sandbox (requested value or null), usage,
+ *   finalMessage (Cursor's own report),
+ *   touchedFiles (git porcelain, null if git cannot report), and paths to
+ *   brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `cursor-agent` binary
+ * exits 127 and writes status `cursor_agent_unavailable`; otherwise the exit
+ * code mirrors cursor-agent's own (0 success, non-zero failure). If the child
+ * dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome — completed, failed, timeout (the --timeout
+ * watchdog fired), aborted (the relay itself was killed and forwarded the kill
+ * to cursor-agent), or cursor_agent_unavailable.
+ */
+
+import {spawn, execSync, execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync, renameSync, rmSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:@/[\],=-]*$/;
+const SAFE_SESSION = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const SANDBOX_MODES = new Set(["enabled", "disabled"]);
+
+const IMPLEMENTER_KEY = "cursor";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    readOnly: false,
+    force: true,
+    sandbox: null,
+    session: null,
+    resumeLast: false,
+    addDirs: [],
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--sandbox": opts.sandbox = next(); flagged.add("sandbox"); break;
+      case "--no-force": opts.force = false; flagged.add("force"); break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--add-dir": opts.addDirs.push(next()); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.sandbox !== null && !SANDBOX_MODES.has(opts.sandbox)) {
+    fail(`--sandbox "${opts.sandbox}" is invalid; expected enabled or disabled`);
+  }
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  if (opts.model !== null && !SAFE_MODEL.test(opts.model)) {
+    fail("--model contains unsupported characters (allowed: letters, digits, . _ : @ / [ ] , = -)");
+  }
+  if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
+    fail("--session contains unsupported characters (allowed: letters, digits, . _ : -)");
+  }
+  // cursor-agent resolves a relative --add-dir against ITS cwd, so resolve
+  // against --cd (not the relay's own cwd) — and only after the loop, since
+  // --add-dir may appear before --cd on the command line. resolve() passes
+  // absolutes through.
+  opts.addDirs = opts.addDirs.map((dir) => resolve(opts.cd, dir));
+  if (process.platform === "win32" && opts.addDirs.some((dir) => /[\0\r\n"%!]/.test(dir))) {
+    fail("--add-dir cannot contain %, !, a quote, or a newline when cursor-agent launches through cmd.exe");
+  }
+  // The watchdog is relay-only (cursor-agent has no timeout flag), so a
+  // malformed --timeout must fail loudly here — a silent 30m fallback would be wrong.
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to cursor-agent -p\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function cursorAgentVersion(timeoutMs) {
+  try {
+    // On Windows, cursor-agent installs as a .cmd shim; Node's CreateProcess only
+    // auto-appends .exe, never .cmd, so launching it needs a shell there or it
+    // ENOENTs on a working install. A pre-joined string (not shell:true + args)
+    // avoids Node's DEP0190 warning. POSIX is unaffected. (git installs a real
+    // git.exe and must NOT go through a shell — see gitTouchedFiles.)
+    const options = {
+      encoding: "utf8",
+      timeout: Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS),
+      killSignal: "SIGKILL",
+    };
+    const out = process.platform === "win32"
+      ? execSync("cursor-agent --version", options).trim()
+      : execFileSync("cursor-agent", ["--version"], options).trim();
+    return { version: out || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    return { version: null, error };
+  }
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function winq(value) {
+  // shell:true on win32 (needed for the cursor-agent.cmd shim) doesn't quote
+  // args, so a path with spaces (C:\Users\First Last\...) would split, and a
+  // parameterized model ("opus[context=1m,effort=high]") would be re-tokenized
+  // by the shim's PowerShell hop. Quote the spaceable/parameterized values on
+  // Windows only — on POSIX the quotes would become literal characters.
+  return process.platform === "win32" ? `"${value}"` : value;
+}
+
+function buildArgv(opts) {
+  const argv = ["--print", "--output-format", "stream-json", "--trust"];
+  if (opts.readOnly) argv.push("--mode", "plan");
+  else if (opts.force) argv.push("--force");
+  if (opts.sandbox) argv.push("--sandbox", opts.sandbox);
+  if (opts.model) argv.push("--model", winq(opts.model));
+  if (opts.session) argv.push("--resume", winq(opts.session));
+  else if (opts.resumeLast) argv.push("--continue");
+  for (const dir of opts.addDirs) argv.push("--add-dir", winq(dir));
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "cursor-agent",
+      workdir: opts.cd,
+      model: opts.model,
+      readOnly: opts.readOnly,
+      force: opts.force && !opts.readOnly,
+      sandbox: opts.sandbox,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      cursorAgentVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "cursor_agent_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    resolvedModel: null,
+    permissionMode: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `cursor-agent` not found on PATH. Install the Cursor CLI (https://cursor.com/cli) and run `cursor-agent login`.\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, timeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `cursor-agent --version preflight timed out after ${Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS)}ms; Cursor was not dispatched`
+    : `cursor-agent --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Cursor was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    resolvedModel: null,
+    permissionMode: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: null,
+        resolvedModel: null,
+        permissionMode: null,
+        usage: null,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the cursor-agent version preflight; Cursor was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
+}
+
+function dispatchToCursor(opts, brief, run, writeResult) {
+  // A shell launch on Windows so the cursor-agent.cmd shim resolves (see
+  // cursorAgentVersion) — as a pre-joined string, which sidesteps Node's
+  // DEP0190 warning about shell:true with an args array. Safe: the brief is
+  // fed via child.stdin below — never argv — and argv holds only fixed flags
+  // plus the win32-quoted model and directory values. detached on POSIX: the
+  // child leads a new process group so killChild can fell the whole tree.
+  const argv = buildArgv(opts);
+  const child = process.platform === "win32"
+    ? spawn(["cursor-agent", ...argv].join(" "), { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], shell: true })
+    : spawn("cursor-agent", argv, { cwd: opts.cd, stdio: ["pipe", "pipe", "pipe"], detached: true });
+
+  let sessionId = null;
+  let resolvedModel = null;
+  let permissionMode = null;
+  let usage = null;
+  let resultMessage = null;
+  let resultIsError = false;
+  const textChunks = [];
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    if (typeof event.session_id === "string") sessionId = event.session_id;
+    if (event.type === "system" && event.subtype === "init") {
+      if (typeof event.model === "string") resolvedModel = event.model;
+      if (typeof event.permissionMode === "string") permissionMode = event.permissionMode;
+    }
+    if (event.type === "assistant" && event.message && Array.isArray(event.message.content)) {
+      for (const part of event.message.content) {
+        if (part && part.type === "text" && typeof part.text === "string") textChunks.push(part.text);
+      }
+    }
+    if (event.type === "result") {
+      if (typeof event.result === "string") resultMessage = event.result;
+      if (event.is_error === true) resultIsError = true;
+      if (event.usage && typeof event.usage === "object") usage = event.usage;
+    }
+  });
+
+  // The brief rides stdin: no process-list exposure, no OS argv-size cap.
+  child.stdin.on("error", () => { /* child exited before reading the brief; its exit code tells the story */ });
+  child.stdin.write(brief);
+  child.stdin.end();
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    // Prefer the result event's own report; fall back to the assistant text
+    // stream when the run died before emitting one.
+    const message = resultMessage && resultMessage.trim() ? resultMessage : textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the cursor-agent child running or dying mid-edit with
+  // nothing recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdogTimer);
+      if (sigkillTimer) clearTimeout(sigkillTimer);
+      const touched = gitTouchedFiles(opts.cd);
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        resolvedModel,
+        permissionMode,
+        usage,
+        finalMessage: assembleFinal(),
+        touchedFiles: touched,
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; cursor-agent was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        const late = gitTouchedFiles(opts.cd);
+        writeResult({ ...abortedFields, touchedFiles: late });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    const touched = gitTouchedFiles(opts.cd);
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      resolvedModel,
+      permissionMode,
+      usage,
+      finalMessage: assembleFinal(),
+      touchedFiles: touched,
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // A timed-out run is failed even if cursor-agent handles SIGTERM by exiting 0 —
+    // orchestrators key off status and the relay exit code. A result event with
+    // is_error true is failed even on exit 0.
+    const succeeded = code === 0 && !watchdogFired && !resultIsError;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const touched = gitTouchedFiles(opts.cd);
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      resolvedModel,
+      permissionMode,
+      usage,
+      finalMessage: assembleFinal(),
+      touchedFiles: touched,
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `cursor-agent did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...(resultIsError && !watchdogFired ? { error: "cursor-agent reported an error result (is_error: true in its result event)" } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const timeoutMs = parseDuration(opts.timeout);
+  const run = prepareRunDir(opts, brief);
+  let writeResult = makeResultWriter(opts, null, run);
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult);
+  const probe = cursorAgentVersion(timeoutMs);
+  // Synchronous child-process calls defer JavaScript signal handlers. Yield once
+  // so a signal received during the bounded probe becomes "aborted" before dispatch.
+  await new Promise((resolve) => setImmediate(resolve));
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    clearPreflightSignals();
+    reportVersionFailure(opts, writeResult, run, probe.error, timeoutMs);
+    return;
+  }
+  clearPreflightSignals();
+  dispatchToCursor(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  cursor-agent ${result.cursorAgentVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a cursor-agent error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated cursor-agent (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.readOnly) lines.push("mode: read-only (plan)");
+  if (result.resolvedModel) lines.push(`model: ${result.resolvedModel}${result.permissionMode ? `  ·  permission mode: ${result.permissionMode}` : ""}`);
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- cursor-agent final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/delegate-setup/SKILL.md
+++ b/skills/delegate-setup/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: delegate-setup
+description: 'Configure delegation fleet lanes: which implementer CLI handles which
+  kind of work, with optional model and effort (or variant) dials. Discovers installed
+  CLIs, proposes a lane map for user approval, and writes global or project config
+  only after explicit yes. Use when the...'
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires Node 18+. No implementer CLIs are required — the skill discovers
+  what is available.
+metadata:
+  version: 0.5.0
+---
+# Delegate Setup
+
+## When to Use
+
+- You want to configure which implementer CLI handles which kind of work (fleet lanes).
+- You need to discover installed implementers and write lane config after user approval.
+
+You are the **orchestrator** in **setup mode**. Discover installed implementer CLIs, propose a
+**fleet of lanes**, and write configuration only after the user approves.
+
+This skill does **not** dispatch coding work. It only authors the lane map.
+
+One concept: **lanes**. Never say “routes.”
+
+Example lane: **feature** → implementer `opencode`, model `opencode/grok`, variant `high`
+(OpenCode uses `variant` for reasoning intensity, not `effort`).
+
+## When NOT to use this
+
+- The user wants a task implemented — use the matching `*-delegate` skill instead.
+- A one-off model change on a single dispatch — pass `--model` / `--effort` / `--variant` on that relay.
+
+## Hard rules
+
+1. Every lane **must** include `implementer`.
+2. Put dials on the same object (`model`, `effort` or `variant`, …) only if that implementer supports them — see [references/schema.md](references/schema.md).
+3. Show a human-readable lane table **and** the full JSON before every write; re-show after every tweak.
+4. Write **only** after an explicit approval (“yes”, “approve”, “write it”).
+5. Ask scope unless already clear: **global** (all projects) vs **this repo only**. Never create a project file just because cwd is a git repo. If there is no git repo, default to global and say so.
+6. Do not invent model identifiers.
+7. In interview or usage-scan mode, never write **any** dial the user did not give you and the schema does not require — omit it, so the CLI’s or relay’s own default applies.
+8. Prefer 3–5 useful lanes over a kitchen-sink map.
+9. Never edit `AGENTS.md`, `CLAUDE.md`, or other user agent-instruction files.
+10. Never run a `*-delegate` relay from this skill.
+
+(`<skill-dir>` is this skill’s install directory — the folder that contains this `SKILL.md`.)
+
+## Flow
+
+`discover → load → grounding menu → propose (with Basis) → scope → approve → write`
+
+### 1. Discover
+
+```bash
+node "<skill-dir>/scripts/discover.mjs"
+```
+
+Summarize installed vs missing, auth (`true` / `false` / `null` = unknown), and whether models were
+`reported`, `aliases` (curated aliases in the registry, not live discovery — full model names also
+work), `unsupported`, or `failed`.
+
+### 2. Load existing (effective map)
+
+```bash
+node "<skill-dir>/scripts/config.mjs" load --cwd "$PWD"
+```
+
+- Neither present → “No lanes configured yet.”
+- Otherwise → table of **effective** lanes with a Source column (`global` / `project`). Do not paste
+  both raw files unless asked.
+- If `projectPresent` is true and `projectTrusted` is false, label the project lanes **untrusted**.
+  They cannot dispatch until the user reviews and approves a project write.
+
+### 3. Propose
+
+Discovery reports capability, never task fit. So ask **one** grounding question before proposing
+anything — one question, three options, not a wizard:
+
+> How should I pick the lanes? **(1) Quick defaults** — I decide, no questions.
+> **(2) Interview** — about four questions on how you want work allocated.
+> **(3) Usage scan** — I re-read your CLIs’ local session folders (counts and dates only, never the
+> conversations) and let the numbers place your lanes — if one CLI dominates, expect one question
+> about its role. Happy to do 2 and 3 together.
+
+- **Quick defaults** → propose immediately.
+- **Interview** → the four questions (allocation policy, never model rankings) and how to ask them
+  (one medium per round) live in [references/setup-dialogue.md](references/setup-dialogue.md) — read
+  it before you ask.
+- **Usage scan** → `node "<skill-dir>/scripts/discover.mjs" --usage`. Tell the user it is metadata
+  only before running it. Each discovered CLI gains `usage: { sessions, lastUsed }`; `null` means no
+  probe is wired — unknown, not unused.
+- **Both** → run the scan first, then ask only what the numbers cannot answer.
+- Inside a git repo, repo signals (languages, test weight, frontend share) are a fourth source of
+  evidence. They do not change the menu; they feed the proposal and the `repo` basis.
+
+**That menu is also the consent surface** — the option chosen sets how much of the map is yours to
+decide:
+
+- **Quick defaults** — the user hired your opinion. A full map is legitimate, dials included; label
+  every lane `my opinion`, say plainly that the map is your opinion, and keep it cheap to revise.
+- **Interview / usage scan** — evidence modes, so **every** dial is gated (rule 7): set one only from
+  the user’s answer, or where the schema requires it (opencode lanes require `model`). Omitting is
+  always safe — every dial has a default the user already lives with, and a CLI’s configured default
+  is their standing choice, better evidence than your priors. Choosing which installed implementer
+  gets a lane is still yours — Basis `my opinion` — but a dial that raises spend is not: offer your
+  dial picks only as an addendum after the proposal, see
+  [references/setup-dialogue.md](references/setup-dialogue.md).
+- **An unanswered question shrinks the map; it never licenses a substitution.** Propose fewer, more
+  conservative lanes, name the axis you are blind on (no quota answer → say the map is quota-blind),
+  and invite the answer anytime. Re-ask once at most; never backfill silence with priors.
+
+**Delegation economics.** The orchestrator reviews and lands every result — the review is the
+quality gate, so optimize total cost, not implementer prestige:
+
+- Prefer capable, authenticated, burnable, **low-usage** CLIs for bounded, objectively gated work
+  (tests, mechanical refactors, straightforward fixes) when their reliability keeps review and
+  rework economical — lanes push token burn away from the subscriptions the user is protecting.
+  Low usage alone does not establish burnable: discovery cannot see plans, limits, or per-run
+  cost, and a rarely-used CLI may be metered or deliberately avoided. Burnable comes from the
+  user's quota answer — or, in quick defaults, from your labeled opinion.
+- Avoid binding a lane to a CLI the user is protecting or orchestrates from, by default; bind it
+  only when the user asks for it or no acceptable alternative exists. Lanes are
+  **orchestrator-blind**: the same lane fires from every seat the user drives from, and from that
+  CLI's own seat it dispatches the CLI to itself.
+- Surplus placement breaks down when rework and review cost exceed the savings; when the
+  implementer is flaky; when correctness rides on security, concurrency, migrations, or unstated
+  domain knowledge; and when the output **is** the product (debate, architecture, research) —
+  review limits damage, it does not manufacture a good first attempt. Bind those lanes to stronger
+  implementers.
+- An explicit "spare X" answer removes X from proposed lanes by default, and overrides blanket
+  posture answers on any lane the user explicitly retains for X — ask whether the posture applies
+  there; omit the dial if unanswered. Never silently stretch one answer across an axis it
+  conflicts with.
+
+Question phrasings for the burn/spare and trust interview live in
+[references/setup-dialogue.md](references/setup-dialogue.md).
+
+Then propose the lanes. Name them after the work the user described; fall back to `feature`, `tests`,
+`ui`, `fast`, `complex`. Installed implementers only.
+
+Show:
+
+| Lane | Implementer | Model | Effort / variant | Basis | Source (if updating) |
+| --- | --- | --- | --- | --- | --- |
+| feature | opencode | opencode/grok | variant: high | your answer + schema requirement | — |
+| tests | codex | — | — | usage data | — |
+| ui | claude | — | — | my opinion (implementer) | — |
+
+**Basis** is mandatory on every lane: `your answer` / `usage data` / `repo` / `my opinion` /
+`schema requirement` (a dial the schema forces is neither evidence nor opinion — say so). A lane you
+picked from model-quality priors is `my opinion` — never present it as something the tooling
+determined, and “installed and authenticated” is capability, not evidence of fit. When a lane’s
+implementer and its dials come from different places, split the label — see
+[references/setup-dialogue.md](references/setup-dialogue.md).
+
+Then the **complete** JSON (`version`: `delegate-fleet.v1`). One line of why per lane; flag auth or
+model uncertainty.
+
+Schema and dial table: [references/schema.md](references/schema.md).
+
+### 4. Scope
+
+- User said global / all projects / outside the project → `global`.
+- No git repo → `global` (say so).
+- Else ask once: global vs this repo only.
+
+### 5. Approve and write
+
+On explicit yes, write **only** the chosen scope (validate first). Build the payload from that
+scope’s raw file (or an empty `lanes` object if new) — not from the effective merged `load` view,
+or a project write will shadow global-only lanes and a global write will promote project-only ones.
+
+Create a uniquely named file under the platform temporary directory (`$TMPDIR`, `%TEMP%`, or Node
+`os.tmpdir()`; never hard-code `/tmp`, which breaks on native Windows), write the **exact approved
+JSON** into it with the orchestrator's file-writing tool, and use that populated path as
+`<lanes-json>` below. Never validate an empty temp file. Remove the temp file after the
+validation/write attempt, whether it succeeds or fails.
+
+```bash
+node "<skill-dir>/scripts/config.mjs" validate "<lanes-json>"
+node "<skill-dir>/scripts/config.mjs" write --scope global "<lanes-json>"
+# or:  write --scope project --cwd /path/to/repo "<lanes-json>"
+```
+
+Re-read with `load`, then confirm the path written and the active lane names. Project writes bind
+approval to the exact config content; later changes fail closed until re-approved. On update, a short
+before/after is enough.
+
+### 6. Ready to delegate
+
+Stop after confirming. Tell the user the map is ready. For later work: read the lane’s
+`implementer`, load that `*-delegate` skill, and dispatch with `--lane <name>` (explicit
+`--model` / `--effort` / `--variant` still win when passed). Do not start a delegate task
+unless they ask.
+
+## Reconfigure
+
+Same flow. Show the effective current map, propose changes, approve, write one scope’s file.
+Reinstalling the skills package must not rewrite these files — they live outside the package.
+
+
+## Limitations
+
+- Never dispatches work itself — only discovers CLIs and writes config after explicit approval.
+- Requires Node 18+; no implementer CLIs are required for setup (it discovers what is available).
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/delegate-setup/references/schema.md
+++ b/skills/delegate-setup/references/schema.md
@@ -1,0 +1,100 @@
+# Fleet schema (`delegate-fleet.v1`)
+
+One concept: **lanes**. A lane names an implementer and optional dials.
+
+## Document
+
+```json
+{
+  "version": "delegate-fleet.v1",
+  "lanes": {
+    "feature": {
+      "implementer": "opencode",
+      "model": "opencode/grok",
+      "variant": "high"
+    },
+    "tests": {
+      "implementer": "grok",
+      "effort": "medium"
+    },
+    "complex": {
+      "implementer": "claude",
+      "effort": "high"
+    }
+  }
+}
+```
+
+- `version` must be `delegate-fleet.v1`.
+- `lanes` is an object keyed by lane name (`[A-Za-z0-9][A-Za-z0-9._-]*`).
+- Every lane **requires** `implementer` (a key from the registry below).
+- Other fields are dials; only dials listed for that implementer are allowed.
+
+## Paths
+
+| Scope | Path |
+| --- | --- |
+| Global | `$XDG_CONFIG_HOME/delegate-skills/config.json` when `XDG_CONFIG_HOME` is set; otherwise `~/.config/delegate-skills/config.json` (`os.homedir()` → `HOME` / `USERPROFILE`) |
+| Project | `<git-root>/.delegate/config.json` |
+
+Project overlays global by **whole-lane replace** (same lane name in project fully replaces the global lane).
+Relays apply a project lane only when its exact config content matches the approval hash written under
+that worktree's Git metadata by an explicitly approved `config.mjs write --scope project`. Cloned or
+later-edited project config fails closed until it is reviewed and written again through `delegate-setup`.
+
+## Implementer keys and dials
+
+| Key | Skill | Binary | Supported dials |
+| --- | --- | --- | --- |
+| `claude` | claude-delegate | `claude` | model, effort, timeout, readOnly |
+| `cline` | cline-delegate | `cline` | provider, model, timeout |
+| `codex` | codex-delegate | `codex` | model, effort, sandbox, timeout, readOnly |
+| `commandcode` | commandcode-delegate | `cmd` | model, effort, timeout, readOnly |
+| `opencode` | opencode-delegate | `opencode` | model, **variant**, timeout, readOnly |
+| `agy` | agy-delegate | `agy` | model, effort, timeout, readOnly |
+| `grok` | grok-delegate | `grok` | model, effort, sandbox, timeout, readOnly |
+| `kimi` | kimi-delegate | `kimi` | model, timeout |
+| `qoder` | qoder-delegate | `qodercli` | model, permissionMode, timeout, readOnly |
+| `vibe` | vibe-delegate | `vibe` | timeout, readOnly |
+| `cursor` | cursor-delegate | `cursor-agent` | model, force, timeout, readOnly |
+| `pi` | pi-delegate | `pi` | provider, model, timeout, readOnly |
+| `omp` | omp-delegate | `omp` | provider, model, **effort** (`--thinking`), timeout, readOnly |
+| `aider` | aider-delegate | `aider` | model, timeout, readOnly |
+| `copilot` | copilot-delegate | `copilot` | model, effort, timeout, readOnly |
+| `warp` | warp-delegate | `oz` | model, timeout |
+| `zcode` | zcode-delegate | `zcode` | permissionMode, timeout, readOnly |
+
+ZCode carries its `--mode` as `permissionMode`, and only `plan` and `yolo` are accepted: ZCode also
+documents `build` and `edit`, but a headless run has no permission client, so those two block every
+write tool and exit 0 having changed nothing. ZCode has no `--model` flag — the model is chosen in
+the CLI's own config file — so `model` is not a dial for `zcode` lanes. ZCode also ships its CLI
+inside the desktop app rather than on PATH, so discovery falls back to the installed app bundle.
+
+OpenCode uses `variant` for reasoning intensity, not `effort`. Do not write `effort` on an `opencode` lane.
+Oh My Pi (`omp`) uses the lane `effort` dial for omp's `--thinking` (`off`, `auto`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`). Do not write `thinking` as a lane field.
+OpenCode lanes **require** `model` in `provider/model` form, with a non-empty provider before the first
+`/` and at least one non-`/` character after it. Cline accepts `provider` and `model` as separate
+dials and does not impose that shape.
+
+Boolean dials: `readOnly`, `force`. All other dials are non-empty strings. Duration strings for
+`timeout` use `h`/`m`/`s` (e.g. `30m`) and must fit the relay watchdog ceiling (~24.8 days).
+Do not combine `readOnly: true` with a write-capable `sandbox` / `permissionMode` / `force`.
+`model` / `provider` / OpenCode `variant` must match the bound relay’s token rules (e.g. Claude
+rejects spaces; Grok/Pi/Oh My Pi/OpenCode/Codex use a shell-safe token set — Windows `shell:true`
+launches, and Oh My Pi's flag-injection defense even without a shell).
+
+## Helpers
+
+```bash
+node <skill-dir>/scripts/discover.mjs
+node <skill-dir>/scripts/config.mjs load [--cwd <dir>]
+node <skill-dir>/scripts/config.mjs validate <file>
+node <skill-dir>/scripts/config.mjs write --scope global|project [--cwd <dir>] <file>
+node <skill-dir>/scripts/lane.mjs resolve --cwd <dir> --lane <name> --implementer <key>
+```
+
+`load` prints the **effective** map (each lane includes a `source` of `global` or `project`) and
+`projectTrusted`, which reports whether the current project content matches its local approval hash.
+`lane.mjs resolve` is what `*-delegate` relays call for `--lane`: it fails loud on a missing
+lane, untrusted project config, or implementer mismatch, and prints relay-native dials
+(e.g. grok `sandbox` → `autonomy`).

--- a/skills/delegate-setup/references/setup-dialogue.md
+++ b/skills/delegate-setup/references/setup-dialogue.md
@@ -1,0 +1,101 @@
+# Setup dialogue details
+
+Load this when running a configure / reconfigure session. `SKILL.md` is authoritative and states each
+rule once; this page expands the dialogue itself — the interview, how to ask it, how to read a usage
+scan, and how to label what you propose.
+
+## Grounding the lane map
+
+The grounding menu is `SKILL.md` step 3. When the user picks the interview:
+
+### The four interview questions
+
+Allocation policy only. Users cannot rank model IDs — that is your job, not theirs.
+
+| # | Ask | What it settles |
+| --- | --- | --- |
+| 1 | What kind of work do you delegate most? | The main lane — and its **name**. “migrations”, “bug triage”, “release-prep” beat the canned `feature`/`tests`/`ui`/`fast`/`complex` five |
+| 2 | Which paid subscriptions should I burn, and which should I spare? | Quota economics. Discovery cannot see plans, limits, or what a run costs — only the user knows |
+| 3 | Any CLI you already trust — and for what kind of work? Any that has burned you? | Lived experience outranks your priors about the underlying models. Trust is scoped: an answer qualifies the CLI for work like the work that earned it — follow up on the scope before it qualifies a high-stakes lane. It is never an order to assign work: "trusted + spared" means qualified but normally excluded (the spare rule is in `SKILL.md` step 3) |
+| 4 | Default to fast and cheap, or slow and thorough? | Effort / variant dials, and who gets the `complex` lane |
+
+Stop at four.
+
+### How to ask them
+
+The questions are conversation, not a survey — cramming all four into one cold multiple-choice
+form loses exactly what they exist to collect.
+
+- **One medium per round.** Every question you ask in a turn goes through the same channel: all
+  prose, or all in one form. Never mix the two — submitting a form ends the turn, so any prose
+  question asked beside it is simply lost, and the silence that follows is not an answer to it.
+- **Question 1 is open-ended.** You want the user's words — they become lane names. If your harness
+  forces options, derive them from evidence (repo, usage scan, what the user has said), keep them one
+  genre (kinds of work — never a mix of domains and task types, which overlap), and treat a selection
+  as a draft lane name, not a category.
+- **Questions 2 and 3 are set-valued.** The answer is a mapping across CLIs, so options must span the
+  *discovered* CLIs — never an arbitrary subset — with both directions expressible: burn *and* spare,
+  trust *and* burned-by. Multi-select if the harness has it; otherwise ask in prose.
+- **Question 4 may be a closed choice.** Do not pre-mark an option as recommended — recommendations
+  belong in the proposal, after the answers.
+- **Lead with question 1.** Its answer usually reshapes or removes the others — fewer than four is
+  better.
+- **Silence shrinks the map** — the consent rule is in `SKILL.md` step 3; here is the phrasing for
+  it. Name the axis in one line — “nobody told me which subscriptions to spare, so I set no effort
+  dials; each CLI will use the default you configured” — and add that the answer is welcome anytime.
+
+### Reading a usage scan
+
+`node <skill-dir>/scripts/discover.mjs --usage` adds `usage` to each discovered CLI:
+`{ "sessions": <int>, "lastUsed": <ISO-8601 | null> }`, or `null`.
+
+- What to tell the user before running it: it counts session files and reads their timestamps. It
+  never opens one, so no conversation content is read.
+- `usage: null` also covers a CLI with no local state directory — never report it as zero.
+- Large disparities show where activity occurs — not what role the CLI played in it. 1600 codex
+  sessions against 20 pi sessions cannot tell you whether the user works inside codex (and would
+  orchestrate from it) or sends delegated work to it. Treat a meaningful disparity as a signal to
+  **ask**, never to assign: "codex has the most local sessions, but the scan cannot tell whether
+  you work inside it or delegate work to it — should I protect its quota, burn it as an
+  implementer, or treat it as mixed?" Combine the answer with the burn/spare interview answer when
+  the interview also ran; in a scan-only session the role answer is your only quota evidence —
+  propose conservatively and name the map quota-blind (the shrink rule in `SKILL.md` step 3).
+- Low usage alone is not evidence of task fit. A surplus CLI still needs to be installed,
+  authenticated, and reliable to earn a lane.
+- Small differences are noise. 97 against 61 decides nothing — fall back to the interview or to your
+  opinion, and label it as such.
+- `lastUsed` weighs as much as the count. A big count that stopped months ago is a CLI the user moved
+  off; a recent date on a small count is one they are adopting.
+- Counts are lifetime totals for that machine, not “this month”, and only cover sessions the CLI still
+  keeps on disk.
+
+### Labelling the basis
+
+The Basis values, and the rule that every lane carries one, are in `SKILL.md`. What lives here is the
+split label and the addendum.
+
+Label the parts separately when they differ. A lane whose implementer came from the usage scan but
+whose model you chose is `usage + my opinion (model)`, never a flat `usage data` — session counts
+say where the user works, not which model or effort level to buy for them. That split only exists in
+quick-defaults mode, or when the user asked you for a dial: the evidence modes gate every dial
+(`SKILL.md` rule 7), so there is no opinion-dial left to label.
+
+In the evidence modes, unsolicited opinions about dials travel as an **addendum**, never as a
+pre-filled field (quick-defaults proposals may include opinion-labeled dials — the user hired that
+opinion). Show the table and the JSON first, then, in a separate paragraph after it: “If you want my
+picks for models and effort levels, say the word and I’ll add them.” Then wait. A dial the user
+asked for is theirs; the same dial sitting inside the JSON they are about to approve spent their
+quota on your say-so.
+
+## Auth and models
+
+- `authenticated: null` (unknown) usually means no auth probe is wired for that CLI — currently `agy`
+  and `pi`, which expose no status command. Say that, rather than implying the login failed.
+- Prefer not binding a lane to a CLI discover reports as `authenticated: false`.
+- For claude specifically, `authenticated: false` can be a Keychain artifact when discovery itself
+  ran inside a sandbox: on macOS the live credentials sit in the login Keychain, and a sandbox that
+  blocks Keychain access makes the probe fall back to a possibly stale credentials file. Verify with
+  `claude auth status` outside the sandbox before treating the CLI as unauthenticated.
+- Never invent model ids (rule 6): use `models.values` when `status` is `reported`, or ask the user,
+  or omit `model` when the CLI has a safe default (OpenCode does **not** — require a model for
+  opencode lanes).

--- a/skills/delegate-setup/scripts/config.mjs
+++ b/skills/delegate-setup/scripts/config.mjs
@@ -1,0 +1,498 @@
+#!/usr/bin/env node
+/**
+ * config.mjs — load, merge, validate, and write delegate-fleet.v1 lane maps.
+ *
+ * Usage:
+ *   node config.mjs load [--cwd <dir>]
+ *   node config.mjs validate <file>
+ *   node config.mjs write --scope global|project [--cwd <dir>] <file>
+ *   node config.mjs --help
+ *
+ * Node built-ins only. No network, credentials, or telemetry.
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  AGY_EFFORT,
+  ALL_DIALS,
+  CLAUDE_EFFORT,
+  COPILOT_EFFORT,
+  OMP_THINKING,
+  CODEX_SANDBOX,
+  CONFIG_VERSION,
+  GROK_SANDBOX,
+  IMPLEMENTER_BY_KEY,
+  LANE_NAME,
+  MODEL_TOKEN,
+  QODER_PERMISSION,
+  TIMEOUT_RE,
+  ZCODE_MODE,
+} from "./implementers.mjs";
+
+/** Same ceiling relays use for --timeout (Node setTimeout max ~24.8 days). */
+const MAX_TIMER_MS = 2_147_483_647;
+
+const HELP = `config.mjs — load / validate / write delegate-fleet.v1 lane maps
+
+Usage:
+  node config.mjs load [--cwd <dir>]
+  node config.mjs validate <file>
+  node config.mjs write --scope global|project [--cwd <dir>] <file>
+  node config.mjs --help
+
+Paths:
+  global   ~/.config/delegate-skills/config.json
+  project  <git-root>/.delegate/config.json  (requires a git repo)
+
+load prints the effective lane map (project whole-lane replaces global) as JSON.
+`;
+
+export function globalConfigPath() {
+  // Prefer XDG when set; otherwise ~/.config (homedir() → HOME / USERPROFILE).
+  const base = process.env.XDG_CONFIG_HOME
+    ? process.env.XDG_CONFIG_HOME
+    : join(homedir(), ".config");
+  return join(base, "delegate-skills", "config.json");
+}
+
+export function findGitRoot(cwd) {
+  const r = spawnSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (r.status !== 0) return null;
+  const root = (r.stdout || "").trim();
+  return root || null;
+}
+
+export function projectConfigPath(cwd) {
+  const root = findGitRoot(cwd);
+  if (!root) return null;
+  return join(root, ".delegate", "config.json");
+}
+
+function projectTrustPath(cwd) {
+  const r = spawnSync("git", ["-C", cwd, "rev-parse", "--absolute-git-dir"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (r.status !== 0) return null;
+  const gitDir = (r.stdout || "").trim();
+  return gitDir ? join(gitDir, "delegate-skills", "project-config.sha256") : null;
+}
+
+function fail(message) {
+  process.stderr.write(`config.mjs: ${message}\n`);
+  process.exit(2);
+}
+
+/**
+ * @returns {{ ok: true, document: object } | { ok: false, error: string }}
+ */
+export function parseConfigDocument(raw, label = "config") {
+  let document;
+  try {
+    document = JSON.parse(raw);
+  } catch (error) {
+    return { ok: false, error: `${label}: invalid JSON (${error.message})` };
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    return { ok: false, error: `${label}: expected a JSON object` };
+  }
+  if (document.version !== CONFIG_VERSION) {
+    return {
+      ok: false,
+      error: `${label}: unsupported version ${JSON.stringify(document.version)} (expected ${CONFIG_VERSION})`,
+    };
+  }
+  if (!document.lanes || typeof document.lanes !== "object" || Array.isArray(document.lanes)) {
+    return { ok: false, error: `${label}: lanes must be an object` };
+  }
+  for (const [name, lane] of Object.entries(document.lanes)) {
+    const laneError = validateLane(name, lane, label);
+    if (laneError) return { ok: false, error: laneError };
+  }
+  return { ok: true, document };
+}
+
+function validateLane(name, lane, label) {
+  if (!LANE_NAME.test(name)) {
+    return `${label}: invalid lane name ${JSON.stringify(name)}`;
+  }
+  if (!lane || typeof lane !== "object" || Array.isArray(lane)) {
+    return `${label}: lane ${name} must be an object`;
+  }
+  if (typeof lane.implementer !== "string" || IMPLEMENTER_BY_KEY[lane.implementer] == null) {
+    return `${label}: lane ${name} needs implementer (one of: ${Object.keys(IMPLEMENTER_BY_KEY).join(", ")})`;
+  }
+  const impl = IMPLEMENTER_BY_KEY[lane.implementer];
+  for (const field of Object.keys(lane)) {
+    if (field === "implementer") continue;
+    if (!ALL_DIALS.includes(field)) {
+      return `${label}: lane ${name} has unknown field ${JSON.stringify(field)}`;
+    }
+    if (!impl.supports.includes(field)) {
+      return `${label}: lane ${name}: ${impl.key} does not support ${field} (supports: ${impl.supports.join(", ") || "none"})`;
+    }
+    if (field === "readOnly" || field === "force") {
+      if (typeof lane[field] !== "boolean") {
+        return `${label}: lane ${name}.${field} must be a boolean`;
+      }
+      continue;
+    }
+    if (typeof lane[field] !== "string" || lane[field].length === 0) {
+      return `${label}: lane ${name}.${field} must be a non-empty string`;
+    }
+    const valueError = validateDialValue(impl.key, field, lane[field], name, label);
+    if (valueError) return valueError;
+  }
+  if (impl.key === "opencode") {
+    if (typeof lane.model !== "string" || !lane.model) {
+      return `${label}: lane ${name}: opencode requires model (provider/model)`;
+    }
+    const separator = lane.model.indexOf("/");
+    if (separator <= 0 || !/[^/]/.test(lane.model.slice(separator + 1))) {
+      return `${label}: lane ${name}.model must be provider/model (e.g. opencode/grok)`;
+    }
+  }
+  const autonomyError = validateAutonomyConsistency(impl.key, lane, name, label);
+  if (autonomyError) return autonomyError;
+  return null;
+}
+
+function validateAutonomyConsistency(implementer, lane, laneName, label) {
+  if (lane.readOnly !== true) return null;
+  if (implementer === "codex" && typeof lane.sandbox === "string" && lane.sandbox !== "read-only") {
+    return `${label}: lane ${laneName}: readOnly contradicts sandbox ${JSON.stringify(lane.sandbox)}`;
+  }
+  if (implementer === "grok" && typeof lane.sandbox === "string" && lane.sandbox !== "read-only") {
+    return `${label}: lane ${laneName}: readOnly contradicts sandbox ${JSON.stringify(lane.sandbox)}`;
+  }
+  if (
+    implementer === "qoder" &&
+    typeof lane.permissionMode === "string" &&
+    lane.permissionMode !== "plan"
+  ) {
+    return `${label}: lane ${laneName}: readOnly contradicts permissionMode ${JSON.stringify(lane.permissionMode)}`;
+  }
+  if (implementer === "cursor" && lane.force === true) {
+    return `${label}: lane ${laneName}: readOnly contradicts force true`;
+  }
+  return null;
+}
+
+function parseTimeoutMs(value) {
+  const match = TIMEOUT_RE.exec(value);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function validateDialValue(implementer, field, value, laneName, label) {
+  if (field === "timeout") {
+    if (parseTimeoutMs(value) === null) {
+      return `${label}: lane ${laneName}.timeout must be a positive h/m/s duration no longer than about 24 days (e.g. 30m)`;
+    }
+    return null;
+  }
+  if (field === "effort") {
+    if (implementer === "agy" && !AGY_EFFORT.includes(value)) {
+      return `${label}: lane ${laneName}.effort must be one of: ${AGY_EFFORT.join(", ")}`;
+    }
+    if (implementer === "claude" && !CLAUDE_EFFORT.includes(value)) {
+      return `${label}: lane ${laneName}.effort must be one of: ${CLAUDE_EFFORT.join(", ")}`;
+    }
+    if (implementer === "copilot" && !COPILOT_EFFORT.includes(value)) {
+      return `${label}: lane ${laneName}.effort must be one of: ${COPILOT_EFFORT.join(", ")}`;
+    }
+    if (implementer === "omp" && !OMP_THINKING.includes(value)) {
+      return `${label}: lane ${laneName}.effort must be one of: ${OMP_THINKING.join(", ")}`;
+    }
+    if (
+      (implementer === "codex" || implementer === "grok" || implementer === "commandcode") &&
+      !/^[a-z][a-z0-9-]*$/i.test(value)
+    ) {
+      return `${label}: lane ${laneName}.effort must be a bare token`;
+    }
+    return null;
+  }
+  if (field === "sandbox") {
+    if (implementer === "codex" && !CODEX_SANDBOX.includes(value)) {
+      return `${label}: lane ${laneName}.sandbox must be one of: ${CODEX_SANDBOX.join(", ")}`;
+    }
+    if (implementer === "grok" && !GROK_SANDBOX.includes(value)) {
+      return `${label}: lane ${laneName}.sandbox must be one of: ${GROK_SANDBOX.join(", ")}`;
+    }
+    return null;
+  }
+  if (field === "permissionMode" && implementer === "qoder" && !QODER_PERMISSION.includes(value)) {
+    return `${label}: lane ${laneName}.permissionMode must be one of: ${QODER_PERMISSION.join(", ")}`;
+  }
+  // ZCode carries --mode here. build/edit are excluded on purpose: headless runs
+  // have no permission client, so they change nothing and still exit 0.
+  if (field === "permissionMode" && implementer === "zcode" && !ZCODE_MODE.includes(value)) {
+    return `${label}: lane ${laneName}.permissionMode must be one of: ${ZCODE_MODE.join(", ")}`;
+  }
+  if (field === "variant") {
+    // OpenCode appends --variant on win32 shell:true; reject cmd metacharacters.
+    if (!MODEL_TOKEN.shellSafe.test(value)) {
+      return `${label}: lane ${laneName}.variant has unsupported characters (allowed: letters, digits, . _ : / -)`;
+    }
+    return null;
+  }
+  if (field === "model" || field === "provider") {
+    const modelError = validateModelOrProvider(implementer, field, value, laneName, label);
+    if (modelError) return modelError;
+  }
+  return null;
+}
+
+function validateModelOrProvider(implementer, field, value, laneName, label) {
+  if (implementer === "qoder" && !value.trim()) {
+    return `${label}: lane ${laneName}.${field} must not be empty`;
+  }
+  let pattern = null;
+  let hint = "";
+  if (implementer === "claude") {
+    pattern = MODEL_TOKEN.claude;
+    hint = "letters, digits, . _ : @ / [ ] -";
+  } else if (implementer === "cursor") {
+    pattern = MODEL_TOKEN.cursor;
+    hint = "letters, digits, . _ : @ / [ ] , = -";
+  } else if (
+    implementer === "grok" ||
+    implementer === "pi" ||
+    implementer === "omp" ||
+    implementer === "opencode" ||
+    implementer === "commandcode" ||
+    // codex (and any other win32 shell:true relay) must not accept cmd metacharacters in -m.
+    implementer === "codex" ||
+    IMPLEMENTER_BY_KEY[implementer]?.winShell
+  ) {
+    pattern = MODEL_TOKEN.shellSafe;
+    hint = "letters, digits, . _ : / -";
+  }
+  if (pattern && !pattern.test(value)) {
+    return `${label}: lane ${laneName}.${field} has unsupported characters for ${implementer} (allowed: ${hint})`;
+  }
+  return null;
+}
+
+/**
+ * Refuse project writes that escape the git root via a symlinked `.delegate`.
+ */
+export function assertSafeProjectConfigPath(cwd) {
+  const root = findGitRoot(cwd);
+  if (!root) throw new Error("project scope requires a git repository (--cwd)");
+  const delegateDir = join(root, ".delegate");
+  if (existsSync(delegateDir) && lstatSync(delegateDir).isSymbolicLink()) {
+    throw new Error("refusing to write: .delegate is a symlink");
+  }
+  mkdirSync(delegateDir, { recursive: true });
+  if (lstatSync(delegateDir).isSymbolicLink()) {
+    throw new Error("refusing to write: .delegate is a symlink");
+  }
+  const realRoot = realpathSync(root);
+  const realDelegate = realpathSync(delegateDir);
+  const rel = relative(realRoot, realDelegate);
+  if (!rel || rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error("refusing to write: .delegate resolves outside the git repository");
+  }
+  if (rel !== ".delegate" && !rel.startsWith(`.delegate${sep}`)) {
+    throw new Error("refusing to write: unexpected .delegate path");
+  }
+  return join(delegateDir, "config.json");
+}
+
+export function readConfigFile(path) {
+  if (!path || !existsSync(path)) return null;
+  const raw = readFileSync(path);
+  const parsed = parseConfigDocument(raw.toString("utf8"), path);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return { path, document: parsed.document, digest: configDigest(raw) };
+}
+
+function configDigest(raw) {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+function projectConfigTrusted(cwd, digest) {
+  const trustPath = projectTrustPath(cwd);
+  if (!digest || !trustPath || !existsSync(trustPath)) return false;
+  return readFileSync(trustPath, "utf8").trim() === digest;
+}
+
+function trustProjectConfig(cwd, digest) {
+  const trustPath = projectTrustPath(cwd);
+  if (!trustPath) throw new Error("project scope requires writable git metadata");
+  mkdirSync(dirname(trustPath), { recursive: true });
+  writeFileSync(trustPath, `${digest}\n`, "utf8");
+}
+
+/**
+ * Effective lanes: start from global, whole-lane replace from project.
+ */
+export function effectiveLanes(globalDoc, projectDoc) {
+  /** @type {Record<string, { lane: object, source: "global"|"project" }>} */
+  const out = {};
+  if (globalDoc?.lanes) {
+    for (const [name, lane] of Object.entries(globalDoc.lanes)) {
+      out[name] = { lane: { ...lane }, source: "global" };
+    }
+  }
+  if (projectDoc?.lanes) {
+    for (const [name, lane] of Object.entries(projectDoc.lanes)) {
+      out[name] = { lane: { ...lane }, source: "project" };
+    }
+  }
+  return out;
+}
+
+export function loadEffective(cwd = process.cwd()) {
+  const globalPath = globalConfigPath();
+  const projectPath = projectConfigPath(cwd);
+  const globalFile = readConfigFile(globalPath);
+  const projectFile = projectPath ? readConfigFile(projectPath) : null;
+  const projectTrusted = Boolean(projectFile && projectConfigTrusted(cwd, projectFile.digest));
+  const effective = effectiveLanes(globalFile?.document, projectFile?.document);
+  return {
+    version: CONFIG_VERSION,
+    globalPath,
+    projectPath,
+    globalPresent: Boolean(globalFile),
+    projectPresent: Boolean(projectFile),
+    projectTrusted,
+    lanes: Object.fromEntries(
+      Object.entries(effective).map(([name, { lane, source }]) => [
+        name,
+        { ...lane, source },
+      ]),
+    ),
+  };
+}
+
+export function writeAtomic(targetPath, document) {
+  const parsed = parseConfigDocument(JSON.stringify(document), "write payload");
+  if (!parsed.ok) throw new Error(parsed.error);
+  mkdirSync(dirname(targetPath), { recursive: true });
+  // Temp file must live beside the target: renameSync across drives fails on Windows (EXDEV).
+  const tmp = join(
+    dirname(targetPath),
+    `.config.${process.pid}.${Date.now()}.tmp`,
+  );
+  const raw = `${JSON.stringify(parsed.document, null, 2)}\n`;
+  try {
+    writeFileSync(tmp, raw, "utf8");
+    renameSync(tmp, targetPath);
+  } catch (error) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {
+      // best-effort cleanup
+    }
+    throw error;
+  }
+  return configDigest(raw);
+}
+
+function main(argv) {
+  try {
+    if (argv.includes("--help") || argv.includes("-h") || argv.length === 0) {
+      process.stdout.write(HELP);
+      process.exit(argv.length === 0 ? 2 : 0);
+    }
+
+    const cmd = argv[0];
+    let cwd = process.cwd();
+    const cwdIdx = argv.indexOf("--cwd");
+    if (cwdIdx !== -1) {
+      if (!argv[cwdIdx + 1]) fail("--cwd needs a directory");
+      cwd = resolve(argv[cwdIdx + 1]);
+    }
+
+    if (cmd === "load") {
+      process.stdout.write(`${JSON.stringify(loadEffective(cwd), null, 2)}\n`);
+      return;
+    }
+
+    if (cmd === "validate") {
+      const file = argv.find(
+        (a, i) => i > 0 && !a.startsWith("--") && argv[i - 1] !== "--cwd",
+      );
+      if (!file) fail("validate needs a file path");
+      const parsed = parseConfigDocument(readFileSync(resolve(file), "utf8"), file);
+      if (!parsed.ok) fail(parsed.error);
+      process.stdout.write(`${JSON.stringify({ ok: true, path: resolve(file), lanes: Object.keys(parsed.document.lanes) }, null, 2)}\n`);
+      return;
+    }
+
+    if (cmd === "write") {
+      const scopeIdx = argv.indexOf("--scope");
+      const scope = scopeIdx !== -1 ? argv[scopeIdx + 1] : null;
+      if (scope !== "global" && scope !== "project") fail("--scope must be global or project");
+      const file = argv.filter((a, i) => {
+        if (a.startsWith("--")) return false;
+        if (i > 0 && (argv[i - 1] === "--cwd" || argv[i - 1] === "--scope")) return false;
+        return i > 0;
+      }).at(-1);
+      if (!file) fail("write needs a JSON file path");
+      const parsed = parseConfigDocument(readFileSync(resolve(file), "utf8"), file);
+      if (!parsed.ok) fail(parsed.error);
+      const target =
+        scope === "global" ? globalConfigPath() : assertSafeProjectConfigPath(cwd);
+      const writtenDigest = writeAtomic(target, parsed.document);
+      if (scope === "project") trustProjectConfig(cwd, writtenDigest);
+      process.stdout.write(`${JSON.stringify({
+        ok: true,
+        path: target,
+        lanes: Object.keys(parsed.document.lanes),
+        ...(scope === "project" ? { projectTrusted: true } : {}),
+      }, null, 2)}\n`);
+      return;
+    }
+
+    fail(`unknown command ${JSON.stringify(cmd)}. Use --help.`);
+  } catch (error) {
+    fail(error.message || String(error));
+  }
+}
+
+// realpath BOTH sides, not resolve: skill dirs are commonly symlinked (e.g.
+// ~/.claude/skills → ~/.agents/skills) and a plain resolve() mismatch made this file
+// silently no-op when run through a symlink. The module URL side needs it too —
+// under --preserve-symlinks-main it keeps the symlink path.
+const isMain = (() => {
+  if (!process.argv[1]) return false;
+  const toReal = (path) => {
+    try {
+      return realpathSync(path);
+    } catch {
+      return resolve(path);
+    }
+  };
+  return toReal(process.argv[1]) === toReal(fileURLToPath(import.meta.url));
+})();
+if (isMain) main(process.argv.slice(2));

--- a/skills/delegate-setup/scripts/discover.mjs
+++ b/skills/delegate-setup/scripts/discover.mjs
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+/**
+ * discover.mjs — probe PATH for installed implementer CLIs.
+ *
+ * Usage:
+ *   node discover.mjs           JSON report on stdout
+ *   node discover.mjs --usage   same report, plus a `usage` field per discovered CLI:
+ *                               { sessions, lastUsed } counted from that CLI's local
+ *                               session store, or null where no probe is wired.
+ *                               Metadata only — session entries are listed and stat'd,
+ *                               never opened, because they hold the user's conversations.
+ *   node discover.mjs --help
+ *
+ * Exit 0 even when nothing is installed. Exit 2 on usage errors.
+ * Node built-ins only. Probed CLIs may contact their own services.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { accessSync, constants as fsConstants, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, isAbsolute, join, resolve, sep } from "node:path";
+import { IMPLEMENTERS } from "./implementers.mjs";
+
+const PROBE_TIMEOUT_MS = 10_000;
+
+const HELP = `discover.mjs — probe PATH for installed implementer CLIs
+
+Usage:
+  node discover.mjs
+  node discover.mjs --usage
+  node discover.mjs --help
+
+Prints JSON:
+  {
+    "version": "delegate-discover.v1",
+    "discovered": [ { key, skill, binary, version, path, authenticated, supports, models } ],
+    "missing": [ { key, binary, skill } ]
+  }
+
+authenticated is true | false | null (null = unknown / no probe).
+models.status is reported | aliases | unsupported | failed
+(aliases = curated aliases from the registry, not a live listing).
+
+--usage adds "usage" to each discovered entry:
+  { "sessions": <int>, "lastUsed": <ISO-8601 | null> }, or null when no usage probe
+  is wired or the CLI has no local state directory (null = unknown, not zero).
+It counts session entries and reads their mtimes; it never opens a session file.
+`;
+
+function resolveBinary(binary) {
+  const pathValue = process.env.PATH || process.env.Path || "";
+  if (!pathValue) return null;
+  const pathEntries = pathValue
+    .split(delimiter)
+    .map((entry) => entry.replace(/^"(.*)"$/, "$1"))
+    .filter((entry) => entry.length > 0);
+
+  if (process.platform === "win32") {
+    const pathExt = (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+      .split(";")
+      .map((ext) => ext.trim().toLowerCase())
+      .filter(Boolean);
+    for (const entry of pathEntries) {
+      const dir = resolve(entry);
+      for (const ext of pathExt) {
+        const candidate = join(dir, `${binary}${ext}`);
+        try {
+          if (statSync(candidate).isFile()) return candidate;
+        } catch {
+          // keep looking
+        }
+      }
+    }
+    return null;
+  }
+
+  for (const entry of pathEntries) {
+    const candidate = join(resolve(entry), binary);
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      // keep looking
+    }
+  }
+  return null;
+}
+
+/** Expand ~ and %VAR% in a registry `locate` candidate, then normalize separators. */
+function expandCandidate(raw) {
+  const expanded = raw
+    .replace(/^~(?=\/)/, homedir())
+    .replace(/%([A-Za-z_][A-Za-z0-9_]*)%/g, (_, name) => process.env[name] || "");
+  return expanded.split("/").join(sep);
+}
+
+/**
+ * Resolve one implementer to a launch descriptor: PATH first, exactly as every
+ * sibling behaves, then the registry's `locate` candidates. The fallback exists
+ * for CLIs that ship inside a desktop app instead of on PATH (ZCode), and is
+ * consulted only when the binary is genuinely absent, so no existing
+ * implementer's behaviour changes. `prefixArgs` is empty for a plain binary and
+ * carries the bundle path when a launcher (node) runs it.
+ */
+function resolveLaunch(impl) {
+  if (impl.key === "commandcode" && process.env.COMMANDCODE_BIN) {
+    const configured = process.env.COMMANDCODE_BIN;
+    if (process.platform === "win32" && !isAbsolute(configured)) return null;
+    const command = /[\\/]/.test(configured) ? resolve(configured) : resolveBinary(configured);
+    if (!command || (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(command))) return null;
+    try {
+      const comspec = process.env.ComSpec || process.env.COMSPEC;
+      if (
+        process.platform === "win32" &&
+        comspec &&
+        realpathSync.native(command).toLowerCase() === realpathSync.native(comspec).toLowerCase()
+      ) return null;
+      if (statSync(command).isFile()) return { path: command, command, prefixArgs: [] };
+    } catch {
+      // report it missing below
+    }
+    return null;
+  }
+  if (process.platform === "win32" && impl.key === "commandcode") return null;
+  const onPath = resolveBinary(impl.binary);
+  if (onPath) return { path: onPath, command: onPath, prefixArgs: [] };
+  const candidates = impl.locate?.candidates?.[process.platform] ?? [];
+  for (const raw of candidates) {
+    const file = expandCandidate(raw);
+    try {
+      if (statSync(file).isFile()) {
+        return { path: file, command: process.execPath, prefixArgs: [file] };
+      }
+    } catch {
+      // keep looking
+    }
+  }
+  return null;
+}
+
+function needsWindowsShell(impl, launch) {
+  // A node-launched bundle is a real executable and never needs the shell, even
+  // for an implementer whose PATH binary would.
+  if (launch.prefixArgs.length > 0) return false;
+  return process.platform === "win32" && (impl.winShell || /\.(?:cmd|bat)$/i.test(launch.command));
+}
+
+/** Quote a path for cmd.exe when shell:true; reject metacharacters. */
+function quoteForCmd(value) {
+  if (/[\r\n%!]/.test(value) || value.includes('"')) {
+    throw new Error(`unsafe path for Windows shell probe: ${value}`);
+  }
+  return `"${value}"`;
+}
+
+function runProbe(launch, args, useShell) {
+  const command = useShell ? quoteForCmd(launch.command) : launch.command;
+  return execFileSync(command, [...launch.prefixArgs, ...args], {
+    encoding: "utf8",
+    timeout: PROBE_TIMEOUT_MS,
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: useShell,
+  });
+}
+
+/** Probe output is colorized (opencode); patterns match the plain text. */
+function stripAnsi(text) {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/** spawnSync, not runProbe: success-path stderr matters (codex prints login status there). */
+function captureProbe(launch, args, useShell) {
+  try {
+    const command = useShell ? quoteForCmd(launch.command) : launch.command;
+    const result = spawnSync(command, [...launch.prefixArgs, ...args], {
+      encoding: "utf8",
+      timeout: PROBE_TIMEOUT_MS,
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: useShell,
+    });
+    const stdout = result.stdout || "";
+    return {
+      ok: !result.error && result.status === 0,
+      stdout,
+      output: stripAnsi(`${stdout}${result.stderr || ""}`),
+    };
+  } catch {
+    return { ok: false, stdout: "", output: "" };
+  }
+}
+
+function probeVersion(impl, launch) {
+  const useShell = needsWindowsShell(impl, launch);
+  const tryArgs = (versionArgs) => {
+    try {
+      const raw = runProbe(launch, versionArgs, useShell);
+      const firstLine = raw.trim().split(/\r?\n/, 1)[0].trim();
+      if (!firstLine) return null;
+      if (impl.versionFormat !== "colon-prefix") return firstLine;
+      return /^([^:\s]+):/.exec(firstLine)?.[1] ?? firstLine;
+    } catch {
+      return null;
+    }
+  };
+  let version = tryArgs(impl.versionArgs);
+  if (version === null && impl.versionFallbackArgs) {
+    version = tryArgs(impl.versionFallbackArgs);
+  }
+  return version;
+}
+
+function readAuthField(raw, jsonField) {
+  try {
+    const field = JSON.parse(raw)[jsonField];
+    return typeof field === "boolean" ? field : null;
+  } catch {
+    return null;
+  }
+}
+
+function probeAuth(impl, launch, captured = null) {
+  if (!impl.authProbe) return null;
+  const { args, jsonField, successPattern, failPattern, missMeansFalse } = impl.authProbe;
+  const useShell = needsWindowsShell(impl, launch);
+
+  if (jsonField) {
+    try {
+      return readAuthField(runProbe(launch, args, useShell), jsonField);
+    } catch (error) {
+      const combined = `${error.stdout || ""}${error.stderr || ""}`;
+      if (combined.trim()) {
+        const parsed = readAuthField(combined, jsonField);
+        if (parsed !== null) return parsed;
+      }
+      return null;
+    }
+  }
+
+  const { ok, output } = captured || captureProbe(launch, args, useShell);
+  // failPattern first: "not logged in" also contains "logged in".
+  if (failPattern && failPattern.test(output)) return false;
+  if (successPattern) {
+    if (successPattern.test(output)) return true;
+    // Only a clean run can mean logged out, and only where the probe says absence is proof;
+    // elsewhere a reworded CLI would read as a confident false.
+    return ok && missMeansFalse ? false : null;
+  }
+  return ok ? true : null;
+}
+
+function modelResult(identifiers, status = "reported") {
+  const unique = [...new Set(identifiers)].filter(Boolean);
+  return {
+    status,
+    values: unique.slice(0, 200),
+    truncated: unique.length > 200,
+  };
+}
+
+function failedModels() {
+  return { status: "failed", values: [], truncated: false };
+}
+
+function parseModelLines(raw, format) {
+  const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  let identifiers;
+  if (format === "cursor") {
+    identifiers = lines
+      .filter((line) => line !== "Available models" && !line.startsWith("Tip:"))
+      .map((line) => line.split(/\s+-\s+/, 1)[0]);
+  } else if (format === "grok") {
+    identifiers = lines
+      .filter((line) => line.startsWith("* "))
+      .map((line) => line.slice(2).replace(/\s*\(default\)$/, "").trim());
+  } else if (format === "commandcode") {
+    // "vendor/name  description" rows, grouped under plain-text section headers and a
+    // count line. A slash in the first column is what separates a model row from those.
+    identifiers = lines
+      .map((line) => line.split(/\s+/, 1)[0])
+      .filter((first) => first.includes("/"));
+  } else if (format === "table") {
+    identifiers = lines
+      .slice(1)
+      .map((line) => line.split(/\s+/))
+      .filter((columns) => columns.length >= 2)
+      .map((columns) => `${columns[0]}/${columns[1]}`);
+  } else {
+    identifiers = lines;
+  }
+  return modelResult(identifiers);
+}
+
+/** Parses the "codex-cache" file shape; only the slugs leave the parser. */
+function parseModelCache(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return failedModels();
+  }
+  if (!Array.isArray(parsed?.models)) return failedModels();
+  return modelResult(
+    parsed.models.map((entry) => (typeof entry?.slug === "string" ? entry.slug : "")),
+  );
+}
+
+/** $CODEX_HOME-style override, else the subdirectory under the user's home. */
+function modelFilePath(probe) {
+  const base = process.env[probe.envDir] || join(homedir(), probe.homeSubdir);
+  return join(base, probe.file);
+}
+
+function probeModels(impl, launch, captured = null) {
+  const probe = impl.modelProbe;
+  if (!probe) {
+    return { status: "unsupported", values: [], truncated: false };
+  }
+  if (probe.static) {
+    return modelResult(probe.static, "aliases");
+  }
+  if (probe.file) {
+    try {
+      return parseModelCache(readFileSync(modelFilePath(probe), "utf8"));
+    } catch {
+      // No cache until the CLI has run once; that is not a discovery failure worth throwing on.
+      return failedModels();
+    }
+  }
+  if (captured) {
+    return captured.ok ? parseModelLines(captured.stdout, probe.format) : failedModels();
+  }
+  try {
+    const raw = runProbe(launch, probe.args, needsWindowsShell(impl, launch));
+    return parseModelLines(raw, probe.format);
+  } catch {
+    return failedModels();
+  }
+}
+
+/** Session containers under `base`; "*" matches any directory at that level. */
+function usageContainers(base, path) {
+  let dirs = [base];
+  for (const segment of path) {
+    const next = [];
+    for (const dir of dirs) {
+      for (const entry of readEntries(dir)) {
+        if (!entry.isDirectory()) continue;
+        if (segment !== "*" && entry.name !== segment) continue;
+        next.push(join(dir, entry.name));
+      }
+    }
+    dirs = next;
+  }
+  return dirs;
+}
+
+function readEntries(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * How much the user works in this CLI, from directory listings and mtimes only.
+ * Session files hold the user's conversations; none of them is ever opened.
+ */
+function probeUsage(impl) {
+  const probe = impl.usageProbe;
+  if (!probe) return null;
+  const base = (probe.envDir && process.env[probe.envDir]) || join(homedir(), probe.homeSubdir);
+  try {
+    if (!statSync(base).isDirectory()) return null;
+  } catch {
+    // No state directory at all: unknown, not zero.
+    return null;
+  }
+
+  let sessions = 0;
+  let lastUsed = 0;
+  for (const dir of usageContainers(base, probe.path)) {
+    for (const entry of readEntries(dir)) {
+      if (probe.entry !== "any" && entry.isDirectory() !== (probe.entry === "dir")) continue;
+      if (!probe.match.test(entry.name)) continue;
+      sessions += 1;
+      const entryPath = join(dir, entry.name);
+      try {
+        lastUsed = Math.max(lastUsed, statSync(entryPath).mtimeMs);
+        if (entry.isDirectory()) {
+          // A directory's mtime does not advance when a file inside it grows, so a
+          // resumed session would read as abandoned; stat the children too (never open them).
+          for (const child of readEntries(entryPath)) {
+            lastUsed = Math.max(lastUsed, statSync(join(entryPath, child.name)).mtimeMs);
+          }
+        }
+      } catch {
+        // Entry vanished mid-scan; the count still holds.
+      }
+    }
+  }
+  return { sessions, lastUsed: lastUsed > 0 ? new Date(lastUsed).toISOString() : null };
+}
+
+function main(argv) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+  const withUsage = argv.includes("--usage");
+  if (argv.some((arg) => arg !== "--usage")) {
+    process.stderr.write("discover.mjs: unexpected arguments. Use --help.\n");
+    process.exit(2);
+  }
+
+  const discovered = [];
+  const missing = [];
+
+  for (const impl of IMPLEMENTERS) {
+    const launch = resolveLaunch(impl);
+    if (!launch) {
+      missing.push({ key: impl.key, binary: impl.binary, skill: impl.skill });
+      continue;
+    }
+    const version = probeVersion(impl, launch);
+    const authArgs = impl.authProbe && !impl.authProbe.jsonField ? impl.authProbe.args : null;
+    const modelArgs = impl.modelProbe?.args;
+    const sharedCapture =
+      authArgs &&
+      modelArgs &&
+      authArgs.length === modelArgs.length &&
+      authArgs.every((arg, index) => arg === modelArgs[index])
+        ? captureProbe(launch, authArgs, needsWindowsShell(impl, launch))
+        : null;
+    const entry = {
+      key: impl.key,
+      skill: impl.skill,
+      binary: impl.binary,
+      version,
+      path: launch.path,
+      authenticated: probeAuth(impl, launch, sharedCapture),
+      supports: [...impl.supports],
+      models: probeModels(impl, launch, sharedCapture),
+    };
+    if (withUsage) entry.usage = probeUsage(impl);
+    discovered.push(entry);
+  }
+
+  process.stdout.write(
+    `${JSON.stringify({ version: "delegate-discover.v1", discovered, missing }, null, 2)}\n`,
+  );
+}
+
+main(process.argv.slice(2));

--- a/skills/delegate-setup/scripts/implementers.mjs
+++ b/skills/delegate-setup/scripts/implementers.mjs
@@ -1,0 +1,442 @@
+/**
+ * Canonical implementer registry for delegate-setup.
+ *
+ * One table: skill key → binary, launch hints, supported lane dials, probes.
+ * Consumed by discover.mjs and config.mjs. Relays will share this in Phase 2.
+ *
+ * `usageProbe.path` walks down from the CLI's state directory to the folders that
+ * hold session entries ("*" matches any directory at that level); `entry` + `match`
+ * say which names count as one session. Session files hold the user's conversations,
+ * so these are listed and stat'd only — never opened.
+ *
+ * Node built-ins only. No network, credentials, or telemetry.
+ */
+
+/** @typedef {"model"|"effort"|"variant"|"timeout"|"readOnly"|"sandbox"|"permissionMode"|"force"|"provider"} Dial */
+
+/**
+ * @type {readonly {
+ *   key: string,
+ *   skill: string,
+ *   binary: string,
+ *   versionArgs: string[],
+ *   versionFallbackArgs?: string[],
+ *   versionFormat?: "colon-prefix",
+ *   authProbe: null | {
+ *     args: string[],
+ *     jsonField?: string,
+ *     successPattern?: RegExp,
+ *     failPattern?: RegExp,
+ *     missMeansFalse?: boolean,
+ *   },
+ *   modelProbe: null
+ *     | { args: string[], format: "lines"|"cursor"|"grok"|"table"|"commandcode" }
+ *     | { envDir: string, homeSubdir: string, file: string, format: "codex-cache" }
+ *     | { static: readonly string[] },
+ *   usageProbe: null | {
+ *     envDir?: string,
+ *     homeSubdir: string,
+ *     path: readonly string[],
+ *     entry: "file"|"dir"|"any",
+ *     match: RegExp,
+ *   },
+ *   supports: Dial[],
+ *   winShell: boolean,
+ * }[]}
+ */
+export const IMPLEMENTERS = Object.freeze([
+  {
+    key: "claude",
+    skill: "claude-delegate",
+    binary: "claude",
+    versionArgs: ["--version"],
+    authProbe: { args: ["auth", "status"], jsonField: "loggedIn" },
+    // No listing command; `--model` takes one of these aliases or a full model name.
+    modelProbe: { static: ["fable", "opus", "sonnet", "haiku"] },
+    // <config>/projects/<project-slug>/<session-uuid>.jsonl — one file per session.
+    usageProbe: {
+      envDir: "CLAUDE_CONFIG_DIR",
+      homeSubdir: ".claude",
+      path: ["projects", "*"],
+      entry: "file",
+      match: /\.jsonl$/,
+    },
+    supports: ["model", "effort", "timeout", "readOnly"],
+    winShell: true,
+  },
+  {
+    key: "cline",
+    skill: "cline-delegate",
+    binary: "cline",
+    versionArgs: ["--version"],
+    // No status command exposes login state; usage stays unknown rather than guessed —
+    // the CLI's conversations live under a profile that has no documented stable path.
+    authProbe: null,
+    modelProbe: null,
+    usageProbe: null,
+    // Plan mode is a dispatch flag (--plan), not a lane dial; readOnly is unsupported.
+    supports: ["provider", "model", "timeout"],
+    winShell: true,
+  },
+  {
+    key: "codex",
+    skill: "codex-delegate",
+    binary: "codex",
+    versionArgs: ["--version"],
+    // codex writes login status to stderr, not stdout.
+    authProbe: {
+      args: ["login", "status"],
+      successPattern: /logged in/i,
+      failPattern: /not logged in/i,
+    },
+    // Never spawn `codex models`: the positional word is read as a prompt and hits the API.
+    // The locally cached catalog is the only offline listing.
+    modelProbe: {
+      envDir: "CODEX_HOME",
+      homeSubdir: ".codex",
+      file: "models_cache.json",
+      format: "codex-cache",
+    },
+    // sessions/<yyyy>/<mm>/<dd>/rollout-*.jsonl. archived_sessions is a second
+    // store of the same shape; counting only live rollouts keeps one meaning per number.
+    usageProbe: {
+      envDir: "CODEX_HOME",
+      homeSubdir: ".codex",
+      path: ["sessions", "*", "*", "*"],
+      entry: "file",
+      match: /^rollout-.*\.jsonl$/,
+    },
+    supports: ["model", "effort", "sandbox", "timeout", "readOnly"],
+    winShell: true,
+  },
+  {
+    key: "commandcode",
+    skill: "commandcode-delegate",
+    // Command Code's PATH name on non-Windows. On Windows resolveLaunch requires
+    // COMMANDCODE_BIN so discovery never mistakes cmd.exe for this implementer.
+    binary: "cmd",
+    versionArgs: ["--version"],
+    authProbe: { args: ["status"], successPattern: /Authenticated/i, failPattern: /not authenticated|logged out/i },
+    // Must stay a flag: `cmd models` would be read as a prompt. --list-models prints
+    // "vendor/name  description" rows under section headers.
+    modelProbe: { args: ["--list-models"], format: "commandcode" },
+    // projects/<project-slug>/<session-uuid>.jsonl, with a sibling
+    // <session-uuid>.checkpoints.jsonl that must not count as a second session.
+    usageProbe: {
+      homeSubdir: ".commandcode",
+      path: ["projects", "*"],
+      entry: "file",
+      match: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i,
+    },
+    // No sandbox or permissionMode dial: headless Command Code has only the withheld-tools
+    // default and --yolo, and --permission-mode does not change either.
+    supports: ["model", "effort", "timeout", "readOnly"],
+    winShell: false,
+  },
+  {
+    key: "opencode",
+    skill: "opencode-delegate",
+    binary: "opencode",
+    versionArgs: ["--version"],
+    // Exits 0 with an empty list too; a "●" row is the only auth signal, so a clean run
+    // without one is the logged-out state, not an ambiguous miss.
+    authProbe: { args: ["auth", "list"], successPattern: /^●\s/m, missMeansFalse: true },
+    modelProbe: { args: ["models"], format: "lines" },
+    // No usage probe: the session files under ~/.local/share/opencode/storage stopped
+    // being written when OpenCode moved to opencode.db, and a session count from that
+    // database would mean opening conversation content.
+    usageProbe: null,
+    // OpenCode reasoning intensity is --variant, not --effort.
+    supports: ["model", "variant", "timeout", "readOnly"],
+    winShell: true,
+  },
+  {
+    key: "agy",
+    skill: "agy-delegate",
+    binary: "agy",
+    versionArgs: ["changelog"],
+    versionFormat: "colon-prefix",
+    authProbe: null,
+    modelProbe: { args: ["models"], format: "lines" },
+    // Antigravity keeps CLI state under ~/.gemini, one .db per conversation.
+    usageProbe: {
+      homeSubdir: ".gemini/antigravity-cli",
+      path: ["conversations"],
+      entry: "file",
+      match: /\.db$/,
+    },
+    supports: ["model", "effort", "timeout", "readOnly"],
+    winShell: false,
+  },
+  {
+    key: "grok",
+    skill: "grok-delegate",
+    binary: "grok",
+    versionArgs: ["version"],
+    versionFallbackArgs: ["--version"],
+    authProbe: { args: ["models"], failPattern: /not authenticated/i },
+    modelProbe: { args: ["models"], format: "grok" },
+    // sessions/<url-encoded-cwd>/<session-uuid>/ — one directory per session; the
+    // prompt_history.jsonl sitting beside them is per-workspace, not per-session.
+    usageProbe: {
+      homeSubdir: ".grok",
+      path: ["sessions", "*"],
+      entry: "dir",
+      match: /^[0-9a-f]{8}-[0-9a-f]{4}-/i,
+    },
+    supports: ["model", "effort", "sandbox", "timeout", "readOnly"],
+    winShell: true,
+  },
+  {
+    key: "kimi",
+    skill: "kimi-delegate",
+    binary: "kimi",
+    versionArgs: ["--version"],
+    authProbe: { args: ["provider", "list"], successPattern: /source=(oauth|api)/ },
+    // No credential-free listing exists: the provider-list JSON and the config file behind it
+    // both inline provider api keys, and this script may not buffer credentials.
+    modelProbe: null,
+    // sessions/<wd_workspace>/session_<uuid>/ — one directory per session.
+    usageProbe: {
+      homeSubdir: ".kimi-code",
+      path: ["sessions", "*"],
+      entry: "dir",
+      match: /^session_/,
+    },
+    supports: ["model", "timeout"],
+    winShell: false,
+  },
+  {
+    key: "qoder",
+    skill: "qoder-delegate",
+    binary: "qodercli",
+    versionArgs: ["--version"],
+    authProbe: null,
+    modelProbe: null,
+    // No documented local session store; usage stays unknown rather than guessed.
+    usageProbe: null,
+    supports: ["model", "permissionMode", "timeout", "readOnly"],
+    winShell: false,
+  },
+  {
+    key: "vibe",
+    skill: "vibe-delegate",
+    binary: "vibe",
+    versionArgs: ["--version"],
+    authProbe: null,
+    modelProbe: null,
+    usageProbe: null,
+    supports: ["timeout", "readOnly"],
+    winShell: false,
+  },
+  {
+    key: "cursor",
+    skill: "cursor-delegate",
+    binary: "cursor-agent",
+    versionArgs: ["--version"],
+    authProbe: {
+      args: ["status"],
+      successPattern: /logged in as/i,
+      failPattern: /not logged in/i,
+    },
+    modelProbe: { args: ["models"], format: "cursor" },
+    // projects/<project-slug>/agent-transcripts/<chat-uuid>/ — what the CLI writes per
+    // chat; some layouts write flat <chat-uuid>.txt files instead, so accept either.
+    // ~/.cursor/chats holds only a handful of older IDE-side entries.
+    usageProbe: {
+      homeSubdir: ".cursor",
+      path: ["projects", "*", "agent-transcripts"],
+      entry: "any",
+      match: /^[0-9a-f]{8}-[0-9a-f]{4}-/i,
+    },
+    // Cursor sandbox is explicit per dispatch only; it is intentionally not a fleet dial.
+    supports: ["model", "force", "timeout", "readOnly"],
+    winShell: true,
+  },
+  {
+    key: "pi",
+    skill: "pi-delegate",
+    binary: "pi",
+    versionArgs: ["--version"],
+    authProbe: null,
+    // Must stay a flag: `pi models` is read as a prompt and hits the API.
+    modelProbe: { args: ["--list-models"], format: "table" },
+    // ~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl.
+    usageProbe: {
+      homeSubdir: ".pi/agent",
+      path: ["sessions", "*"],
+      entry: "file",
+      match: /\.jsonl$/,
+    },
+    supports: ["provider", "model", "timeout", "readOnly"],
+    winShell: true,
+  },
+  {
+    key: "omp",
+    skill: "omp-delegate",
+    binary: "omp",
+    versionArgs: ["--version"],
+    authProbe: null,
+    // Must stay the `models` subcommand: `omp --list-models` is a stale flag and a
+    // hard error. Catalog output is grouped/JSON, not a stable identifier list, so
+    // this script does not parse it — the skill documents `omp models` instead.
+    modelProbe: null,
+    // ~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<sessionId>.jsonl.
+    usageProbe: {
+      envDir: "PI_CODING_AGENT_DIR",
+      homeSubdir: ".omp/agent",
+      path: ["sessions", "*"],
+      entry: "file",
+      match: /\.jsonl$/,
+    },
+    supports: ["provider", "model", "effort", "timeout", "readOnly"],
+    winShell: false,
+  },
+  {
+    key: "aider",
+    skill: "aider-delegate",
+    binary: "aider",
+    versionArgs: ["--version"],
+    // Aider has no auth subcommand; it reads provider keys from the environment
+    // and its own config, and reports a failure only once a run reaches the model.
+    authProbe: null,
+    // `aider --list-models` needs a partial-name argument, so there is no listing
+    // that covers the catalog; leaving this null beats probing with a guessed query.
+    modelProbe: null,
+    // No global session store: Aider keeps its chat history in the repo itself
+    // (.aider.chat.history.md), so there is nothing per-user to count.
+    usageProbe: null,
+    supports: ["model", "timeout", "readOnly"],
+    winShell: false,
+  },
+  {
+    key: "copilot",
+    skill: "copilot-delegate",
+    binary: "copilot",
+    versionArgs: ["version"],
+    // No status command exposes login state; copilot login is interactive only
+    // and there is no `copilot auth status` equivalent.
+    authProbe: null,
+    // No credential-free model listing command exists.
+    modelProbe: null,
+    // No documented local session store path is verified.
+    usageProbe: null,
+    supports: ["model", "effort", "timeout", "readOnly"],
+    winShell: true,
+  },
+  {
+    key: "warp",
+    skill: "warp-delegate",
+    binary: "oz",
+    versionArgs: ["--version"],
+    // `--output-format text` prints one `type:id` line; the default `pretty` format
+    // spells the type out ("User ID: …") and so reads differently per principal. A
+    // headless host authenticated with WARP_API_KEY is a service account, not a
+    // user, so the probe must accept both or it reports CI as logged out.
+    authProbe: {
+      args: ["whoami", "--output-format", "text"],
+      successPattern: /^(?:user|service_account):\S/m,
+    },
+    // `oz model list` emits a JSON array of {id} objects, which none of the shared
+    // list formats parse; ids are read from the CLI directly instead of probed.
+    modelProbe: null,
+    // Conversations live server-side, so there is no local session directory to count.
+    usageProbe: null,
+    // `oz agent run` exposes no sandbox, permission-mode, or read-only flag, so
+    // those dials are deliberately absent — the relay refuses a lane that sets one.
+    supports: ["model", "timeout"],
+    winShell: false,
+  },
+  {
+    key: "zcode",
+    skill: "zcode-delegate",
+    binary: "zcode",
+    versionArgs: ["--version"],
+    // ZCode ships its CLI inside the desktop app rather than on PATH or npm, so
+    // discovery falls back to the installed bundle. Consulted only when `binary`
+    // is absent from PATH; the bundle is a Node bundle, hence the node launcher.
+    locate: {
+      launcher: "node",
+      candidates: {
+        win32: ["%LOCALAPPDATA%/Programs/ZCode/resources/glm/zcode.cjs"],
+        darwin: [
+          "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+          "~/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+        ],
+        // Linux ships an AppImage with no fixed install path: nothing honest to guess.
+        linux: [],
+      },
+    },
+    // No auth-status command exists, and `zcode login` fails with ZaiCliOAuthError
+    // (seen on 0.16.1 and 0.16.3), so auth stays unknown rather than guessed.
+    authProbe: null,
+    // No --model flag: the model is chosen in the CLI's own config file.
+    modelProbe: null,
+    // ~/.zcode/cli holds sess_* directories under several subdirectories, but their
+    // counts disagree, so none is proven one-per-session. Unknown, not guessed.
+    usageProbe: null,
+    supports: ["permissionMode", "timeout", "readOnly"],
+
+    winShell: false,
+
+  },
+]);
+
+/** Prototype-free map so names like "toString" cannot pass as implementers. */
+export const IMPLEMENTER_BY_KEY = Object.freeze(
+  IMPLEMENTERS.reduce((map, impl) => {
+    map[impl.key] = impl;
+    return map;
+  }, Object.create(null)),
+);
+
+export const CLAUDE_EFFORT = Object.freeze(["low", "medium", "high", "xhigh", "max", "ultracode"]);
+export const AGY_EFFORT = Object.freeze(["low", "medium", "high"]);
+export const COPILOT_EFFORT = Object.freeze(["low", "medium", "high", "xhigh", "max"]);
+export const OMP_THINKING = Object.freeze(["off", "auto", "minimal", "low", "medium", "high", "xhigh", "max"]);
+export const CODEX_SANDBOX = Object.freeze(["read-only", "workspace-write", "danger-full-access"]);
+export const GROK_SANDBOX = Object.freeze(["workspace", "read-only", "off"]);
+export const QODER_PERMISSION = Object.freeze([
+  "default",
+  "accept_edits",
+  "auto",
+  "bypass_permissions",
+  "dont_ask",
+  "plan",
+]);
+/**
+ * ZCode's --mode, carried as the `permissionMode` dial. `build` and `edit` are
+ * deliberately absent: a headless run has no permission client, so they block
+ * every write tool and exit 0 having changed nothing. The relay rejects them for
+ * the same reason, so a lane must not be able to select one either.
+ */
+export const ZCODE_MODE = Object.freeze(["plan", "yolo"]);
+/** Positive h/m/s duration, same shape relays accept. */
+export const TIMEOUT_RE = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/;
+
+/**
+ * Model/provider token shapes mirrored from each relay's parseArgs.
+ * Relays that do not constrain the string still get a non-empty check in config.mjs.
+ */
+export const MODEL_TOKEN = Object.freeze({
+  /** Keep in lockstep with claude-delegate SAFE_MODEL. */
+  claude: /^[A-Za-z0-9][A-Za-z0-9._:@\/\[\]-]*$/,
+  /** Keep in lockstep with cursor-delegate SAFE_MODEL. */
+  cursor: /^[A-Za-z0-9][A-Za-z0-9._:@\/\[\]\,=-]*$/,
+  /** Keep in lockstep with grok/pi/codex/commandcode shell-safe tokens (also used for opencode). */
+  shellSafe: /^[A-Za-z0-9][A-Za-z0-9._:\/-]*$/,
+});
+
+export const CONFIG_VERSION = "delegate-fleet.v1";
+export const LANE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+export const ALL_DIALS = Object.freeze([
+  "model",
+  "effort",
+  "variant",
+  "timeout",
+  "readOnly",
+  "sandbox",
+  "permissionMode",
+  "force",
+  "provider",
+]);

--- a/skills/delegate-setup/scripts/lane.mjs
+++ b/skills/delegate-setup/scripts/lane.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * lane.mjs — resolve a fleet lane for a relay (or print help).
+ *
+ * Usage:
+ *   node lane.mjs resolve --cwd <dir> --lane <name> --implementer <key>
+ *   node lane.mjs --help
+ *
+ * On success, prints JSON:
+ *   { "lane", "source", "implementer", "skill", "dials": { ...relay-native fields } }
+ *
+ * `dials` uses field names the target relay understands (e.g. grok gets `autonomy`,
+ * opencode gets `agent` for read-only). Relays apply dials only where a CLI flag
+ * did not already set the field.
+ *
+ * Node built-ins only.
+ */
+
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve as resolvePath } from "node:path";
+import {
+  IMPLEMENTER_BY_KEY,
+  LANE_NAME,
+} from "./implementers.mjs";
+import { loadEffective } from "./config.mjs";
+
+const HELP = `lane.mjs — resolve a delegate-fleet.v1 lane for a relay
+
+Usage:
+  node lane.mjs resolve --cwd <dir> --lane <name> --implementer <key>
+  node lane.mjs --help
+`;
+
+function fail(message) {
+  process.stderr.write(`lane.mjs: ${message}\n`);
+  process.exit(2);
+}
+
+/**
+ * Map a stored lane onto dials the named relay can apply directly.
+ * @returns {{ lane: string, source: string, implementer: string, skill: string, dials: Record<string, unknown> }}
+ */
+export function resolveLaneForRelay(cwd, laneName, implementerKey) {
+  if (!LANE_NAME.test(laneName)) {
+    throw new Error(`invalid lane name ${JSON.stringify(laneName)}`);
+  }
+  if (IMPLEMENTER_BY_KEY[implementerKey] == null) {
+    throw new Error(`unknown implementer ${JSON.stringify(implementerKey)}`);
+  }
+  const effective = loadEffective(cwd);
+  const entry = effective.lanes[laneName];
+  if (!entry) {
+    throw new Error(`fleet lane not found: ${laneName}`);
+  }
+  const { source, implementer, ...rest } = entry;
+  if (source === "project" && !effective.projectTrusted) {
+    throw new Error(
+      "project fleet config is not trusted; review and approve it with delegate-setup before dispatch",
+    );
+  }
+  if (implementer !== implementerKey) {
+    const bound = IMPLEMENTER_BY_KEY[implementer];
+    throw new Error(
+      `fleet lane "${laneName}" → ${implementer} (use ${bound.skill}); this relay is ${implementerKey}`,
+    );
+  }
+  const dials = normalizeDials(implementerKey, rest);
+  return {
+    lane: laneName,
+    source,
+    implementer,
+    skill: IMPLEMENTER_BY_KEY[implementer].skill,
+    dials,
+  };
+}
+
+function normalizeDials(implementerKey, raw) {
+  const dials = { ...raw };
+  if (implementerKey === "grok") {
+    if (typeof dials.sandbox === "string") {
+      const map = {
+        workspace: "workspace-write",
+        "read-only": "read-only",
+        off: "full-access",
+      };
+      dials.autonomy = map[dials.sandbox] ?? dials.sandbox;
+      delete dials.sandbox;
+    }
+    // Grok relay consumes autonomy, not readOnly.
+    if (dials.readOnly === true) {
+      if (dials.autonomy === undefined) dials.autonomy = "read-only";
+      delete dials.readOnly;
+    }
+  }
+  if (implementerKey === "codex" && dials.readOnly === true) {
+    if (dials.sandbox === undefined) dials.sandbox = "read-only";
+    delete dials.readOnly;
+  }
+  if (implementerKey === "opencode" && dials.readOnly === true) {
+    dials.agent = "plan";
+    delete dials.readOnly;
+  }
+  if (implementerKey === "qoder" && dials.readOnly === true) {
+    if (dials.permissionMode === undefined) dials.permissionMode = "plan";
+    delete dials.readOnly;
+  }
+  if (implementerKey === "omp" && typeof dials.effort === "string") {
+    dials.thinking = dials.effort;
+    delete dials.effort;
+  }
+  if (implementerKey === "vibe" && dials.readOnly === true) {
+    dials.planOnly = true;
+    delete dials.readOnly;
+  }
+  // agy / claude / cursor / pi / omp keep readOnly as a boolean on opts
+  return dials;
+}
+
+/**
+ * Apply resolved dials onto relay opts. `flagged` lists fields set by CLI flags.
+ */
+export function mergeDials(opts, dials, flagged) {
+  for (const [field, value] of Object.entries(dials)) {
+    if (flagged.has(field)) continue;
+    // read-only / sandbox / agent / autonomy often share a flag surface
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) {
+      continue;
+    }
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (
+      field === "planOnly" &&
+      (flagged.has("planOnly") || flagged.has("readOnly") || flagged.has("fullAccess"))
+    ) {
+      continue;
+    }
+    if (
+      field === "readOnly" &&
+      (flagged.has("readOnly") ||
+        flagged.has("dangerouslySkipPermissions") ||
+        flagged.has("fullAccess"))
+    ) {
+      continue;
+    }
+    if (field === "force" && flagged.has("force")) continue;
+    if (field === "thinking" && flagged.has("thinking")) continue;
+    opts[field] = value;
+  }
+}
+
+function parseResolveArgs(argv) {
+  let cwd = process.cwd();
+  let lane = null;
+  let implementer = null;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[++i];
+      if (value === undefined) fail(`${arg} requires a value`);
+      return value;
+    };
+    if (arg === "--cwd") cwd = resolvePath(next());
+    else if (arg === "--lane") lane = next();
+    else if (arg === "--implementer") implementer = next();
+    else fail(`unknown option: ${arg}`);
+  }
+  if (!lane) fail("resolve requires --lane");
+  if (!implementer) fail("resolve requires --implementer");
+  return { cwd, lane, implementer };
+}
+
+function main(argv) {
+  if (argv.includes("--help") || argv.includes("-h") || argv.length === 0) {
+    process.stdout.write(HELP);
+    process.exit(argv.length === 0 ? 2 : 0);
+  }
+  const cmd = argv[0];
+  if (cmd !== "resolve") fail(`unknown command ${JSON.stringify(cmd)}`);
+  try {
+    const { cwd, lane, implementer } = parseResolveArgs(argv.slice(1));
+    const result = resolveLaneForRelay(cwd, lane, implementer);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    fail(error.message || String(error));
+  }
+}
+
+// realpath BOTH sides, not resolve: mirrors config.mjs — symlinked install paths
+// otherwise make this silently no-op (including under --preserve-symlinks-main,
+// where the module URL keeps the symlink path), and relays call it for every
+// --lane dispatch.
+const isMain = (() => {
+  if (!process.argv[1]) return false;
+  const toReal = (path) => {
+    try {
+      return realpathSync(path);
+    } catch {
+      return resolvePath(path);
+    }
+  };
+  return toReal(process.argv[1]) === toReal(fileURLToPath(import.meta.url));
+})();
+if (isMain) main(process.argv.slice(2));

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: grok-delegate
+description: Delegate a coding task to the Grok Build CLI as a background implementer,
+  then review its diff and land it yourself. Use this whenever the user wants to hand
+  implementation work to Grok — phrasings like "have Grok do X", "delegate this to
+  Grok", "run it through Grok", "use...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `grok` CLI (Grok Build) installed and authenticated (`grok
+  login`, or `XAI_API_KEY`; beta access needs an eligible xAI subscription), Node
+  18+, and git. The orchestrating agent must be able to run shell commands and read
+  files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+# Grok Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `grok` implementer (`Grok Build`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the Grok Build CLI (`grok`) — then review what it produced and land it yourself. You
+write the brief and own the judgment; Grok does the typing under an explicit autonomy profile; you
+verify and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so it works the same whether you are Claude Code, Cursor, OpenCode with a
+selected model, or any comparable agent. (It is designed for Claude Code and Cursor; treat other
+orchestrators as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- The `grok` CLI is not installed, not authenticated, or the account lacks Grok Build beta access.
+- You want to write the code yourself, or you only need a review without an implementer run.
+
+## Prerequisites (check once)
+
+1. `grok version` succeeds. If not, install on any platform with
+   `npm i -g @xai-official/grok` (or use the installer from xAI's official Grok CLI docs) and
+   authenticate (`grok login`, or `grok login --device-auth` on headless hosts, or set
+   `XAI_API_KEY`).
+2. **Confirm which `grok` is on PATH.** `command -v grok` shows the active binary and `grok version`
+   its version — the relay records the version it ran into `result.json`, so a stale binary is visible
+   after the fact.
+3. You are in (or will point `--cd` at) the target git repository.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Grok sees **only** the text you send — no orchestrator chat history, no shared context. Everything the
+task needs goes in the brief: the goal, the current state, what to change, what to leave untouched,
+the project's **actual** gate commands (discover them from the repo's CLAUDE.md/AGENTS.md/Makefile —
+do not assume), and a report contract. Tell Grok it will **not** commit (you will). Keep one task per
+brief. Full guidance and a template: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to Grok with the bundled helper. It wraps `grok -p`, captures the run, and writes a
+structured `result.json` — so your only job is "run a command, read a file." (`<skill-dir>` below is
+this skill's installed directory — the folder containing this `SKILL.md`, i.e. the directory you loaded
+the skill from. Claude Code prints it as "Base directory for this skill" when the skill loads; on other
+orchestrators use that same directory — if unsure where it landed, run
+`find ~ -name relay.mjs -path '*grok-delegate*'` and substitute the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only (review/diagnosis; best-effort — verify touchedFiles): add --read-only
+# continue the previous Grok session:       add --resume-last  (send only the delta brief)
+# hard time limit (watchdog):               add --timeout 2h  (default: off; implementation runs routinely need 1-2h)
+# see all options:                          node .../relay.mjs --help
+```
+
+The helper defaults to a write-capable (`workspace-write`) autonomy profile — `--always-approve` plus
+`--sandbox workspace` — and writes its artifacts to a temp dir, so the repo under review stays clean.
+It **never commits** — see step 5. Mechanics, flags, and the `result.json` shape:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Grok finishes, so back it with whatever your orchestrator offers and resume
+when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job`
+  in PowerShell, `start /b` in cmd). The run is done when `result.json` exists with a `status`. (A
+  pre-run usage error — bad args or an empty brief — instead exits with code 2 and a stderr message and
+  writes no result file, so check the exit code too. A missing `grok` binary exits 127 but *does* write
+  a `result.json` with status `grok_unavailable`.)
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line. The implementer's full report is
+the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
+
+### 4. Review — do not trust the self-report
+
+Grok's `result.json` includes its own summary and gate claims. **Re-verify, don't accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did Grok do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+**The orchestrator commits.** Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
+  review again.
+
+## Autonomy model
+
+Grok's default permission mode is `ask`, which **blocks on approval prompts in a headless pipe**. The
+relay therefore always sets autonomy explicitly:
+
+| Relay flag | What Grok gets | Use when |
+| --- | --- | --- |
+| *(default)* | `--always-approve --sandbox workspace` | Normal implementation — writes scoped to the working tree |
+| `--read-only` | `--sandbox read-only --permission-mode plan` | Review / diagnosis — **best-effort, not enforced** (see caveat below) |
+| `--full-access` | `--always-approve --sandbox off` | Explicit opt-in when the task needs unrestricted tools |
+
+`--always-approve` alone would approve *all* tools (writes, shell, network) — closer to unrestricted
+than to a workspace-scoped write. Pairing it with `--sandbox workspace` is what keeps the default
+safe. Reach for `--full-access` only when the human asks for it.
+
+**`--read-only` is best-effort, not a hard guarantee.** The read-only sandbox restricts out-of-workspace
+filesystem/network access, not grok's own edit tool, and headless `plan` mode is advisory — a run
+verified here still wrote the working tree when told to. Use `--read-only` to *signal* review intent,
+but always confirm `touchedFiles` afterward; treat the diff, not the flag, as the guarantee. The relay
+automates a reporting tripwire: it compares parsed git porcelain and fingerprints the working-tree
+identity and index entries of Git-visible paths that were already dirty. `readOnlyViolation` is `true`
+when either signal proves a change, `false` when coverage is complete and detects none, and `null` when
+coverage is incomplete. Ignored paths, submodule internals, perfect restores, and attribution of
+concurrent changes remain outside it, so the diff
+review stays the guarantee.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report Grok's design decisions, defensible-but-unasked turns, and
+non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if correct
+completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
+is in [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief Grok can
+  execute blind: structure, XML blocks, the report contract, embedding the real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the rework cycle via `--resume-last`.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.
+
+
+## Limitations
+
+- Requires the `grok` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/grok-delegate/references/dispatch-and-poll.md
+++ b/skills/grok-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,171 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `grok -p` (headless mode), runs the brief under
+an explicit autonomy profile, captures everything, and writes a structured `result.json`. Your job
+collapses to: run one command, then read one file. Everything Grok-specific lives in the helper, which
+is what keeps the loop portable across orchestrators.
+
+## Before the first run: check the binary
+
+Two gotchas, both worth 30 seconds:
+
+```bash
+command -v grok      # the active binary; a stale install can shadow a current one
+grok version         # recorded into result.json so a stale binary is visible after the fact
+grok login           # or: grok login --device-auth / export XAI_API_KEY=...
+```
+
+Grok Build is an early beta gated behind an eligible xAI subscription (SuperGrok / X Premium+). An
+auth failure or missing beta access shows up as a failed run, not as `grok_unavailable`.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for Grok (default: current directory); passed as `--cwd`. |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Grok model (default: Grok's own configured default). |
+| `--effort <level>` | Reasoning effort for this run (`--effort`). |
+| `--max-turns <n>` | Maximum number of agent turns for this run (`--max-turns`). |
+| `--read-only` | Review/diagnosis intent (`--sandbox read-only --permission-mode plan`). **Best-effort, not enforced** — grok can still edit the tree headlessly. The relay reports a tri-state Git-visible change tripwire. |
+| `--full-access` | Unrestricted auto-approve (`--always-approve --sandbox off`); opt-in. |
+| `--resume-last` | Continue the most recent Grok session for this cwd; send only the delta brief. |
+| `--session <id>` | Continue a specific session id; mutually exclusive with `--resume-last`. |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Default autonomy (neither `--read-only` nor `--full-access`) is **workspace-write**:
+`--always-approve --sandbox workspace`. Grok's native default is `ask`, which would hang a headless
+pipe; the relay always sets autonomy explicitly.
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only Grok's edits and nothing of the helper's own.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `tool` — `"grok"`
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `grok_unavailable`
+- `exitCode` — mirrors Grok's exit code; `128` plus the signal number if the child was killed; `127` if `grok` isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
+- `signal` — the signal that killed the child, otherwise `null`
+- `grokVersion` — the binary that actually ran
+- `sessionId` — feed this to a later `--session <id>` (or use `--resume-last`)
+- `finalMessage` — Grok's own final report (the `<structured_output_contract>` you asked for), assembled from the streaming-json `text` events
+- `usage` — token counts from the run's end event (`input_tokens` / `output_tokens` / `total_tokens`); `null` if none were reported
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point. `null` (not `[]`) when git can't report; `[]` means git ran and the tree is clean
+- `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw streaming-json event stream, and the final-message file
+- `workdir`, `autonomy`, `model`, `effort`, `resumeLast`, `startedAt`, `finishedAt`
+- `readOnlyViolation` — present on dispatched `--read-only` runs: `true` when parsed git porcelain or
+  the working-tree/index fingerprint of an already-dirty Git-visible path proves a change; `false`
+  when coverage is complete and detects none; `null` when coverage is incomplete. Ignored paths,
+  submodule internals, perfect restores, and attribution remain outside it — the diff review, not this flag, is the guarantee
+- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`, `grok_unavailable`, and launch failures
+- `error` — present on a launch failure, and on `timeout` and `aborted` runs
+
+The helper also prints a summary to stdout and exits with Grok's exit code, so a wrapping script can
+branch on success/failure directly.
+
+## Waiting for completion
+
+The helper blocks until Grok finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job` in PowerShell,
+  `start /b` in cmd). A run is done when `result.json` exists with a `status`. **But** a pre-run usage
+  error (bad args, empty brief) exits with code 2 *before* writing any file — so check the exit code
+  too, don't only watch for the file. (A missing `grok` binary exits 127 but *does* write a
+  `result.json` with status `grok_unavailable`.)
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## When a run misbehaves
+
+- **`status: grok_unavailable` (exit 127):** `grok` isn't on PATH or isn't found. Install with
+  `npm i -g @xai-official/grok` and `grok login`, then re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `grok version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
+  grok was never dispatched; only the relay's own artifacts may already exist under `--out-dir`.
+  Check the install by running `grok version` yourself.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a resume.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to grok. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
+  or a supervisor timeout, not an implementer error. Free up host memory or split the task into
+  smaller briefs, then re-dispatch.
+- **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
+  Common causes: an auth lapse, missing beta access, an invalid `--model`, or a sandbox that blocked
+  something the task needed. Fix the cause and re-dispatch; don't paper over it by doing the work
+  yourself unless that's what the user wants.
+- **Empty `finalMessage`:** Grok exited before producing a final message, or the streaming-json event
+  shape didn't match the extractor. Treat as a failed run; the events log usually shows where it
+  stopped — and is the source of truth for tightening the parser.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Whether it also carries the edit contents depends on what the CLI streams,
+so treat any reconstruction as unverified until it matches a working-tree diff — when the tree
+still holds the work, preserve the tree rather than replaying the log.
+
+## What the helper is doing (and the alternatives)
+
+Under the hood the helper runs roughly:
+
+```bash
+# fresh run (default workspace-write autonomy)
+grok --no-auto-update --no-alt-screen --output-format streaming-json --cwd <repo> \
+  --always-approve --sandbox workspace --prompt-file <brief.txt>
+
+# resume most recent session for this cwd
+grok --no-auto-update --no-alt-screen --output-format streaming-json --cwd <repo> \
+  --continue --always-approve --sandbox workspace --prompt-file <delta.txt>
+
+# resume a specific session
+grok --no-auto-update --no-alt-screen --output-format streaming-json --cwd <repo> \
+  --resume <id> --always-approve --sandbox workspace --prompt-file <delta.txt>
+```
+
+`--no-auto-update` and `--no-alt-screen` are always set so automated runs don't check for updates or
+take over the terminal. Autonomy flags are re-passed on resume because headless permission mode may
+not inherit.
+
+**Prompt delivery:** the brief is handed to grok via `--prompt-file`, never argv — so it stays out of
+the host process list, isn't bounded by the OS argument-length cap, and a brief that begins with `-`
+can't be misread as a flag. The relay writes the brief you pass (via `--brief` or stdin) to a file and
+points `--prompt-file` at it.
+
+Two alternatives exist if you ever want them, but the helper is the recommended path:
+
+- **Raw `grok --prompt-file`** — fine for one-offs; you give up the captured `result.json`,
+  touched-files summary, and session-id extraction the helper does for you.
+- **`grok agent stdio` (ACP)** — richer IDE/tool integration over JSON-RPC. Out of scope for this
+  skill; the headless single-turn path is the one the relay drives.
+
+## The commit boundary
+
+The helper never commits — by design, not omission. The robust contract is: Grok edits the working
+tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/grok-delegate/references/multi-task-queues.md
+++ b/skills/grok-delegate/references/multi-task-queues.md
@@ -1,0 +1,67 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential.
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. Each fresh dispatch starts a **new** Grok session with no memory of
+the earlier run (unless you deliberately `--resume-last` / `--session`), so a constraint that emerged
+in task 2 must be restated in task 5's brief or it won't hold. This is the queue equivalent of keeping
+briefs self-contained.
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions Grok made, non-blocking nitpicks, anything you want the
+  human to overrule or confirm. This is the section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/grok-delegate/references/review-and-land.md
+++ b/skills/grok-delegate/references/review-and-land.md
@@ -1,0 +1,130 @@
+# Review and land
+
+Grok did the typing; you own the judgment. This is where delegation earns its keep or quietly ships a
+mistake. The discipline is simple to state and easy to skip under time pressure: **verify against
+reality, never against the self-report — and read the diff as generated code, which fails in ways a
+green gate can't see.**
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries Grok's own claim that the gates passed. Treat that as a claim, not evidence —
+re-run the project's actual test/lint/build commands in the working tree and read the output. And keep
+the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a gate,
+not just misreport it — that is what the test check above and the sweep below exist to catch.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+For `--read-only`, treat `readOnlyViolation: true` as proof of a detected Git-visible change and
+`null` as incomplete coverage. `false` does not cover ignored paths, submodule internals, perfect
+restores, or attribution; inspect the actual diff.
+
+- **Scope creep** — did Grok change things the brief said to leave untouched? Unasked refactors,
+  renames, "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version?
+- **Quiet judgment calls** — sometimes Grok makes a defensible decision the brief didn't anticipate.
+  Don't just accept it because it looks reasonable; understand it and decide.
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If Grok couldn't implement something,
+  the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to Grok as a delta brief (below) or gets fixed in the tree before
+commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never Grok. This isn't a
+workaround for a missing feature; it's the deliberate boundary. Committing should be the act of the
+party that verified the work. Write a clear message describing what landed. If your project attributes
+co-authorship, that's the place for it.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same Grok session with
+just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
+
+`--resume-last` keeps Grok's context from the first run (via `grok --continue`), so a short delta is
+enough. To resume a specific session from `result.json`'s `sessionId`, pass `--session <id>` instead.
+Then review again — rework gets the same gate-rerun, test check, diff-read, and sweep as the original,
+no shortcuts. Repeat until it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** Grok made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or Grok's.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/grok-delegate/references/writing-the-brief.md
+++ b/skills/grok-delegate/references/writing-the-brief.md
@@ -1,0 +1,119 @@
+# Writing the brief
+
+A brief is the entire task as Grok will see it. Grok runs in a fresh process with **no memory of
+your conversation, no access to your prior notes, and no shared context** — only the text you send and
+whatever it can read from the working tree (including repo rules it discovers via `grok inspect`, and
+the repo's own `AGENTS.md` when present).
+If a constraint isn't in the brief or discoverable in the repo, it doesn't exist for Grok. The single
+most common failure is a brief that assumes context Grok doesn't have.
+
+## The shape that works
+
+Grok responds best to compact, block-structured prompts with XML tags rather
+than long prose. State the task, what "done" looks like, how to behave by default, and the few
+constraints that actually matter. Add a block only when the task needs it — don't ship empty ceremony.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps Grok from
+wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
+  inferences), tell Grok in the brief not to edit anything, and run with `--read-only`. Note
+  `--read-only` is best-effort on grok, not a hard block — verify `touchedFiles` after the run.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`CLAUDE.md` / `AGENTS.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you a Grok that guesses — or skips.
+
+## Honor the repo's conventions
+
+Grok discovers project configuration for the current directory (`grok inspect` shows rules, skills,
+plugins, hooks, and MCP servers). House rules in the repo (style, forbidden patterns, commit
+conventions) already apply when configured. If the project forbids certain things in code — say,
+spec/ticket IDs in comments, process language like "MVP"/"for now"/"phase N", or specific test
+conventions — restate the load-bearing ones in the brief too, because compliance is only as reliable
+as what's in front of the implementer.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and
+suggest a roadmap" produces a muddled run; split it into separate dispatches. One brief → one Grok
+run → one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout (the idempotency key isn't checked before re-submitting). Make the refund
+submission idempotent: check for an existing refund by idempotency key before creating a new one.
+Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes, and the
+data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/grok-delegate/scripts/relay.mjs
+++ b/skills/grok-delegate/scripts/relay.mjs
@@ -1,0 +1,1054 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · grok-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Grok Build CLI (`grok --prompt-file`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every Grok-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified end-to-end on macOS against grok 0.2.101;
+ * other shell-capable agents (Claude Code, Cursor, …) are designed-for but not
+ * yet verified there.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `grok` and `git`. The `grok` process it
+ * launches does authenticate — exactly as you do at the terminal. Read this
+ * file before you run it.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job —
+ * after it reviews the diff and re-runs the project gates.
+ *
+ * Grok's default permission mode is `ask`, which blocks on approval prompts in
+ * a non-interactive pipe. The relay therefore sets autonomy explicitly:
+ *   default        — `--always-approve --sandbox workspace` (write in CWD)
+ *   --read-only    — `--sandbox read-only --permission-mode plan` (review intent)
+ *   --full-access  — `--always-approve --sandbox off` (unrestricted; opt-in)
+ *
+ * `--read-only` is best-effort, NOT a hard guarantee: on grok 0.2.101 the
+ * read-only sandbox governs out-of-workspace filesystem/network access, not the
+ * agent's own edit tool, and headless `plan` mode is advisory — a determined run
+ * can still write the working tree. Always confirm `touchedFiles` after a
+ * read-only run; don't rely on the flag alone.
+ * The relay reports `readOnlyViolation` as true when git porcelain or an
+ * already-dirty Git-visible path proves a change, false when coverage is
+ * complete and detects none, and null when coverage is incomplete. It cannot
+ * attribute a concurrent change to Grok and does not cover ignored paths.
+ *
+ * The brief is handed to grok via `--prompt-file`, never argv: it stays out of
+ * the host process list, isn't bounded by the OS arg-length cap, and a brief
+ * that starts with "-" can't be misread as a flag.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for Grok (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Grok model (default: Grok's own configured default).
+ *   --effort <level>        Reasoning effort for this run (passed as `--effort`).
+ *   --max-turns <n>         Maximum number of agent turns for this run.
+ *   --read-only             Review/diagnosis with no edits (`--sandbox read-only`).
+ *   --full-access           Unrestricted auto-approve (`--sandbox off`); opt-in.
+ *   --resume-last           Continue the most recent Grok session for this cwd;
+ *                           send only the delta brief.
+ *   --session <id>          Continue a specific session id; send only the delta brief.
+ *                           Mutually exclusive with --resume-last.
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the grok child is killed
+ *                           and result.json gets status "timeout".
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, grokVersion, sessionId (for a later resume), finalMessage
+ *   (Grok's own report), usage (token counts from the run's end event, null if
+ *   none), touchedFiles (git porcelain, null if git can't report), and the paths
+ *   to events.jsonl and final.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `grok` binary exits 127;
+ * otherwise the exit code mirrors Grok's own (0 success, non-zero failure). If
+ * the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, timeout (the --timeout watchdog fired), aborted (the relay
+ * itself was killed and forwarded the kill to grok), or grok_unavailable. An
+ * orchestrator that polls for the
+ * file must therefore also treat a non-zero exit with no file as a usage error.
+ */
+
+import { spawn, execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, readdirSync, existsSync, appendFileSync, lstatSync, readlinkSync, openSync, readSync, closeSync, realpathSync } from "node:fs";
+import { join, relative, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+import { TextDecoder } from "node:util";
+
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_TIMER_MS = 2_147_483_647;
+const AUTONOMY_MODES = new Set(["workspace-write", "read-only", "full-access"]);
+
+const IMPLEMENTER_KEY = "grok";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    effort: null,
+    maxTurns: null,
+    autonomy: "workspace-write",
+    resumeLast: false,
+    session: null,
+    timeout: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--effort": opts.effort = next(); flagged.add("effort"); break;
+      case "--max-turns": opts.maxTurns = next(); break;
+      case "--read-only": opts.autonomy = "read-only"; flagged.add("autonomy"); flagged.add("readOnly"); break;
+      case "--full-access": opts.autonomy = "full-access"; flagged.add("autonomy"); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  // The watchdog is relay-only (the grok launch has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  if (!AUTONOMY_MODES.has(opts.autonomy)) {
+    fail(`invalid autonomy "${opts.autonomy}"`);
+  }
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive");
+  }
+  // These values reach a shell on win32 (shell:true for the .cmd shim), so restrict them to safe tokens.
+  const safeToken = /^[A-Za-z0-9][A-Za-z0-9._:\/-]*$/;
+  for (const flag of ["model", "effort", "session"]) {
+    if (opts[flag] !== null && !safeToken.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  // Digits-only also keeps the value safe for the win32 shell launch.
+  if (opts.maxTurns !== null && !/^[1-9]\d*$/.test(opts.maxTurns)) {
+    fail("--max-turns must be a positive integer");
+  }
+  return opts;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to grok --prompt-file\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once grok is running, so the preflight needs a bound of its
+  // own: a version probe that never returns would wedge the relay here, before any
+  // result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function grokVersion(probeTimeoutMs) {
+  // On Windows, npm installs `grok` as a .cmd shim; Node's CreateProcess only
+  // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
+  // ENOENTs on a working install. POSIX is unaffected. (git installs a real
+  // git.exe and must NOT get this flag — see gitTouchedFiles.)
+  const probe = (argv, timeout = probeTimeoutMs) => {
+    try {
+      const version = execFileSync("grok", argv, {
+        encoding: "utf8",
+        shell: process.platform === "win32",
+        timeout,
+        killSignal: "SIGKILL",
+      }).trim();
+      return { version: version || "unknown", error: null };
+    } catch (error) {
+      if (error?.code === "ENOENT") return { version: null, error: null };
+      // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+      // exit rather than ENOENT; that is still "not installed", not a broken install.
+      if (process.platform === "win32" &&
+          /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+        return { version: null, error: null };
+      }
+      // Anything else — a hung probe we killed, or a real non-zero exit — means grok is
+      // installed but not usable. Reporting that as "unavailable" would send the caller
+      // off to reinstall a binary that is already there.
+      return { version: null, error };
+    }
+  };
+  // Prefer `grok version` (documented subcommand); fall back to `--version` for builds that
+  // only answer the flag. A missing binary and a hung probe are both conclusive, though:
+  // retrying either would only spend the bound a second time.
+  const startedAt = performance.now();
+  const documented = probe(["version"]);
+  if (documented.version || !documented.error || documented.error.code === "ETIMEDOUT") return documented;
+  const remainingMs = Math.floor(probeTimeoutMs - (performance.now() - startedAt));
+  if (remainingMs <= 0) return { version: null, error: { code: "ETIMEDOUT" } };
+  return probe(["--version"], remainingMs);
+}
+
+// Porcelain status alone cannot see every write. A path that is " M file" before a run and
+// " M file" after it produces an identical line, so comparing status lines proves nothing about
+// its contents — which is why the read-only tripwire below fingerprints the already-dirty paths
+// as well. Two sentinels stand for "could not fingerprint"; they are never treated as unchanged.
+const FINGERPRINT_UNREADABLE = "<unreadable>";
+const FINGERPRINT_DIRECTORY = "<directory>";
+
+function gitRepoRoot(cwd) {
+  // Porcelain paths are relative to the repository ROOT, not to the directory git ran in
+  // (--porcelain forces status.relativePaths off). Joining them against a --cd that is a
+  // subdirectory would look for <repo>/src/src/file and find nothing at either end.
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).replace(/\n$/, "") || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitStatusEntries(cwd) {
+  // -z so a path containing a space, a quote, or a newline stays one field rather than being
+  // quoted and escaped; -uall so an untracked directory is expanded into its files, because a
+  // collapsed "?? dir/" line never changes when a file inside it does.
+  try {
+    const output = execFileSync("git", ["status", "--porcelain", "-z", "-uall"], {
+      cwd,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const fields = new TextDecoder("utf-8", { fatal: true }).decode(output)
+      .split("\0").filter((field) => field.length > 0);
+    const entries = [];
+    for (let i = 0; i < fields.length; i += 1) {
+      const entry = fields[i];
+      const status = entry.slice(0, 2);
+      const path = entry.slice(3);
+      // R and C can sit in EITHER status column, and under -z such an entry is followed by its
+      // origin path as its own unprefixed field. Consume that field in both cases. A rename
+      // origin belongs in the dirty set (the file moved away from it); a copy origin does not,
+      // since a copy source can be a perfectly clean file.
+      const renamed = status.includes("R");
+      const copied = status.includes("C");
+      let origin = null;
+      if (renamed || copied) {
+        i += 1;
+        origin = fields[i] ?? null;
+      }
+      entries.push({ status, path, origin });
+    }
+    return entries;
+  } catch {
+    return null;
+  }
+}
+
+function dirtyPaths(cwd) {
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const paths = [];
+  for (const entry of entries) {
+    paths.push(entry.path);
+    if (entry.status.includes("R") && entry.origin !== null) paths.push(entry.origin);
+  }
+  return paths;
+}
+
+function asciiFold(value) {
+  return value.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+}
+
+function canonicalFilePath(path) {
+  const absolute = resolve(path);
+  let parent;
+  try { parent = realpathSync.native(dirname(absolute)); } catch { return absolute; }
+  const leaf = basename(absolute);
+  const canonical = join(parent, leaf);
+  try { lstatSync(canonical); } catch { return canonical; }
+  try {
+    const entries = readdirSync(parent);
+    if (entries.includes(leaf)) return canonical;
+    const matches = entries.filter((entry) => asciiFold(entry) === asciiFold(leaf));
+    return join(parent, matches.length === 1 ? matches[0] : leaf);
+  } catch {
+    return canonical;
+  }
+}
+
+function gitPathKey(root, path) {
+  let canonicalRoot;
+  try { canonicalRoot = realpathSync.native(root); } catch { canonicalRoot = resolve(root); }
+  const key = relative(canonicalRoot, canonicalFilePath(path));
+  return process.platform === "win32" ? key.replaceAll("\\", "/") : key;
+}
+
+function gitPathIsExcluded(root, path, excluded, foldedExcluded) {
+  return excluded.has(path) ||
+    (foldedExcluded.has(asciiFold(path)) && excluded.has(gitPathKey(root, join(root, path))));
+}
+
+function gitTripwireState(cwd, excludedPaths) {
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return entries.flatMap((entry) => [
+    [entry.status, "path", entry.path],
+    ...(entry.origin === null ? [] : [[entry.status.replace(/[^RC]/g, " "), "origin", entry.origin]]),
+  ]
+    .filter(([, , path]) => !gitPathIsExcluded(root, path, excluded, foldedExcluded)));
+}
+
+function pathFingerprint(absolutePath) {
+  // Identity, not just bytes: a retargeted symlink, a flipped mode bit, or a file replaced by a
+  // directory are all writes, and none of them change file contents.
+  let stats;
+  try {
+    stats = lstatSync(absolutePath);
+  } catch (error) {
+    // Absence is a state, not a failure - it differs from every real fingerprint, so a deletion
+    // or a re-creation still registers. Any other errno means we genuinely cannot tell.
+    return error && error.code === "ENOENT" ? "absent" : FINGERPRINT_UNREADABLE;
+  }
+  if (stats.isSymbolicLink()) {
+    try {
+      return `symlink:${readlinkSync(absolutePath, { encoding: "buffer" }).toString("hex")}`;
+    } catch {
+      return FINGERPRINT_UNREADABLE;
+    }
+  }
+  // A directory in the dirty set is a submodule, whose contents belong to another repository.
+  // Reported as unknown coverage rather than silently passed off as unchanged.
+  if (stats.isDirectory()) return FINGERPRINT_DIRECTORY;
+  if (!stats.isFile()) return FINGERPRINT_UNREADABLE;
+  let fd;
+  try {
+    // Streamed rather than read whole: an unignored multi-gigabyte artifact must not be pulled
+    // into memory just to answer whether it changed.
+    const hash = createHash("sha256");
+    fd = openSync(absolutePath, "r");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    for (;;) {
+      const read = readSync(fd, buffer, 0, buffer.length, null);
+      if (read <= 0) break;
+      hash.update(buffer.subarray(0, read));
+    }
+    return `file:${(stats.mode & 0o7777).toString(8)}:${hash.digest("hex")}`;
+  } catch {
+    return FINGERPRINT_UNREADABLE;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* already closed */ }
+    }
+  }
+}
+
+function gitIndexFingerprints(root, paths) {
+  if (paths.length === 0) return new Map();
+  try {
+    const output = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const wanted = new Set(paths);
+    const prints = new Map(paths.map((path) => [path, []]));
+    for (const field of new TextDecoder("utf-8", { fatal: true }).decode(output).split("\0")) {
+      if (!field) continue;
+      const separator = field.indexOf("\t");
+      if (separator === -1) return null;
+      const path = field.slice(separator + 1);
+      if (wanted.has(path)) prints.get(path).push(field.slice(0, separator));
+    }
+    return prints;
+  } catch {
+    return null;
+  }
+}
+
+function fingerprintPaths(root, paths) {
+  // `complete` goes false the moment one path cannot be fingerprinted, so the caller reports
+  // "unknown" instead of an unearned clean bill of health.
+  const indexPrints = gitIndexFingerprints(root, paths);
+  const prints = new Map();
+  let complete = indexPrints !== null;
+  for (const path of paths) {
+    const file = pathFingerprint(join(root, path));
+    if (file === FINGERPRINT_UNREADABLE || file === FINGERPRINT_DIRECTORY) complete = false;
+    prints.set(path, { file, index: indexPrints?.get(path) ?? null });
+  }
+  return { prints, complete };
+}
+
+function fingerprintDirtyPaths(cwd, excludedPaths) {
+  // Only the already-dirty set is covered. A path that is clean at dispatch and gets written
+  // surfaces as a brand-new porcelain line anyway, and fingerprinting a whole repository per run
+  // would cost far more than the case it covers.
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const paths = dirtyPaths(cwd);
+  if (paths === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return {
+    root,
+    ...fingerprintPaths(root, paths.filter((path) => !gitPathIsExcluded(root, path, excluded, foldedExcluded))),
+  };
+}
+
+function changedDirtyPaths(before) {
+  // Re-fingerprint exactly the baseline paths, not whatever happens to be dirty now: a path the
+  // run newly dirtied is already reported by the porcelain comparison, and letting an unreadable
+  // one of those blind this signal would be a regression, not caution.
+  if (!before) return { changed: [], complete: false };
+  const now = fingerprintPaths(before.root, [...before.prints.keys()]);
+  const changed = [];
+  for (const [path, print] of before.prints) {
+    const current = now.prints.get(path);
+    const fileKnown = print.file !== FINGERPRINT_UNREADABLE && current.file !== FINGERPRINT_UNREADABLE;
+    const fileChanged = fileKnown &&
+      !(print.file === FINGERPRINT_DIRECTORY && current.file === FINGERPRINT_DIRECTORY) &&
+      current.file !== print.file;
+    const indexChanged = print.index !== null && current.index !== null &&
+      JSON.stringify(current.index) !== JSON.stringify(print.index);
+    if (fileChanged || indexChanged) changed.push(path);
+  }
+  return { changed: changed.sort(), complete: before.complete && now.complete };
+}
+
+function readOnlyVerdict(beforeTree, afterTree, beforeFingerprints) {
+  // Three-valued on purpose. Proof of a write settles it even when the other signal is unknown;
+  // only when nothing is proven AND coverage is incomplete is the answer genuinely unknown.
+  // Collapsing that last case to false is the false assurance a tripwire must never give.
+  const changed = changedDirtyPaths(beforeFingerprints);
+  const porcelainMoved =
+    beforeTree !== null && afterTree !== null && JSON.stringify(beforeTree) !== JSON.stringify(afterTree);
+  if (porcelainMoved || changed.changed.length > 0) return true;
+  if (beforeTree === null || afterTree === null || !changed.complete) return null;
+  return false;
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function autonomyFlags(autonomy) {
+  // Maps the relay's three autonomy modes onto Grok's native --sandbox /
+  // --always-approve / --permission-mode flags. Grok's default permission mode
+  // is `ask`, which hangs a headless pipe — so every path sets autonomy
+  // explicitly. Sandbox profiles (verified valid on grok 0.2.101):
+  //   workspace  — write CWD /tmp ~/.grok/   (workspace-write analog)
+  //   read-only  — review intent ONLY; the sandbox restricts out-of-workspace
+  //                access, not grok's own edit tool, so a headless run can still
+  //                write the tree. Best-effort — verify touchedFiles afterward.
+  //   off        — unrestricted              (full-access opt-in)
+  switch (autonomy) {
+    case "read-only":
+      return ["--sandbox", "read-only", "--permission-mode", "plan"];
+    case "full-access":
+      return ["--always-approve", "--sandbox", "off"];
+    case "workspace-write":
+    default:
+      return ["--always-approve", "--sandbox", "workspace"];
+  }
+}
+
+function buildArgv(opts, run) {
+  // ponytail: shell:true on win32 (needed for the grok.cmd shim) doesn't quote
+  // args, so a path with spaces (C:\Users\First Last\...) splits before grok
+  // sees it. Quote the two spaceable path args; --model/--effort/--session are
+  // already restricted to safe tokens at parse time.
+  // Ceiling: if quoting proves too blunt, drop shell:true and resolve the shim.
+  const quotePath = (p) => (process.platform === "win32" ? `"${p}"` : p);
+  // Always: automation hygiene + structured events + working root.
+  const argv = [
+    "--no-auto-update",
+    "--no-alt-screen",
+    "--output-format", "streaming-json",
+    "--cwd", quotePath(opts.cd),
+  ];
+
+  if (opts.resumeLast) argv.push("--continue");
+  else if (opts.session) argv.push("--resume", opts.session);
+
+  // Re-pass autonomy on resume too — headless permission mode may not inherit.
+  argv.push(...autonomyFlags(opts.autonomy));
+
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.effort) argv.push("--effort", opts.effort);
+  if (opts.maxTurns) argv.push("--max-turns", opts.maxTurns);
+
+  // Deliver the brief via a file, not argv: keeps it out of the host process
+  // list, isn't bounded by the OS arg-length cap, and a brief that begins with
+  // "-" can't be misread as a flag. prepareRunDir already wrote run.briefPath.
+  argv.push("--prompt-file", quotePath(run.briefPath));
+  return argv;
+}
+
+function extractSessionId(event) {
+  // grok's streaming-json carries sessionId (camelCase) on the end event; the
+  // extra fallbacks tolerate a shape drift across versions.
+  return (
+    event.sessionId ??
+    event.session_id ??
+    (event.session && (event.session.id ?? event.session.sessionId)) ??
+    null
+  );
+}
+
+function extractTextChunk(event) {
+  // grok streams the assistant reply as {"type":"text","data":"…"}; reasoning
+  // arrives as type:"thought" and is deliberately kept out of the report.
+  // The type:"text"+event.text fallback covers a possible field rename.
+  if (event.type !== "text") return null;
+  if (typeof event.data === "string") return event.data;
+  if (typeof event.text === "string") return event.text;
+  return null;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only Grok's edits, not relay's artifacts.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    eventsPath: join(outDir, "events.jsonl"),
+    finalPath: join(outDir, "final.txt"),
+    briefPath: join(outDir, "brief.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.finalPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "grok",
+      workdir: opts.cd,
+      autonomy: opts.autonomy,
+      model: opts.model,
+      effort: opts.effort,
+      resumeLast: opts.resumeLast,
+      grokVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      eventsPath: run.eventsPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "grok_unavailable", exitCode: 127, signal: null, sessionId: null, finalMessage: "", usage: null, touchedFiles: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `grok` not found on PATH. Install it with `npm i -g @xai-official/grok` and run `grok login`.\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `grok version preflight timed out after ${probeTimeoutMs}ms; Grok was not dispatched`
+    : `grok version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Grok was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    usage: null,
+    touchedFiles: gitTouchedFiles(opts.cd),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToGrok(opts, run, writeResult) {
+  // grok cannot be prevented from writing headlessly (the read-only sandbox and
+  // plan mode are advisory), so a --read-only run snapshots the tree up front
+  // and flags a violation in the result instead of pretending to enforce.
+  const relayArtifacts = [run.briefPath, run.eventsPath, run.finalPath, run.resultPath];
+  const beforeTree = opts.autonomy === "read-only" ? gitTripwireState(opts.cd, relayArtifacts) : null;
+  // Working-tree and index state for paths that are ALREADY dirty. Their porcelain lines will not
+  // move if the run edits them, so the line comparison alone cannot see those writes.
+  const beforeFingerprints = opts.autonomy === "read-only" ? fingerprintDirtyPaths(opts.cd, relayArtifacts) : null;
+  // every dispatched result that reports touchedFiles carries the verdict, aborted runs included -
+  // an aborted --read-only review can still have modified the tree
+  const readOnlyFlag = () =>
+    opts.autonomy === "read-only"
+      ? { readOnlyViolation: readOnlyVerdict(beforeTree, gitTripwireState(opts.cd, relayArtifacts), beforeFingerprints) }
+      : {};
+  const argv = buildArgv(opts, run);
+  // shell:true on Windows so the grok.cmd shim resolves (see grokVersion). Safe:
+  // the brief is delivered via --prompt-file (never argv), --model/--effort/--session
+  // are restricted to safe tokens at parse time, and the two path args are
+  // quoted for win32 in buildArgv.
+  const child = spawn("grok", argv, {
+    cwd: opts.cd,
+    env: { ...process.env },
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = opts.session || null;
+  let usage = null;
+  const textChunks = [];
+  const stderrTail = [];
+
+  const scan = makeEventScanner((event) => {
+    const sid = extractSessionId(event);
+    if (sid) sessionId = sid;
+    const chunk = extractTextChunk(event);
+    if (chunk) textChunks.push(chunk);
+    if (event.usage && typeof event.usage === "object") usage = event.usage;
+  });
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk); // faithful raw record
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk); // surface Grok progress live for the orchestrator
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textChunks.join("").trim();
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        if (!settled) killChild(child, "SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the grok child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const touchedAtAbort = gitTouchedFiles(opts.cd);
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        finalMessage: assembleFinal(),
+        usage,
+        touchedFiles: touchedAtAbort,
+        ...readOnlyFlag(),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; grok was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        const touchedAfterGrace = gitTouchedFiles(opts.cd);
+        writeResult({ ...abortedFields, touchedFiles: touchedAfterGrace, ...readOnlyFlag() });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const touchedFiles = gitTouchedFiles(opts.cd);
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      finalMessage: assembleFinal(),
+      usage,
+      touchedFiles,
+      ...readOnlyFlag(),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    const finalMessage = assembleFinal();
+    const touchedFiles = gitTouchedFiles(opts.cd);
+    // A timed-out run is never a success even if grok handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
+      sessionId,
+      finalMessage,
+      usage,
+      touchedFiles,
+      ...readOnlyFlag(),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `grok did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
+  const run = prepareRunDir(opts, brief);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = grokVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+
+  if (!probe.version && !probe.error) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+
+  dispatchToGrok(opts, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  grok ${result.grokVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a grok error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated grok (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.readOnlyViolation === null) lines.push("warning: this --read-only run could not be verified - git could not report, or a submodule or unreadable path left coverage incomplete; inspect the working tree directly.");
+  if (result.readOnlyViolation === true) lines.push("warning: a git-visible change was detected during this --read-only run — grok's read-only is best-effort; review the diff before trusting the run.");
+  lines.push(`autonomy: ${result.autonomy}`);
+  if (result.resumeLast) lines.push("mode: resumed most recent session (--continue)");
+  else if (result.sessionId && result.status !== "grok_unavailable") {
+    lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  }
+  if (result.usage) {
+    const u = result.usage;
+    lines.push(`tokens: ${u.total_tokens ?? "?"} total (in ${u.input_tokens ?? "?"}, out ${u.output_tokens ?? "?"})`);
+  }
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- grok final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/kimi-delegate/SKILL.md
+++ b/skills/kimi-delegate/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: kimi-delegate
+description: Delegate a coding task to the Kimi Code CLI (`kimi`) as a background
+  implementer, then review its diff and land it yourself. Use this whenever the user
+  wants to hand implementation work to Kimi - phrasings like "have Kimi implement
+  X", "delegate this to Kimi", "run it through...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+metadata:
+  version: 0.5.0
+---
+# Kimi Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `kimi` implementer (`Kimi Code`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Hand a bounded coding task to a separate **implementer** - the Kimi Code
+CLI - then review what it produced and land it yourself. You write the brief and own the judgment;
+Kimi does the typing in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `kimi` CLI is not installed or authenticated.
+- You need a CLI-enforced read-only implementer. Headless Kimi has no read-only mode.
+
+## Prerequisites (check once)
+
+1. Install Kimi Code with `brew install kimi-code` on macOS/Linux, or use the native installer from
+   the [official Kimi Code documentation](https://moonshotai.github.io/kimi-code/en/).
+2. Authenticate with `kimi login` (device-code flow, no TUI), or use `/login` in the TUI.
+3. Confirm `kimi --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the model alias
+
+Kimi uses `default_model` from its `config.toml` when `--model` is omitted. To choose another model
+alias, pass `--model <alias from your kimi config>`. Model aliases are user-defined config keys; use
+one the human has configured rather than inventing one.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Kimi sees only the text you send plus what it can inspect in the workspace - no chat history or shared
+context. Include the goal, current state, what to change, what to leave untouched, the project's
+**actual** gates, and a report contract. Tell Kimi not to commit. Keep one task per brief. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled helper. It wraps Kimi's headless prompt mode, captures the structured event stream,
+and writes `result.json`. (`<skill-dir>` is the installed folder containing this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a configured model alias:       add --model <alias from your kimi config>
+# resume the most recent session:        add --resume-last  (delta brief only)
+# resume a specific session:             add --session <id> (delta brief only)
+# hard time limit (watchdog):            add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
+# see all options:                       node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. Use repeatable `--add-dir` flags only for extra workspace
+directories. The relay writes artifacts under the system temp dir by default and never commits. See
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Kimi finishes. Run it with the orchestrator's background-command facility, or
+background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
+result; a missing `kimi` exits 127 and writes `status: "kimi_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process exited
+and `result.json` exists. Kimi's full report is the `finalMessage` field in `result.json` (also printed
+in full on stdout between the report markers).
+
+### 4. Review - do not trust the self-report
+
+Treat Kimi's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates pass
+and the diff holds. If rework is needed, send a delta brief with `--resume-last` or `--session <id>`,
+then review again.
+
+## Autonomy and permissions
+
+In headless `-p` mode, Kimi always runs in **auto permission mode** and never asks for approval. Kimi
+rejects `--prompt` combined with `--yolo`, `--auto`, or `--plan`, so the relay passes none of them and
+offers no `--read-only` or `--full-access` option. There is no CLI-enforced read-only mode: inspect
+`touchedFiles` and the diff after every run. That diff, not a flag, is the guarantee of what changed.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't absorb**
+(report Kimi's design decisions, defensible-but-unasked turns, and non-blocking nitpicks) and **stop
+for scope changes** (if correct completion needs going beyond the brief, ask instead of expanding the
+mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - structure, report contract,
+  real gates, argv delivery, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - review checklist, commit boundary,
+  and rework through Kimi sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues, constraint
+  carry-forward, progress tracking, and the final coherence pass.
+
+
+## Limitations
+
+- Requires the `kimi` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/kimi-delegate/references/dispatch-and-poll.md
+++ b/skills/kimi-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,134 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps Kimi's headless prompt mode, captures its structured stream, and writes a
+`result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v kimi
+kimi --version
+kimi login
+```
+
+Install with `brew install kimi-code` on macOS/Linux or use a native installer from the
+[official Kimi Code documentation](https://moonshotai.github.io/kimi-code/en/). `kimi login` uses a
+device-code flow without opening the TUI; `/login` is also available inside the TUI.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <alias>` | Kimi model alias for this run (default: Kimi's own `default_model`). |
+| `--session <id>` | Resume a specific Kimi session; send only the delta brief. |
+| `--resume-last` | Resume the most recent Kimi session for this cwd (`kimi --continue`); send only the delta brief. |
+| `--add-dir <dir>` | Add an extra workspace directory. Repeatable. Edits there are not reported in `touchedFiles`. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Kimi has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive. The child cwd pins the primary workspace;
+`--add-dir` adds extra workspaces only.
+
+Headless `-p` mode always uses Kimi's auto permission mode. Kimi rejects `--prompt` combined with
+`--yolo`, `--auto`, or `--plan`, so the relay passes no autonomy flags and has no `--read-only` or
+`--full-access` option. Inspect `touchedFiles` and the diff after every run.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an `--out-dir`
+inside the worktree can make the artifacts appear there:
+
+- `brief.txt` - the exact brief.
+- `events.jsonl` - raw Kimi stdout events.
+- `final.txt` - assistant text joined with a blank line between chunks; absent if none was emitted.
+- `stderr.txt` - complete stderr.
+- `result.json` - the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"kimi"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `kimi_unavailable`), `exitCode`, and
+  `signal` (`null` unless the child died on a signal).
+- `workdir`, `model` (the model alias or `null`), `resumed`, `kimiVersion`, `sessionId`, `startedAt`,
+  and `finishedAt`.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `finalMessage` - assistant `content` strings joined with `"\n\n"`; tool calls and tool results are
+  excluded.
+- `touchedFiles` - `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of Kimi's edits: anything already dirty before dispatch shows up too, and edits
+  Kimi makes inside `--add-dir` workspaces do not show up at all - inspect those trees yourself.
+  Dispatch from a clean tree when you want the list to read as "what Kimi changed". `null` means git
+  could not report; `[]` means git ran and the tree is clean.
+- `stderrTail` - the last 20 non-empty stderr lines on any run that did not complete (`failed`, `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`.
+- `error` - present for launch failures, when the relay watchdog fires (`timeout`), and on an `aborted` run.
+
+Kimi's stream carries no token usage, so `result.json` has no `usage` field.
+
+## Waiting for completion
+
+The helper blocks. Use the orchestrator's background-command facility, or background it in a shell and
+poll for `result.json`. The run is done only when the process exits and the file contains a `status`.
+
+A pre-run usage error exits 2 and writes no result. A missing `kimi` exits 127 and writes
+`status: "kimi_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "kimi_unavailable"` (exit 127):** install the native Kimi Code CLI, authenticate with
+  `kimi login`, and re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `kimi --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter), so
+  kimi was never dispatched; only the relay's own artifacts may already exist under `--out-dir`.
+  Check the install by running `kimi --version` yourself.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. A common
+  cause is an unconfigured model alias: `error: failed to run prompt: config.invalid: Model "<x>" is not configured in config.toml…`
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to kimi. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through the
+  OOM killer or a supervisor timeout. This is not a Kimi error; check host memory and re-dispatch, or
+  split the task into smaller briefs.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `kimi did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout` or
+  split the task. The relay sends SIGTERM, waits 10 seconds, then sends SIGKILL if needed.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Whether it also carries the edit contents depends on what the CLI streams,
+so treat any reconstruction as unverified until it matches a working-tree diff — when the tree
+still holds the work, preserve the tree rather than replaying the log.
+
+## What the relay runs
+
+The argv is equivalent to:
+
+```bash
+kimi --output-format stream-json [--model <alias>] [--session <id> | --continue] \
+  [--add-dir <dir> ...] --prompt=<brief>
+```
+
+The prompt rides argv and is visible in the host process list. The relay rejects briefs over 120 KB
+before launch because the OS caps a single argument. It spawns the native `kimi` binary directly with
+the selected `--cd` as cwd; no shell or Kimi timeout flag is involved.
+
+## The commit boundary
+
+The relay never commits. Kimi edits the working tree; the orchestrator reviews, re-runs the gates, and
+commits. See [review-and-land.md](review-and-land.md).

--- a/skills/kimi-delegate/references/multi-task-queues.md
+++ b/skills/kimi-delegate/references/multi-task-queues.md
@@ -1,0 +1,58 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is the
+default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh Kimi sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture location,
+or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed Kimi session only for rework on the same task. Send a delta brief with `--resume-last`,
+or with `--session <id>` from that task's `result.json`. Start unrelated queue items in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** - queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** - what landed, what you verified, and gate outcomes.
+- **Needs your eyes** - design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** - the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/kimi-delegate/references/review-and-land.md
+++ b/skills/kimi-delegate/references/review-and-land.md
@@ -1,0 +1,92 @@
+# Review and land
+
+Kimi did the typing; you own the judgment. Verify against reality, never the self-report, and read the
+diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries Kimi's claims, not evidence. Re-run the project's actual test, lint, and build
+commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** - changes the brief excluded.
+- **Scope shortfall** - missed behavior, edges, or cleanup.
+- **Quiet judgment calls** - defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to Kimi as a delta brief, or fix it in the tree, and report either choice
+to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer. Write a
+clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove the
+unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--session <id>` instead when resuming the specific id recorded in `result.json`. Kimi itself
+rejects combining `--continue` and `--session`; the relay rejects `--resume-last` plus `--session`
+before launch. Rework gets the same gate rerun, test review, diff review, and implementer sweep.
+
+Headless Kimi always uses auto permission mode and has no CLI-enforced read-only mode. Confirm
+`touchedFiles` after every fresh or resumed run.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep them
+in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/kimi-delegate/references/writing-the-brief.md
+++ b/skills/kimi-delegate/references/writing-the-brief.md
@@ -1,0 +1,132 @@
+# Writing the brief
+
+A brief is the entire task as Kimi will see it. It runs in a separate session with **no memory of your
+conversation, no access to prior notes, and no shared context** - only the text you send and whatever
+it can inspect in the workspace. If a constraint is not in the brief or discoverable in the repo, it
+does not exist for Kimi.
+
+## Model choice and resumed sessions
+
+Kimi uses `default_model` from its `config.toml`, so a fresh dispatch does not require `--model`. Pass
+`--model <alias from your kimi config>` only when the human wants one of their configured model
+aliases. Do not invent an alias.
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report Kimi must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** - add `<completeness_contract>` (resolve fully, not just the first
+  plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is unknown).
+- **Research or recommendations** - add `<research_mode>` (separate observed facts, inferences, and
+  open questions).
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from assistant text in Kimi's structured stream. Without a closing
+summary, the edits may exist but the result is hard to review. The `<structured_output_contract>`
+block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy the
+actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Kimi can inspect the workspace, but the important
+constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one Kimi run -> one reviewed commit keeps the diff and rollback
+clean. Split mixed implementation, review, documentation, and roadmap requests into separate
+dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Argv delivery limits
+
+Kimi headless mode requires the brief as a command-line argument. The relay reads a file or stdin for
+convenience, then passes the text with `--prompt=<brief>`. The equals form binds a brief that starts
+with `-` instead of treating it as another flag.
+
+This has two consequences:
+
+- The brief is visible in the host process list (`ps`, `/proc`). Keep secrets out of it on shared
+  machines; reference workspace files or environment variables instead.
+- A brief over 120 KB is rejected before launch because operating systems cap a single argv value.
+  Put large context in the workspace and tell Kimi which file to read.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/kimi-delegate/scripts/relay.mjs
+++ b/skills/kimi-delegate/scripts/relay.mjs
@@ -1,0 +1,649 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · kimi-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Kimi Code CLI (`kimi -p`), capture
+ * the run, and write a structured result the orchestrating agent can review.
+ * The orchestrator runs this one command and reads the result JSON - every
+ * Kimi-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified against kimi CLI 0.24.0 on macOS.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `kimi` and `git`. The `kimi` process it launches
+ * does authenticate - exactly as you do at the terminal. Read this file before
+ * you run it.
+ *
+ * Note: `kimi -p` takes the prompt as a command-line argument, so the brief is
+ * visible in the host process list (`ps`, /proc). On a shared machine keep
+ * secrets out of the brief - reference them by a path or environment variable
+ * the workspace can read.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * - after it reviews the diff and re-runs the project gates.
+ *
+ * Headless `-p` mode always uses Kimi's auto permission mode. Kimi rejects
+ * `--yolo`, `--auto`, and `--plan` when combined with `--prompt`, so this relay
+ * passes no autonomy flags and offers no read-only mode. The diff reported in
+ * `touchedFiles`, not a flag, is the guarantee of what changed.
+ *
+ * Kimi's supported Homebrew and official-installer distributions provide a
+ * native binary on every platform. The npm-installed `kimi` on Windows is a
+ * `.cmd` shim this relay does not launch; use the native install there.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for Kimi (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <alias>         Kimi model alias (default: Kimi's own default_model).
+ *   --session <id>          Resume a specific Kimi session; send only the delta brief.
+ *   --resume-last           Resume the most recent Kimi session for this cwd;
+ *                           send only the delta brief.
+ *   --add-dir <dir>         Add an extra workspace directory. Repeatable.
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). Kimi has no
+ *                           timeout flag; durations use h/m/s strings.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout -
+ *   status, exitCode, signal, kimiVersion, sessionId, finalMessage (Kimi's own
+ *   report), touchedFiles (git porcelain, null if git cannot report), and paths
+ *   to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `kimi` binary exits 127;
+ * otherwise the exit code mirrors Kimi's own (0 success, non-zero failure). If
+ * the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome - completed, failed, timeout (the --timeout watchdog
+ * fired), aborted (the relay itself was killed and forwarded the kill to kimi),
+ * or kimi_unavailable.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_TIMER_MS = 2_147_483_647;
+
+const IMPLEMENTER_KEY = "kimi";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    session: null,
+    resumeLast: false,
+    addDirs: [],
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--add-dir": opts.addDirs.push(next()); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  // kimi resolves a relative --add-dir against ITS cwd, so resolve against --cd
+  // (not the relay's own cwd) - and only after the loop, since --add-dir may
+  // appear before --cd on the command line. resolve() passes absolutes through.
+  opts.addDirs = opts.addDirs.map((dir) => resolve(opts.cd, dir));
+  // The watchdog is relay-only (kimi has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent 30m fallback would be wrong.
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to kimi -p\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once kimi is running, so the preflight needs a bound of its
+  // own: a `kimi --version` that never returns would wedge the relay here, before any
+  // result.json exists, and --timeout could not reach it.
+  return Math.min(parseDuration(opts.timeout), VERSION_PROBE_TIMEOUT_MS);
+}
+
+function kimiVersion(probeTimeoutMs) {
+  try {
+    const out = execFileSync("kimi", ["--version"], {
+      encoding: "utf8",
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+    }).trim();
+    return { version: out || "unknown", error: null };
+  } catch (err) {
+    // Only a missing binary means "unavailable"; any other version-probe
+    // failure must not masquerade as exit 127.
+    if (err && err.code === "ENOENT") return { version: null, error: null };
+    // A hung probe we killed, or a real non-zero exit, means kimi is installed but not
+    // usable. Dispatching anyway would send the brief to a CLI already known to be broken.
+    return { version: null, error: err };
+  }
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, brief) {
+  const argv = ["--output-format", "stream-json"];
+  if (opts.model) argv.push("-m", opts.model);
+  if (opts.session) argv.push("--session", opts.session);
+  else if (opts.resumeLast) argv.push("--continue");
+  for (const dir of opts.addDirs) argv.push("--add-dir", dir);
+  // Use --prompt=<brief>, not a separate ["--prompt", brief] pair: the equals
+  // form binds a brief that starts with "-" instead of letting it parse as a flag.
+  argv.push(`--prompt=${brief}`);
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "kimi",
+      workdir: opts.cd,
+      model: opts.model,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      kimiVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "kimi_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `kimi` not found on PATH. Install Kimi Code and run `kimi login`.\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `kimi --version preflight timed out after ${probeTimeoutMs}ms; Kimi was not dispatched`
+    : `kimi --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Kimi was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToKimi(opts, brief, run, writeResult) {
+  const child = spawn("kimi", buildArgv(opts, brief), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = null;
+  const textChunks = [];
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    if (event.role === "assistant" && typeof event.content === "string") {
+      textChunks.push(event.content);
+    }
+    if (event.role === "meta" && event.type === "session.resume_hint" && typeof event.session_id === "string") {
+      sessionId = event.session_id;
+    }
+  });
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the kimi child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdogTimer);
+      if (sigkillTimer) clearTimeout(sigkillTimer);
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; kimi was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // A timed-out run is failed even if kimi handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `kimi did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // kimi --prompt takes the prompt as a CLI argument, so the brief rides argv.
+  // The OS caps one argument (~128KB on Linux via MAX_ARG_STRLEN); reject a
+  // huge brief early instead of allowing an opaque E2BIG spawn failure.
+  const briefBytes = Buffer.byteLength(brief, "utf8");
+  const MAX_BRIEF_BYTES = 120 * 1024;
+  if (briefBytes > MAX_BRIEF_BYTES) {
+    fail(`brief is ${Math.round(briefBytes / 1024)}KB; kimi passes the prompt as a CLI argument, which the OS caps (~128KB on Linux). Trim it, or have kimi read large context from the workspace instead of inlining it.`);
+  }
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
+  const run = prepareRunDir(opts, brief);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = kimiVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+  dispatchToKimi(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  kimi ${result.kimiVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a kimi error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated kimi (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- kimi final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/omp-delegate/SKILL.md
+++ b/skills/omp-delegate/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: omp-delegate
+description: Delegate a coding task to Oh My Pi (`omp`) as a background implementer,
+  then review its diff and land it yourself. Use this whenever the user wants to delegate
+  implementation work to Oh My Pi / omp - phrasings like "have omp implement X", "delegate
+  this to oh my pi", "run it...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `omp` CLI installed and authenticated (`/login` inside
+  omp, or a provider API-key environment variable), Node 18+, and git. The orchestrating
+  agent must be able to run shell commands and read files. Shell examples assume bash/zsh
+  (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+# Oh My Pi Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `omp` implementer (`Oh My Pi`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Delegate a bounded coding task to a separate **implementer** - Oh My
+Pi (`omp`) - then review what it produced and land it yourself. You write the brief and own the
+judgment; the implementer makes changes in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## The binary is `omp`, not `pi`
+
+Oh My Pi is a fork of Pi. This skill drives **`omp`** (`@oh-my-pi/pi-coding-agent`). The original
+Pi CLI is a different binary (`pi`) with a different skill (`pi-delegate`). If `omp` is missing but
+`pi` is installed, you have Pi, not Oh My Pi.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `omp` CLI is not installed or authenticated.
+- The user asked for the original Pi CLI (`pi`) — use `pi-delegate`.
+- You need a sandboxed implementer. Oh My Pi has no sandbox. `--read-only` restricts the tool
+  surface; a write-capable run executes without prompts (`--yolo`).
+
+## Prerequisites (check once)
+
+1. Install omp with `bun install -g @oh-my-pi/pi-coding-agent` (or the install path from
+   https://omp.sh).
+2. Authenticate: `/login` inside omp for a subscription provider, or an API-key environment
+   variable for an API-key provider. Credentials live under `~/.omp/`.
+3. Confirm `omp --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the model (optional)
+
+Omit `--model` (and `--provider`) to use omp's configured default for this project / profile. The
+catalog is **this install's** authenticated providers — not a fixed list in this skill.
+
+To pick another model:
+
+1. **List what this install can actually run.** Do **not** pass `omp --list-models` — that flag is
+   gone and omp treats it as an unknown flag (exit 2). Use the `models` subcommand:
+   - `omp models` — every available model, grouped by provider
+   - `omp models --json` — the same catalog, machine-readable
+   - `omp models find <substring>` — filter by provider, id, or name (example:
+     `omp models find sonnet`)
+   - `omp models <provider>` — one provider's models
+2. **Pass that id to the relay.** `--model <pattern>` is omp's own `--model`: a fuzzy match against
+   the catalog (provider/id, a bare id, or a unique substring). `--provider <name>` pins the
+   provider when the pattern is ambiguous.
+3. The relay forwards only letters, digits, and `. _ : / -`. Glob patterns with `*` are rejected.
+
+`--thinking <level>` is a separate reasoning dial, not a model id. Allowed values: `off`, `auto`,
+`minimal`, `low`, `medium`, `high`, `xhigh`, `max`. The relay rejects anything else (including
+`inherit`) before dispatch — omp would otherwise warn and ignore a bad value.
+
+A fleet lane (`--lane`) can set `provider`, `model`, and `effort`. Lane `effort` becomes
+`--thinking`; an explicit `--thinking` / `--model` / `--provider` flag wins over the lane.
+
+The relay does not forward `--api-key`, `--smol`, `--slow`, or `--plan`. Those stay omp's own CLI.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Oh My Pi sees only the text you send plus what it can inspect in the workspace - no chat history or
+shared context. Include the goal, current state, what to change, what to leave untouched, the
+project's **actual** gates, and a report contract. Tell omp not to commit. Keep one task per brief.
+omp auto-loads `AGENTS.md`/`CLAUDE.md` context files from the workspace and its parents, so repo
+instructions reach it without inlining. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled relay. It pipes the brief to `omp --mode json` on stdin, captures the JSON event
+stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing this
+`SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# list models first:                       omp models   (or: omp models --json)
+# choose a model:                          add --model <id from omp models>
+# choose a provider:                       add --provider <name>
+# set thinking level:                      add --thinking high
+# read-only run (review/diagnosis):        add --read-only
+# trust project .omp resources:            add --approve
+# resume the most recent session:          add --resume-last  (delta brief only)
+# resume a specific session:               add --session <id> (delta brief only)
+# hard time limit (watchdog):              add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
+# see all options:                         node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. The relay writes artifacts under the system temp dir
+by default and never commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until omp finishes. Run it with the orchestrator's background-command facility,
+or background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes
+no result; a missing `omp` exits 127 and writes `status: "omp_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process
+exited and `result.json` exists. omp's full report is the `finalMessage` field in `result.json`
+(also printed in full on stdout between the report markers).
+
+### 4. Review - do not trust the self-report
+
+Treat omp's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates
+pass and the diff holds. If rework is needed, send a delta brief with `--resume-last` or
+`--session <id>`, then review again.
+
+## Autonomy and permissions
+
+Oh My Pi has **no sandbox**. Print mode has no approval UI, so a write-capable relay run always
+passes `--yolo` (`tools.approvalMode: yolo`) — otherwise a user's `always-ask` or `write` config
+would stall until the watchdog. The other controls are:
+
+1. `--read-only` restricts omp's callable tools to `--tools read,grep,glob`. It does not pass
+   `--yolo`. Installed extension code still runs with the user's host permissions if project
+   resources are trusted.
+2. The relay passes `--no-extensions --no-skills --no-rules` by default, so project `.omp`
+   extensions, skills, and rules stay undiscovered. `--approve` is the explicit opt-in for a
+   repository the user trusts.
+3. `touchedFiles` and the diff are the record of what changed. Inspect them after every run.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"),
+committing verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't
+absorb** (report omp's design decisions, defensible-but-unasked turns, and non-blocking nitpicks)
+and **stop for scope changes** (if correct completion needs going beyond the brief, ask instead of
+expanding the mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - structure, report contract,
+  real gates, stdin delivery, model listing, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - review checklist, commit
+  boundary, and rework through omp sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues,
+  constraint carry-forward, progress tracking, and the final coherence pass.
+
+
+## Limitations
+
+- Requires the `omp` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/omp-delegate/references/dispatch-and-poll.md
+++ b/skills/omp-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,155 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps omp's non-interactive JSON print mode, captures its event stream, and
+writes a `result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v omp
+omp --version
+omp models            # list models this install can run; then pass one id as --model
+# omp models --json   # machine-readable catalog
+# omp models find sonnet
+```
+
+Do **not** run `omp --list-models`. That flag is a hard error.
+
+Install with `bun install -g @oh-my-pi/pi-coding-agent`. Authenticate with `/login` inside omp
+(subscription providers) or an API-key environment variable; omp stores credentials in `~/.omp/`.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. A lane `effort` value becomes `--thinking`. |
+| `--provider <name>` | omp `--provider` (default: omp's own default). Token-validated. |
+| `--model <pattern>` | omp `--model` id or fuzzy pattern (default: omp's own default). Token-validated: letters, digits, `. _ : / -`. Pick the value from `omp models`, not from memory. |
+| `--thinking <level>` | omp `--thinking`: `off`, `auto`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. |
+| `--session <id>` | Resume a specific omp session (`--session` / `--resume`); send only the delta brief. A value is required — bare `--resume` would open omp's picker and hang. |
+| `--resume-last` | Continue the most recent omp session for this cwd (`omp --continue`); send only the delta brief. |
+| `--read-only` | Restrict omp to `--tools read,grep,glob`. |
+| `--approve` | Load project-local `.omp` extensions, skills, and rules. The default passes `--no-extensions --no-skills --no-rules`. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). The relay does not forward omp's `--max-time`. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive. The child cwd pins the workspace; omp's
+`--cwd` is not passed. omp has no sandbox, so reachability is simply the filesystem.
+
+A run without `--read-only` can write and execute anything the user account can: the relay passes
+`--yolo` so print mode does not stall on tool approval. `--read-only` removes write/edit/bash (and
+the rest of omp's default tool surface) from the callable tools; installed extension code still
+runs with the user's host permissions when `--approve` is set.
+
+The relay never forwards `--api-key`.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an
+`--out-dir` inside the worktree can make the artifacts appear there:
+
+- `brief.txt` - the exact brief.
+- `events.jsonl` - raw omp stdout events (the session header, then every agent event).
+- `final.txt` - assistant text joined with a blank line between chunks; absent if none was emitted.
+- `stderr.txt` - complete stderr.
+- `result.json` - the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"omp"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `omp_unavailable`), `exitCode`, and
+  `signal` (`null` unless the child died on a signal).
+- `workdir`, requested `provider`/`model`/`thinking`, `projectTrusted`, `readOnly`, `yolo`, `resumed`, `ompVersion`,
+  `sessionId`, `startedAt`, and `finishedAt`.
+- `actualProvider`, `actualModel`, `usage`, and `stopReason` from omp's final assistant event.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `sessionId` - parsed from the JSON stream's `session` header. Resume with `--session <id>`.
+  Note: `--continue` may mint a new session id for the continued run; the result always reports
+  the id of the run that just happened.
+- `finalMessage` - assistant text parts joined with `"\n\n"`; tool calls and tool results are
+  excluded.
+- `touchedFiles` - `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of omp's edits: anything already dirty before dispatch shows up too. Dispatch
+  from a clean tree when you want the list to read as "what omp changed". `null` means git could
+  not report; `[]` means git ran and the tree is clean.
+- `stderrTail` - the last 20 non-empty stderr lines on any run that did not complete (`failed`,
+  `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`.
+- `error` - present for launch failures, preflight failures, when the relay watchdog fires
+  (`timeout`), and on an `aborted` run.
+
+omp's stream carries thinking and message-update events the relay archives but does not parse.
+
+## Waiting for completion
+
+The relay blocks. Use the orchestrator's background-command facility, or background it in a
+shell and poll for `result.json`. The run is done only when the process exits and the file
+contains a `status`. The result file is written atomically, so a partial read is impossible.
+
+A pre-run usage error exits 2 and writes no result. A missing `omp` exits 127 and writes
+`status: "omp_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "omp_unavailable"` (exit 127):** install omp (`bun install -g @oh-my-pi/pi-coding-agent`),
+  authenticate, and re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
+  causes: an unknown `--model`, an expired login, or a provider error.
+  A final assistant event with `stopReason: "error"` or `"aborted"` is failed even if omp exits zero.
+- **`status: "failed"` with an `error` mentioning `version preflight`:** the bounded `omp --version`
+  probe failed or hung, so omp was never dispatched. Check the install (`omp --version` yourself).
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to omp. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through
+  the OOM killer or a supervisor timeout. This is not an omp error; check host memory and
+  re-dispatch, or split the task into smaller briefs.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `omp did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout`
+  or split the task. On POSIX the relay sends SIGTERM to the process group, waits 10 seconds,
+  then sends SIGKILL if needed; on Windows there is no escalation phase — the whole process tree
+  is felled immediately with `taskkill /pid <pid> /t /f`.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Tool execution events carry the write/edit arguments, but treat any
+reconstruction as unverified until it matches a working-tree diff — when the tree still holds the
+work, preserve the tree rather than replaying the log.
+
+## What the relay runs
+
+The launch is equivalent to:
+
+```bash
+cat brief.txt | omp --mode json [--provider <name>] [--model <pattern>] [--thinking <level>] \
+  [--session <id> | --continue] [--yolo] \
+  [--no-extensions --no-skills --no-rules] [--tools read,grep,glob]
+```
+
+`--yolo` is omitted on `--read-only`. The three `--no-*` flags are omitted when `--approve` is
+set.
+
+The brief rides stdin, so it is not visible in the host process list and no argv size cap
+applies. `omp` is a native binary (bun / install script / Homebrew), so the relay never launches
+it through a shell. Before dispatch the relay runs a bounded `omp --version` preflight (10s cap)
+so a hung or crashing CLI fails fast and explicitly instead of hanging the run.
+
+## The commit boundary
+
+The relay never commits. omp edits the working tree; the orchestrator reviews, re-runs the gates,
+and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/omp-delegate/references/multi-task-queues.md
+++ b/skills/omp-delegate/references/multi-task-queues.md
@@ -1,0 +1,59 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is
+the default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh omp sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture
+location, or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed omp session only for rework on the same task. Send a delta brief with
+`--resume-last`, or with `--session <id>` from that task's `result.json`. Start unrelated queue
+items in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** - queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** - what landed, what you verified, and gate outcomes.
+- **Needs your eyes** - design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** - the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/omp-delegate/references/review-and-land.md
+++ b/skills/omp-delegate/references/review-and-land.md
@@ -1,0 +1,95 @@
+# Review and land
+
+The implementer made the changes; you own the judgment. Verify against reality, never the self-report, and read
+the diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries omp's claims, not evidence. Re-run the project's actual test, lint, and build
+commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** - changes the brief excluded.
+- **Scope shortfall** - missed behavior, edges, or cleanup.
+- **Quiet judgment calls** - defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to omp as a delta brief, or fix it in the tree, and report either
+choice to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer.
+Write a clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points —
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`,
+`git diff --cached` for anything the implementer staged (plain `git diff` is blind to the index),
+and open any untracked files (`??` in `git status`) directly — they are the implementer's new
+files, and no diff shows their contents. The tree is evidence, not clutter. After that inspection
+the verdict can legitimately be to discard — work built on a premise you have since corrected,
+for example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove the
+unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--session <id>` instead when resuming the specific id recorded in `result.json` - the stable
+handle, since `--continue` may mint a new id for each continued run. The relay rejects
+`--resume-last` plus `--session` before launch. Rework gets the same gate rerun, test review,
+diff review, and implementer sweep.
+
+A write-capable rework run passes `--yolo` and executes with no prompts - keep rework briefs as
+narrow as the original. A `--read-only` run restricts omp to `read,grep,glob`; installed extension
+code still runs with the user's host permissions when `--approve` is set, so inspect `touchedFiles`
+and the tree after every run.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep
+them in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/omp-delegate/references/writing-the-brief.md
+++ b/skills/omp-delegate/references/writing-the-brief.md
@@ -1,0 +1,149 @@
+# Writing the brief
+
+A brief is the entire task as omp will see it. It runs in a separate session with **no memory of
+your conversation, no access to prior notes, and no shared context** - only the text you send and
+whatever it can inspect in the workspace. If a constraint is not in the brief or discoverable in
+the repo, it does not exist for omp.
+
+One shortcut: omp auto-loads `AGENTS.md` and `CLAUDE.md` context files from the workspace and its
+parent directories, so conventions written there reach omp without inlining. Restate the
+load-bearing rules in the brief anyway - the brief is the contract. Project `.omp` skills, rules,
+and extensions stay undiscovered unless the dispatch passed `--approve`.
+
+## Model choice and resumed sessions
+
+omp uses its configured default model when `--model` is omitted, so a fresh dispatch does not
+require it. Pass `--model <id>` only when the human asked for a specific model.
+
+**How to choose an id:**
+
+1. Run `omp models` (human table) or `omp models --json`. Narrow with `omp models find <substring>`
+   or `omp models <provider>`.
+2. Copy a catalog id (often `provider/model-id`, sometimes a unique substring omp can fuzzy-match).
+3. Pass it as the relay's `--model`. Add `--provider <name>` when two providers share a short name.
+
+Do **not** run `omp --list-models`. That flag was removed; omp exits 2 with `unknown flag:
+--list-models`. Do **not** pass `--api-key` through the relay.
+
+`--thinking` is independent of `--model`. Use `off`, `auto`, `minimal`, `low`, `medium`, `high`,
+`xhigh`, or `max`. The relay rejects any other value before dispatch.
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report omp must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** - add `<completeness_contract>` (resolve fully, not just the
+  first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
+  unknown).
+- **Research or recommendations** - add `<research_mode>` (separate observed facts, inferences,
+  and open questions), and dispatch with `--read-only` so omp cannot invoke write/edit/bash tools.
+  That restricts the tool surface; it is not a sandbox. `AGENTS.md` and `CLAUDE.md` are also
+  repository-controlled instructions and may load without `--approve`. Use read-only dispatches
+  for untrusted repositories. Leave `--approve` off unless the user trusts this repo's `.omp`
+  extras (the relay already passes `--no-extensions --no-skills --no-rules` unless `--approve`
+  is set).
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from assistant text in omp's JSON event stream. Without a closing
+summary, the edits may exist but the result is hard to review. The `<structured_output_contract>`
+block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy
+the actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. omp can inspect the workspace (and auto-loads
+context files), but the important constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one omp run -> one reviewed commit keeps the diff and
+rollback clean. Split mixed implementation, review, documentation, and roadmap requests into
+separate dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Stdin delivery
+
+The relay pipes the brief to omp on stdin. Unlike CLIs that take the brief as an argument, there
+is no OS argv size cap and the brief never appears in the host process list. Large context can be
+inlined, but prefer pointing omp at workspace files it can read itself. Keep secrets out of the
+brief anyway on shared machines - reference environment variables or files with tight permissions.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/omp-delegate/scripts/relay.mjs
+++ b/skills/omp-delegate/scripts/relay.mjs
@@ -1,0 +1,806 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · omp-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to Oh My Pi (`omp --mode json`), capture the
+ * JSON event stream, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every omp-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `omp` and `git`, plus the platform
+ * process-termination utility when a Windows process-tree kill requires one.
+ * The `omp` process it launches does authenticate — exactly as you do at the
+ * terminal. Read this file before you run it.
+ *
+ * The brief is piped to omp on stdin, so it never appears in the host process
+ * list and no argv size cap applies. Keep secrets out of the brief anyway on
+ * shared machines — reference workspace files or environment variables instead.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Autonomy: omp has no sandbox. Print mode has no approval UI, so a write run
+ * passes `--yolo` (`tools.approvalMode: yolo`) and executes without prompts.
+ * `--read-only` restricts the callable tool surface to `read,grep,glob`.
+ * Installed extension code still runs with the user's host permissions when
+ * project resources are trusted. The relay passes `--no-extensions --no-skills
+ * --no-rules` unless `--approve` explicitly trusts project `.omp` resources.
+ * The diff reported in `touchedFiles` is the record of what changed.
+ *
+ * omp is a native binary (bun / install script / Homebrew), including on
+ * Windows, so this relay never launches it through a shell. Only
+ * token-validated flag values ride argv (the brief never does).
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for omp (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --provider <name>       omp provider name (default: omp's own default).
+ *   --model <pattern>       omp model id or fuzzy pattern (default: omp's own
+ *                           default). List ids with `omp models`, not
+ *                           `--list-models`. Letters, digits, and . _ : / - only.
+ *   --thinking <level>      omp --thinking: off, auto, minimal, low, medium,
+ *                           high, xhigh, or max.
+ *   --session <id>          Resume a specific omp session; send only the delta brief.
+ *   --resume-last           Continue the most recent omp session for this cwd
+ *                           (`omp --continue`); send only the delta brief.
+ *   --approve               Trust project-local .omp extensions, skills, and
+ *                           rules. By default the relay passes --no-extensions
+ *                           --no-skills --no-rules.
+ *   --read-only             Restrict omp to read,grep,glob (no write/edit/bash).
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). Durations use
+ *                           h/m/s strings. omp's --max-time is not forwarded.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, ompVersion, sessionId, finalMessage (omp's own
+ *   report), requested/actual provider and model, thinking, usage, touchedFiles
+ *   (git porcelain, null if git cannot report), readOnly, yolo, projectTrusted,
+ *   and paths to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `omp` binary exits 127;
+ * otherwise the exit code mirrors omp's own (0 success, non-zero failure), except
+ * a final assistant `error`/`aborted` event exits 1 even if omp exits 0. If the
+ * child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome — completed, failed, timeout (the --timeout watchdog
+ * fired, or the bounded --version preflight hung), aborted (the relay itself
+ * was killed and forwarded the kill to omp), or omp_unavailable.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const VERSION_TIMEOUT_MS = 10_000;
+const READ_ONLY_TOOLS = "read,grep,glob";
+const THINKING_LEVELS = new Set(["off", "auto", "minimal", "low", "medium", "high", "xhigh", "max"]);
+// --model, --provider, and --session values must not look like flags. omp is
+// launched without a shell, so this is flag-injection defense, not quoting.
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const IMPLEMENTER_KEY = "omp";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    if (field === "effort") {
+      if (flagged.has("thinking")) continue;
+      opts.thinking = value;
+      continue;
+    }
+    if (field === "thinking" && flagged.has("thinking")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    provider: null,
+    model: null,
+    thinking: null,
+    session: null,
+    resumeLast: false,
+    readOnly: false,
+    approve: false,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--provider": opts.provider = next(); flagged.add("provider"); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--thinking": opts.thinking = next(); flagged.add("thinking"); break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--approve": opts.approve = true; break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  for (const flag of ["model", "provider", "session"]) {
+    if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  if (opts.thinking !== null && !THINKING_LEVELS.has(opts.thinking)) {
+    fail(`invalid --thinking "${opts.thinking}" (expected: ${[...THINKING_LEVELS].join(", ")})`);
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+  if (parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
+  // setTimeout overflows past 2^31 - 1 ms (~24.8 days) and fires immediately,
+  // which would read as an instant spurious timeout — reject it up front.
+  if (parseDuration(opts.timeout) > 2_147_483_647) {
+    fail(`--timeout "${opts.timeout}" exceeds the maximum schedulable watchdog (~24.8 days)`);
+  }
+  if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
+    fail(`working directory not found: ${opts.cd}`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to omp --mode json\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+async function ompVersion(timeoutMs, onChild) {
+  const limit = Math.min(timeoutMs, VERSION_TIMEOUT_MS);
+  const runProbe = (command, argv, options = {}) => new Promise((resolveProbe) => {
+    const child = spawn(command, argv, {
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      ...options,
+    });
+    onChild(child);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let timer;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveProbe({ stdout, stderr, ...result });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => finish({ code: null, error, timedOut: false }));
+    child.on("close", (code) => finish({ code, error: null, timedOut }));
+    timer = setTimeout(() => {
+      timedOut = true;
+      killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+    }, limit);
+  });
+
+  const probe = await runProbe("omp", ["--version"]);
+  if (probe.timedOut) {
+    return { version: null, error: Object.assign(new Error("omp --version timed out"), { code: "ETIMEDOUT", stderr: probe.stderr }) };
+  }
+  if (probe.error && probe.error.code === "ENOENT") return { version: null, error: null };
+  if (probe.error) return { version: null, error: probe.error };
+  if (probe.code !== 0) {
+    return { version: null, error: Object.assign(new Error("omp --version failed"), { status: probe.code, stderr: probe.stderr }) };
+  }
+  return { version: probe.stdout.trim() || "unknown", error: null };
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts) {
+  // The brief rides stdin, never argv. --mode json is print mode: omp reads
+  // the piped brief, streams events, and exits.
+  const argv = ["--mode", "json"];
+  if (opts.provider) argv.push("--provider", opts.provider);
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.thinking) argv.push("--thinking", opts.thinking);
+  if (opts.session) argv.push("--session", opts.session);
+  else if (opts.resumeLast) argv.push("--continue");
+  if (!opts.readOnly) argv.push("--yolo");
+  if (opts.readOnly) argv.push("--tools", READ_ONLY_TOOLS);
+  if (!opts.approve) argv.push("--no-extensions", "--no-skills", "--no-rules");
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  // A reused --out-dir must not leak a previous run's artifacts into this one.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "omp",
+      workdir: opts.cd,
+      provider: opts.provider,
+      model: opts.model,
+      thinking: opts.thinking,
+      readOnly: opts.readOnly,
+      yolo: !opts.readOnly,
+      projectTrusted: opts.approve,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      ompVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    // Atomic write: a polling orchestrator never reads a half-written result.
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "omp_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    actualProvider: null,
+    actualModel: null,
+    usage: null,
+    stopReason: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `omp` not found on PATH. Install with `bun install -g @oh-my-pi/pi-coding-agent`, then authenticate (`/login`, or an API-key environment variable).\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(writeResult, run, error, timeoutMs) {
+  const timedOut = error && error.code === "ETIMEDOUT";
+  const stderr = String((error && error.stderr) || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `omp --version preflight timed out after ${Math.min(timeoutMs, VERSION_TIMEOUT_MS)}ms; omp was not dispatched`
+    : `omp --version preflight failed${Number.isInteger(error && error.status) ? ` with exit ${error.status}` : ""}; omp was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error && error.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    actualProvider: null,
+    actualModel: null,
+    usage: null,
+    stopReason: null,
+    finalMessage: "",
+    touchedFiles: null,
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: null,
+        actualProvider: null,
+        actualModel: null,
+        usage: null,
+        stopReason: null,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the omp version preflight; omp was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      const child = getChild();
+      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
+}
+
+function dispatchToOmp(opts, brief, run, writeResult) {
+  const child = spawn("omp", buildArgv(opts), {
+    cwd: opts.cd,
+    stdio: ["pipe", "pipe", "pipe"],
+    // Native binary on every platform, including Windows. Never shell: a shell
+    // would reinterpret the (already stdin-delivered) session, and omp.exe is
+    // not a .cmd shim.
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = null;
+  let actualProvider = null;
+  let actualModel = null;
+  let usage = null;
+  let stopReason = null;
+  let assistantError = null;
+  const textChunks = [];
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    if (event.type === "session" && typeof event.id === "string") {
+      sessionId = event.id;
+    }
+    if (event.type === "message_end" && event.message && event.message.role === "assistant") {
+      const content = event.message.content;
+      if (typeof content === "string") textChunks.push(content);
+      if (Array.isArray(content)) {
+        for (const part of content) {
+          if (part && part.type === "text" && typeof part.text === "string") textChunks.push(part.text);
+        }
+      }
+      if (typeof event.message.provider === "string") actualProvider = event.message.provider;
+      if (typeof event.message.model === "string") actualModel = event.message.model;
+      if (event.message.usage && typeof event.message.usage === "object") usage = event.message.usage;
+      if (typeof event.message.stopReason === "string") stopReason = event.message.stopReason;
+      if (typeof event.message.errorMessage === "string") assistantError = event.message.errorMessage;
+    }
+  });
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  // A fast-exiting omp (usage error, crashed startup) closes the pipe before
+  // the write; swallow EPIPE here — the exit code reports the failure.
+  child.stdin.on("error", () => {});
+  child.stdin.write(brief);
+  child.stdin.end();
+
+  const assembleFinal = () => {
+    const message = textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the omp child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        actualProvider,
+        actualModel,
+        usage,
+        stopReason,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; omp was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      actualProvider,
+      actualModel,
+      usage,
+      stopReason,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // A timed-out run is failed even if omp handles SIGTERM by exiting 0 —
+    // orchestrators key off status and the relay exit code.
+    const assistantFailed = stopReason === "error" || stopReason === "aborted";
+    const succeeded = code === 0 && !watchdogFired && !assistantFailed;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      actualProvider,
+      actualModel,
+      usage,
+      stopReason,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `omp did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...(!watchdogFired && assistantFailed ? { error: assistantError || `omp ended with stopReason "${stopReason}"` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const run = prepareRunDir(opts, brief);
+  let writeResult = makeResultWriter(opts, null, run);
+  let preflightChild = null;
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult, () => preflightChild);
+  const probe = await ompVersion(timeoutMs, (child) => { preflightChild = child; });
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (!probe.version) {
+    clearPreflightSignals();
+    reportVersionFailure(writeResult, run, probe.error, timeoutMs);
+    return;
+  }
+  clearPreflightSignals();
+  dispatchToOmp(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  omp ${result.ompVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an omp error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated omp (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.readOnly) lines.push(`mode: read-only (tools ${READ_ONLY_TOOLS})`);
+  if (result.yolo) lines.push("mode: --yolo (tools.approvalMode yolo)");
+  if (result.projectTrusted) lines.push("mode: project resources trusted (--approve)");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.thinking) lines.push(`thinking: ${result.thinking}`);
+  if (result.actualModel) lines.push(`model: ${result.actualProvider ? `${result.actualProvider}/` : ""}${result.actualModel}`);
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- omp final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: opencode-delegate
+description: Delegate a coding task to the OpenCode CLI as a background implementer,
+  then review its diff and land it yourself. Use this whenever the user wants to hand
+  implementation work to OpenCode — phrasings like "have OpenCode do X", "delegate
+  this to OpenCode", "run it through...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `opencode` CLI installed and authenticated, Node 18+,
+  and git. The orchestrating agent must be able to run shell commands and read files.
+  Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+# OpenCode Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `opencode` implementer (`OpenCode`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the OpenCode CLI — then review what it produced and land it yourself. You write
+the brief and own the judgment; OpenCode does the typing in its own session; you verify and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file, so any agent with those two capabilities — Claude Code, OpenCode driving a
+sibling session, or a comparable one — can drive it. (It is designed for and run on Claude Code; treat
+other orchestrators as designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- The `opencode` CLI is not installed or not authenticated (run `opencode auth login`).
+- You want to write the code yourself, or you only need a review (use the `plan` agent via `--read-only`).
+
+## Prerequisites (check once)
+
+1. `opencode --version` succeeds. If not, install (`npm i -g opencode-ai`, or the native installer from
+   opencode.ai) and `opencode auth login`.
+2. **Confirm which `opencode` is on PATH.** `command -v opencode` shows the active binary and
+   `opencode --version` its version. The relay records the version it ran into `result.json`, so a stale
+   binary is visible after the fact.
+3. A model provider is authenticated — `opencode auth list` shows at least one credential.
+4. You are in (or will point `--cd` at) the target git repository.
+
+## Choose the implementer model
+
+OpenCode has **no safe default** — a bare `opencode run` errors — so a fresh run needs a model via
+`--model` or a fleet `--lane` that sets one (a resumed run inherits its session's model). Naming the
+model is the one decision a single-model backend like codex-delegate never had, and it has two owners:
+
+- **The human owns which models are allowed.** `opencode models` lists hundreds of entries, most billed
+  per token (OpenRouter and the like); only the human knows which are their flat-rate subscriptions, and
+  the CLI can't tell them apart. So the usable set is theirs — ideally stated once in the repo's
+  `AGENTS.md` or their `CLAUDE.md` (e.g. "delegate mechanical work to `opencode-go/…`, hard logic to
+  `…`").
+- **You, the orchestrator, pick per task — from that set.** Match the model to the brief: a cheap, fast
+  model for a mechanical sweep (rename, migration, removal); a strong one for a subtle bug or a
+  money/security path.
+- **If no usable set is stated, ask — don't guess.** Guessing from the catalog risks a metered model and
+  a surprise bill. Name the constraint to the human and let them choose.
+
+More depth: [references/writing-the-brief.md](references/writing-the-brief.md).
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+OpenCode sees **only** the text you send plus what it can read from the working tree — no chat history,
+no shared context. Everything the task needs goes in the brief: the goal, the current state, what to
+change, what to leave untouched, the project's **actual** gate commands (discover them from the repo's
+AGENTS.md/CLAUDE.md/Makefile — do not assume), and a report contract. Tell OpenCode it will **not**
+commit (you will). Keep one task per brief. Full guidance and a template:
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Send the brief to OpenCode with the bundled helper. It wraps `opencode run`, captures the run, and
+writes a structured `result.json` — so your only job is "run a command, read a file." (`<skill-dir>`
+below is this skill's installed directory — the folder containing this `SKILL.md`. Claude Code prints
+it as "Base directory for this skill" when the skill loads; on other orchestrators use that same
+directory — if unsure where it landed, run `find ~ -name relay.mjs -path '*opencode-delegate*'` and
+substitute the directory above it.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --model <provider/model> --cd /path/to/repo
+# --model (or a --lane that sets model) is required on a fresh run
+# fleet lane from delegate-setup:           add --lane <name>  (dials apply; flags still win)
+# read-only (review/diagnosis, no edits):   add --read-only   (uses the plan agent)
+# continue the previous OpenCode session:   add --resume-last  (delta brief only; keeps the model)
+# hard time limit (watchdog):               add --timeout 2h  (default: off; implementation runs routinely need 1-2h)
+# see all options:                          node .../relay.mjs --help
+```
+
+The helper defaults to the write-capable `build` agent and writes its artifacts to a temp dir, so the
+repo under review stays clean. It **never commits** — see step 5. Mechanics, flags, and the
+`result.json` shape: [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until OpenCode finishes, so back it with whatever your orchestrator offers and resume
+when it returns:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** run it in the foreground for short tasks, or background it and poll
+  the result file — `… &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job`
+  in PowerShell, `start /b` in cmd). The run is done when `result.json` exists with a `status`. (A
+  pre-run usage error — bad args or an empty brief — instead exits with code 2 and writes no result
+  file, so check the exit code too. A missing `opencode` binary exits 127 but *does* write a
+  `result.json` with status `opencode_unavailable`.)
+
+Do not trust progress trackers over reality: a run is finished when `result.json` is written and the
+process has exited. Read the working tree, not a status line. The implementer's full report is
+the `finalMessage` field in `result.json` (also printed in full on stdout between the report markers).
+
+### 4. Review — do not trust the self-report
+
+OpenCode's `result.json` includes its own final message and any gate claims. **Re-verify, don't accept:**
+
+- **Re-run the project's gates yourself** (the test/lint/build commands from step 1). Never take
+  "gates passed" on faith.
+- **Read the diff** against the brief: did OpenCode do what was asked, nothing more (scope creep) and
+  nothing less? `touchedFiles` in the result is your starting point.
+- **Run the relevant guard skills** on the diff if you have them installed (clean-code-guard,
+  test-guard, etc. from `guard-skills`) — this skill produces the work; those skills judge it.
+- For schema/migration changes, round-trip them; for removals, grep for dangling references.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Committing should be the act of
+the party that verified the work. Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--resume-last` (don't restate the whole task) and
+  review again.
+
+## Autonomy model
+
+OpenCode's autonomy is governed by the **agent**, not a sandbox enum:
+
+- **`build`** (the relay default) — write-capable; edits files in the working dir headlessly. The
+  equivalent of "let it implement."
+- **`plan`** (via `--read-only`) — read-only; reviews and diagnoses without touching the tree. The
+  equivalent of "let it look but not edit."
+
+Permissions **auto-approve by default**: the relay passes `--auto` so a headless run never blocks on a
+prompt no one can answer. That is the point of unattended delegation — the orchestrator's diff review
+and the implementer sweep (step 4) are the safety net, not a per-action prompt. Pass `--no-auto` to
+honor the agent's own permission config instead (allow/ask/deny per action); pair it with an agent whose
+in-workspace permissions are set to *allow*, or a headless run can hang waiting on an `ask`.
+**Read-only (`plan`) runs never get `--auto`** — auto-approving would let the plan agent's ask-gated
+edit/bash permissions through and defeat "read-only," so a review can't be tricked into touching the tree.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract — that is the whole point. Two limits on that
+mandate: **surface, don't absorb** (report OpenCode's design decisions, defensible-but-unasked turns,
+and non-blocking nitpicks rather than silently keeping them) and **stop for scope changes** (if correct
+completion needs going beyond the brief, ask — don't expand the mandate yourself). The full treatment
+is in [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief OpenCode can
+  execute blind: structure, XML blocks, the report contract, embedding the real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, backgrounding per orchestrator, and recovery when a run misbehaves.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the rework cycle via `--resume-last`.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.
+
+
+## Limitations
+
+- Requires the `opencode` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/opencode-delegate/references/dispatch-and-poll.md
+++ b/skills/opencode-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,156 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` is the dispatch layer. It wraps `opencode run`, runs the brief under the chosen
+agent, captures everything, and writes a structured `result.json`. Your job collapses to: run one
+command, then read one file. Everything OpenCode-specific lives in the helper, which is what keeps the
+loop portable across orchestrators.
+
+## Before the first run: check the binary
+
+Two gotchas, both worth 30 seconds:
+
+```bash
+command -v opencode    # the active binary on PATH
+opencode --version     # the relay records this in result.json too
+opencode auth list     # at least one provider credential must be present
+```
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --model <provider/model> --cd /path/to/repo
+```
+
+(`<skill-dir>` is wherever this skill is installed — the folder containing its `SKILL.md`. On Claude
+Code it's the printed "Base directory for this skill"; on other orchestrators substitute that install
+path. See [`SKILL.md`](../SKILL.md) if you need to locate it.)
+
+Options:
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | The brief. Omit it to read the brief from stdin (`node relay.mjs … < brief.txt`). |
+| `--cd <dir>` | Working root for OpenCode (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Model as `provider/model`. **Required on a fresh run** — OpenCode has no safe default (a bare `opencode run` errors); a resumed run inherits its session's model. |
+| `--agent <name>` | OpenCode agent (default: `build`, write-capable). |
+| `--read-only` | Shortcut for `--agent plan` — review/diagnosis with no edits. |
+| `--variant <name>` | Provider reasoning effort (e.g. `high`, `max`, `minimal`). |
+| `--no-auto` | The relay passes `opencode`'s `--auto` (auto-approve permissions) **by default** so a headless run doesn't hang on a prompt; `--no-auto` drops it and honors the agent's own permission config instead. A `--read-only`/`plan` run never gets `--auto`, so it can't be auto-approved into edits. |
+| `--resume-last` | Continue the most recent OpenCode session; send only the delta brief (see review-and-land). |
+| `--session <id>` | Continue a specific session id (`ses_…`); send only the delta brief. |
+| `--pure` | Run OpenCode without external plugins (cleaner event stream). |
+| `--timeout <dur>` | Relay-side watchdog (e.g. `30m`, `2h`); on expiry the child is killed and `result.json` gets `status: "timeout"`. Off by default. |
+| `--out-dir <dir>` | Where artifacts go (default: a fresh dir under the system temp dir). |
+
+Artifacts default to the system temp dir on purpose: the repo under review stays clean, so the
+touched-files report shows only OpenCode's edits and nothing of the helper's own.
+
+## The result
+
+`<out-dir>/result.json` is the contract. Fields:
+
+- `schema` — the result-format version (currently `delegate-relay.result.v1`)
+- `tool` — `opencode`
+- `status` — `completed` | `failed` | `timeout` | `aborted` | `opencode_unavailable`
+- `exitCode` — mirrors OpenCode's exit code; `128` plus the signal number if the child was killed; `127` if `opencode` isn't on PATH; on a `timeout` the relay forces a non-zero code even when the child exited `0` after the watchdog's SIGTERM
+- `signal` — the signal that killed the child, otherwise `null`
+- `opencodeVersion` — the binary that actually ran
+- `agent` — the agent selected for this dispatch (`build`, `plan`, …)
+- `sessionId` — feed this to a later `--session <id>` (or use `--resume-last`)
+- `finalMessage` — OpenCode's assembled final text (the `<structured_output_contract>` you asked for).
+  Empty if OpenCode stopped without emitting a closing summary — ask for the report explicitly
+- `touchedFiles` — `git status --porcelain` lines in the working root: your review starting point.
+  `null` (not `[]`) when git can't report — `git` missing, or a non-repo run; `[]` means git ran and
+  the tree is clean
+- `cost` — total run cost in USD, summed from the step events (`null` if none were reported)
+- `briefPath` / `eventsPath` / `finalPath` — the exact brief relay sent, the raw JSON event stream, and
+  the final-message file
+- `workdir`, `model`, `auto`, `resumed`, `resumeLast`, `startedAt`, `finishedAt`
+- `stderrTail` — last ~20 stderr lines; present on every run that did not complete (`failed`, `timeout`, `aborted`), absent on `completed`,
+  `opencode_unavailable`, and launch failures
+- `error` — present on a launch failure, and on `timeout` and `aborted` runs
+
+The helper also prints a summary to stdout and exits with OpenCode's exit code, so a wrapping script can
+branch on success/failure directly.
+
+## Waiting for completion
+
+The helper blocks until OpenCode finishes. Back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the `Bash` call with `run_in_background: true`; you're notified on completion,
+  then read `result.json`.
+- **Plain shell / other agents:** foreground for short tasks, or background and poll — `node relay.mjs
+  … &` in bash/zsh (including Git Bash/WSL), or your shell's equivalent (`Start-Job` in PowerShell,
+  `start /b` in cmd). A run is done when `result.json` exists with a `status`. **But** a pre-run usage
+  error (bad args, empty brief) exits with code 2 *before* writing any file — so check the exit code
+  too, don't only watch for the file. (A missing `opencode` binary exits 127 but *does* write a
+  `result.json` with status `opencode_unavailable`.)
+
+Trust the working tree and the process state over any progress display. A run is finished when the
+process has exited and `result.json` is written — not when a status line says so.
+
+## When a run misbehaves
+
+- **`status: opencode_unavailable` (exit 127):** `opencode` isn't on PATH or isn't found. Install
+  (`npm i -g opencode-ai`) and `opencode auth login`, then re-dispatch.
+- **an `error` mentioning `version preflight` (`failed`, or `timeout` at exit 124):** the bounded
+  `opencode --version` probe exited non-zero or hung past its cap (10s, or `--timeout` when shorter),
+  so opencode was never dispatched; only the relay's own artifacts may already exist under
+  `--out-dir`. Check the install by running `opencode --version` yourself.
+- **`status: failed`:** read `result.json`'s `stderrTail` and the tail of `eventsPath` for the cause.
+  Common causes: an auth lapse, an unknown `--model` or `--agent`, or a permission the run needed but
+  the agent didn't grant. Fix the cause and re-dispatch; don't paper over it by doing the work yourself
+  unless that's what the user wants.
+- **`status: timeout`:** the `--timeout` watchdog killed the run. The working tree may hold a
+  half-applied change — inspect it before deciding between a longer `--timeout`, a smaller brief,
+  or a resume.
+- **`status: aborted`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to opencode. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
+- **`status: failed` with `signal: "SIGKILL"`:** the host ended the child — commonly the OOM killer
+  or a supervisor timeout, not an implementer error. Free up host memory or split the task into
+  smaller briefs, then re-dispatch.
+- **Empty `finalMessage`:** OpenCode finished without emitting a closing text summary (common when it
+  completes purely through tool calls). The edits may still be correct — check `touchedFiles` and the
+  diff. To get a report next time, add a `<structured_output_contract>` block (see
+  [writing-the-brief.md](writing-the-brief.md)).
+- **A run hangs:** an agent with an `ask` permission can block waiting for approval that never comes in
+  headless mode. Runs pass `--auto` by default precisely to avoid this — so a hang almost always means
+  you passed `--no-auto`. Either drop it, or set the agent's permissions to *allow* (not ask) the
+  actions the task needs.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Whether it also carries the edit contents depends on what the CLI streams,
+so treat any reconstruction as unverified until it matches a working-tree diff — when the tree
+still holds the work, preserve the tree rather than replaying the log.
+
+## What the helper is doing (and the alternatives)
+
+Under the hood the helper runs roughly:
+
+```bash
+opencode run --format json --agent build -m provider/model < brief.txt             # fresh run (model required)
+opencode run --format json --continue --agent build < delta-brief.txt               # resume most recent (inherits model)
+opencode run --format json --session ses_… --agent build < delta-brief.txt           # resume a specific session
+```
+
+The brief is fed on **stdin**, never as an argument — which is why a multi-line, XML-tagged brief needs
+no quoting. The `--format json` stream is newline-delimited JSON events; the relay assembles
+`finalMessage` from the `text` events and pulls `sessionId` from the event stream. OpenCode selects an
+agent for each prompt, so the helper passes the requested agent on fresh and resumed runs.
+
+If you ever want it, raw `opencode run` is fine for one-offs — you just give up the captured
+`result.json`, touched-files summary, and session-id extraction the helper does for you.
+
+## The commit boundary
+
+The helper never commits — by design, not omission. The robust contract is: OpenCode edits the working
+tree, the orchestrator reviews and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/opencode-delegate/references/multi-task-queues.md
+++ b/skills/opencode-delegate/references/multi-task-queues.md
@@ -1,0 +1,68 @@
+# Multi-task queues
+
+The single-task loop scales to a queue, and that's where delegation pays off most — a removal split
+across layers, a migration touching many files, a refactor sweep. The discipline that makes a queue
+trustworthy is sequencing and bookkeeping, not parallelism.
+
+## Run sequentially, one commit per task
+
+Resist the urge to fan out the whole queue at once. Run tasks **one at a time, in dependency order**,
+landing each (review + gates + commit) before dispatching the next. Three reasons:
+
+- **Later tasks assume earlier ones landed.** Task 3's brief can say "the X added in the previous step
+  exists" only if the previous step actually committed.
+- **One commit per task** keeps the history reviewable and any single step revertible.
+- **Each review is honest.** A clean working tree before each dispatch means the next task's
+  `touchedFiles` shows only *its* changes, not a pile-up from earlier tasks.
+
+Parallelism is occasionally worth it for genuinely independent tasks on separate files, but it
+sacrifices the clean-tree-per-task property and makes review harder. Default to sequential. (Each fresh
+`relay.mjs` dispatch starts a new OpenCode session, so independent tasks don't share context — fold any
+shared constraint into each brief, see below.)
+
+## Carry decided constraints forward
+
+Implementation surfaces facts the original plan didn't have: a helper got named, a fixture lives in a
+specific place, an interface was chosen. When a later task depends on one of those, **fold it into that
+task's brief** as an explicit line. A fresh OpenCode session has no memory of the earlier run, so a
+constraint that emerged in task 2 must be restated in task 5's brief or it won't hold. This is the queue
+equivalent of keeping briefs self-contained.
+
+## Keep a progress file
+
+For anything longer than two or three tasks — especially a run the human steps away from — maintain a
+single progress file alongside the work. It's the durable record that survives your own context limits
+and lets the human catch up at a glance. A shape that works:
+
+- **Status table** — each task: queued / at-implementer / reviewed+committed (with the commit hash).
+- **Per-task review notes** — what landed, what you verified, the gate outcome. One short paragraph.
+- **"Needs your eyes"** — design decisions OpenCode made, non-blocking nitpicks, anything you want the
+  human to overrule or confirm. This is the section they read first.
+- **End-of-run checklist** — what happens after the last task (push, open/update the PR, manual checks
+  the human should do).
+
+Update it as each task lands, not in a batch at the end — if the run is interrupted, the file is still
+accurate.
+
+## Close with a coherence check
+
+Per-task review proves each step in isolation; it doesn't prove the steps cohere. After the last task,
+verify the whole:
+
+- Run the full test/build once more on the final tree — not just the last task's slice.
+- Do a repo-wide check for the thing the queue was about (e.g. after a removal, grep the entire tree
+  for any surviving reference; after a rename, confirm no stragglers).
+- For schema work, replay all the new migrations from a clean state and check for drift.
+- Then push and open or update the PR, with a description that reflects what actually shipped.
+
+## When to stop and ask
+
+Proceed without asking on anything that follows from the agreed plan — that's the point of the human
+opting into the queue. Stop and surface when:
+
+- A task can't be completed correctly within its brief's scope (a scope change is the human's call).
+- A review finds something that calls the *plan* into question, not just the implementation.
+- The gates reveal a problem that affects tasks already "done."
+
+Then report where you are, what's committed, and what the open question is — and wait. A queue that
+quietly works around a broken assumption produces a lot of commits in the wrong direction.

--- a/skills/opencode-delegate/references/review-and-land.md
+++ b/skills/opencode-delegate/references/review-and-land.md
@@ -1,0 +1,125 @@
+# Review and land
+
+OpenCode did the typing; you own the judgment. This is where delegation earns its keep or quietly ships
+a mistake. The discipline is simple to state and easy to skip under time pressure: **verify against
+reality, never against the self-report — and read the diff as generated code, which fails in ways a
+green gate can't see.**
+
+## Check the tests before trusting the gates
+
+If the diff touches existing tests, review those edits *first* — before the gate re-run means anything.
+A weakened assertion, an added skip, or a deleted test makes the gate measure less than it did before
+the run; green is only meaningful if the yardstick wasn't shortened.
+
+- **Unbriefed edits to existing tests are a contract change, not part of the fix.** The brief asked for
+  an implementation; nothing in it authorized moving the goalposts. Flag them, don't absorb them.
+- **Skipped, disabled, or commented-out tests added in this diff:** treat the underlying test as failing
+  until proven otherwise, whatever the annotation's comment claims.
+- **Loosened assertions** (exact match relaxed to contains/truthy, error-type checks broadened, tolerance
+  widened): same treatment.
+
+## Re-run the gates yourself
+
+`result.json` carries OpenCode's own claim that the gates passed. Treat that as a claim, not evidence —
+re-run the project's actual test/lint/build commands in the working tree and read the output. And keep
+the result in proportion: **passing is necessary, not sufficient.** An implementer can *game* a gate,
+not just misreport it — that is what the test check above and the sweep below exist to catch.
+
+For changes with their own verification shape, go further:
+
+- **Migrations / schema:** round-trip them (apply, reverse, re-apply on a scratch target) and check for
+  drift, rather than trusting that "the migration is reversible."
+- **Removals / renames:** grep the codebase for dangling references to whatever was removed.
+- **Anything stateful:** exercise the actual behavior, don't just confirm it compiles.
+
+## Read the diff against the brief
+
+Open the diff (`touchedFiles` in the result is your starting list) and hold it against what you asked
+for:
+
+- **Scope creep** — did OpenCode change things the brief said to leave untouched? Unasked refactors,
+  renames, "while I was here" edits. These are the most common quality problem in delegated work.
+- **Scope shortfall** — did it do the whole task, including the edge cases and cleanup, or stop at the
+  first plausible version?
+- **Quiet judgment calls** — sometimes OpenCode makes a defensible decision the brief didn't anticipate.
+  Don't just accept it because it looks reasonable; understand it and decide.
+
+## The implementer sweep
+
+Generated code fails in systematic ways that gates are structurally blind to — each of these can sit in
+a diff whose tests are all green. Walk them against every diff before you commit:
+
+- **Hardcoded success or fixture data** on a path the brief says does real work — a canned
+  `{status: "ok"}` or default return passes tests *by design*. If OpenCode couldn't implement something,
+  the diff should fail loudly, not pretend.
+- **Catch-all error handling that returns a default** instead of propagating — the suppressed failure is
+  exactly what the gate would have caught. A broad catch is only acceptable with a recovery path the
+  contract documents.
+- **Unverified imports and API calls** — confirm every new dependency, method, and signature exists in
+  the *installed* version (read the lockfile or the package, don't trust plausibility).
+- **Dead weight** — unused imports, helpers nothing calls, unreachable branches, "Step 1/Step 2"
+  comment scaffolding, comments that restate the line below them.
+- **A second way to do what the file already does** — a new HTTP client, error idiom, or logging style
+  introduced beside the existing one instead of reusing it.
+- **New tests that assert internals** — asserting that an internal helper was called, or mocking the
+  project's own functions to isolate a "unit." Green, brittle, and worthless as regression cover.
+- **Near-duplicate test bodies** differing by one value — fold into one data-driven test or drop the
+  copies; bloat reads as coverage but isn't.
+- **Speculative surface** — optional parameters, config flags, or abstractions with no caller in this
+  diff or the repo. Delegated work gets the concrete behavior the brief asked for, nothing extra.
+- **Guards for impossible cases** — null/type checks for values the code's own contract already
+  excludes. Noise that buries the validation that matters at real trust boundaries.
+
+Anything the sweep catches goes back to OpenCode as a delta brief (below) or gets fixed in the tree
+before commit — and either way is reported to the user (see "Surface, don't absorb").
+
+If the `guard-skills` package is installed, run the relevant guard on the diff for the full treatment —
+`clean-code-guard` on production code, `test-guard` on tests, `docs-guard` on documentation. The sweep
+above is the built-in floor; the guards go deeper.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **you commit** — the orchestrator, never the implementer. The
+`build` agent *can* write the working tree, but committing should be the act of the party that verified
+the work, not the one that produced it. Write a clear message describing what landed. If your project
+attributes co-authorship, that's the place for it.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run `git checkout`, `reset`, `clean`, or a branch switch in the
+workspace between those two points — however messy an interrupted run looks, inspect it first:
+`git status`, `git diff`, `git diff --cached` for anything the implementer staged (plain
+`git diff` is blind to the index), and open any untracked files (`??` in `git status`) directly —
+they are the implementer's new files, and no diff shows their contents. The tree is evidence,
+not clutter. After that inspection the
+verdict can legitimately be to discard — work built on a premise you have since corrected, for
+example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Reworking: send the delta, not the whole task
+
+If the review turns up problems, don't restate the entire brief. Continue the same OpenCode session with
+just the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session - use the real migrated fixture instead, and
+drop the now-unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+(`<skill-dir>` is this skill's install directory — see [dispatch-and-poll.md](dispatch-and-poll.md).)
+
+`--resume-last` keeps OpenCode's session context from the first run (and its model), so a short delta is
+enough. Then review again — rework gets the same gate-rerun, test check, diff-read, and sweep as the
+original, no shortcuts. Repeat until it's right, then commit.
+
+## Surface, don't absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the agreed contract.
+But keep them in the loop on anything that changes the shape of the work:
+
+- **Report design decisions** OpenCode made, and any defensible-but-unrequested turns it took.
+- **Note non-blocking nitpicks** you chose not to block on, so the human can overrule you.
+- **Stop and ask** if correct completion requires going beyond the brief — don't expand the mandate on
+  your own. A scope change is the human's call, not yours or OpenCode's.
+
+For a multi-task run, capture these in the progress file rather than letting them scroll past — see
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/opencode-delegate/references/writing-the-brief.md
+++ b/skills/opencode-delegate/references/writing-the-brief.md
@@ -1,0 +1,142 @@
+# Writing the brief
+
+A brief is the entire task as OpenCode will see it. OpenCode runs in a fresh session with **no memory of
+your conversation, no access to your prior notes, and no shared context** — only the text you send and
+whatever it can read from the working tree (including the repo's own `AGENTS.md`, which it picks up
+automatically). If a constraint isn't in the brief or discoverable in the repo, it doesn't exist for
+OpenCode. The single most common failure is a brief that assumes context OpenCode doesn't have.
+
+## Match the model to the brief
+
+OpenCode has no default model, so every fresh dispatch names one with `--model provider/model`. Which
+model is a two-owner decision: the **human** owns which models are allowed to run; **you, the
+orchestrator**, pick one of them to fit the task in front of you.
+
+- **The allowed set is the human's to state.** `opencode models` lists a few hundred models, but most
+  bill per token (OpenRouter and the like) and the CLI does not mark which are the human's
+  subscriptions. So they name their usable models — ideally once, in the target repo's `AGENTS.md` or
+  their `CLAUDE.md` (e.g. `opencode-go/…`, `zai-coding-plan/…`, `minimax-coding-plan/…`). If they
+  haven't, ask before dispatching rather than guessing a model and risking a metered bill.
+- **Read the task's difficulty off the brief you just wrote, and match within that set.** A mechanical,
+  well-bounded brief — a rename sweep, a `moment`→`date-fns` migration, a dead-code removal — is safe on
+  a cheap, fast model. A brief whose risk lives in judgment — a concurrency fix, a money or auth path,
+  an ambiguous spec — wants a strong one, because the sweep's failure modes (plausible-but-wrong logic,
+  swallowed errors) are exactly what a weaker model produces more of.
+- **A resumed run keeps the first run's model.** `--resume-last` / `--session` don't take `--model`; the
+  session already has one. Send only the delta brief.
+
+## The shape that works
+
+OpenCode responds well to compact, block-structured prompts with XML tags rather than long prose. State
+the task, what "done" looks like, how to behave by default, and the few constraints that actually
+matter. Add a block only when the task needs it — don't ship empty ceremony.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The "leave untouched" list is what keeps OpenCode from
+wandering into unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, don't just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (paste the test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+That four-block skeleton covers most implementation tasks. Reach for the extra blocks when the task
+profile calls for them:
+
+- **Debugging / open-ended fixes** — add `<completeness_contract>` (resolve fully, don't stop at the
+  first plausible fix) and `<missing_context_gating>` (don't guess missing repo facts; find them or
+  state what's unknown).
+- **Review / diagnosis (read-only)** — add `<grounding_rules>` (ground every claim in evidence; label
+  inferences) and dispatch with `--read-only` so OpenCode runs as the `plan` agent and can't edit.
+- **Research / recommendations** — add `<research_mode>` (separate observed facts, inferences, open
+  questions).
+
+## Always ask for the report explicitly
+
+The relay assembles OpenCode's final message from the text it emits when it stops. If the agent finishes
+a task purely through tool calls and stops without a closing summary, `finalMessage` comes back empty —
+not a relay defect, just nothing said. The `<structured_output_contract>` block is what guarantees a
+report you can read: it tells OpenCode to end with a written summary, so the result file carries one.
+
+## Discover the real gates — don't hardcode
+
+`<verification_loop>` is only useful if it names the project's *actual* commands. Read the repo's
+`AGENTS.md` / `CLAUDE.md` / `Makefile` / `package.json` first and copy the real ones in (`make test`,
+`npm run lint`, `cargo test`, `pytest -q`, whatever it is). A brief that says "run the tests" without
+naming them gets you an OpenCode that guesses — or skips.
+
+## Honor the repo's conventions
+
+OpenCode reads the repo's `AGENTS.md` automatically, so house rules there (style, forbidden patterns,
+commit conventions) already apply. If the project forbids certain things in code — say, spec/ticket IDs
+in comments, process language like "MVP"/"for now"/"phase N", or specific test conventions, whatever the
+repo's own conventions ban — restate the load-bearing ones in the brief too, because OpenCode's
+compliance is only as reliable as what's in front of it.
+
+## One task per brief
+
+Keep each brief to a single, bounded job. "Review this, fix what you find, update the docs, and suggest
+a roadmap" produces a muddled run; split it into separate dispatches. One brief → one OpenCode run →
+one commit keeps review and rollback clean, and lets a later task assume the earlier one landed.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout (the idempotency key isn't checked before re-submitting). Make the refund
+submission idempotent: check for an existing refund by idempotency key before creating a new one.
+Touch only services/billing/refund.py and its tests. Leave the charge path, the API routes, and the
+data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and your fix, (2) files touched, (3) pytest + ruff outcomes with counts,
+(4) anything you left open or want decided.
+</structured_output_contract>
+```
+
+Send this with `relay.mjs` (see [dispatch-and-poll.md](dispatch-and-poll.md)); review the result and
+commit it yourself (see [review-and-land.md](review-and-land.md)).

--- a/skills/opencode-delegate/scripts/relay.mjs
+++ b/skills/opencode-delegate/scripts/relay.mjs
@@ -1,0 +1,719 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · opencode-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the OpenCode CLI (`opencode run`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every OpenCode-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified against opencode CLI v1.17.13.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `opencode` and `git`. The `opencode` process it
+ * launches does authenticate — exactly as you do at the terminal. Read this
+ * file before you run it.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job —
+ * after it reviews the diff and re-runs the project gates.
+ *
+ * OpenCode autonomy is governed by the chosen agent, not a sandbox enum:
+ *   build (default) — write-capable; edits files in the working dir headlessly.
+ *   plan            — read-only; reviews/diagnoses without touching the tree.
+ * A build run passes `--auto` by default so OpenCode never blocks on a permission
+ * prompt no one can answer in headless mode; the orchestrator's diff review is the
+ * safety net. Pass --no-auto to instead honor the agent's own permission config.
+ * A plan (read-only) run never gets --auto, so it can't be auto-approved into edits.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for OpenCode (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Model as provider/model. REQUIRED for a fresh run — OpenCode has no
+ *                           safe default; a resumed run inherits its session's model.
+ *   --agent <name>          OpenCode agent (default: build). Use plan for read-only review.
+ *   --read-only             Shortcut for --agent plan (review/diagnosis, no edits).
+ *   --variant <name>        Provider reasoning effort (e.g. high, max, minimal).
+ *   --no-auto               Don't pass --auto; honor the agent's own permission config (a headless
+ *                           run may then hang if the agent is set to ask for a permission).
+ *   --resume-last           Continue the most recent OpenCode session; send only the delta brief.
+ *   --session <id>          Continue a specific session id (ses_...); send only the delta brief.
+ *   --pure                  Run OpenCode without external plugins (cleaner event stream).
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the opencode child is
+ *                           killed and result.json gets status "timeout".
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, opencodeVersion, sessionId (for a later resume), finalMessage
+ *   (OpenCode's own report), touchedFiles (git porcelain, null if git can't report), and the
+ *   paths to events.jsonl and final.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `opencode` binary exits 127;
+ * otherwise the exit code mirrors OpenCode's own (0 success, non-zero failure).
+ * If the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal.
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, timeout (the --timeout watchdog fired), aborted (the relay
+ * itself was killed and forwarded the kill to opencode), or
+ * opencode_unavailable. An orchestrator that polls for the
+ * file must therefore also treat a non-zero exit with no file as a usage error.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_TIMER_MS = 2_147_483_647;
+// model/variant reach cmd.exe on win32 (shell:true for the opencode.cmd shim).
+// Keep in lockstep with delegate-setup MODEL_TOKEN.shellSafe.
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const IMPLEMENTER_KEY = "opencode";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    agent: "build",
+    variant: null,
+    auto: true,
+    resumeLast: false,
+    session: null,
+    pure: false,
+    timeout: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--agent": opts.agent = next(); flagged.add("agent"); break;
+      case "--read-only": opts.agent = "plan"; flagged.add("agent"); flagged.add("readOnly"); break;
+      case "--variant": opts.variant = next(); flagged.add("variant"); break;
+      case "--auto": opts.auto = true; break;
+      case "--no-auto": opts.auto = false; break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--pure": opts.pure = true; break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.model !== null && !SAFE_TOKEN.test(opts.model)) {
+    fail("--model contains unsupported characters (allowed: letters, digits, . _ : / -)");
+  }
+  if (opts.variant !== null && !SAFE_TOKEN.test(opts.variant)) {
+    fail("--variant contains unsupported characters (allowed: letters, digits, . _ : / -)");
+  }
+  // The watchdog is relay-only (the opencode launch has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  return opts;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to opencode run\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once opencode is running, so the preflight needs a bound of
+  // its own: an `opencode --version` that never returns would wedge the relay here, before
+  // any result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+function opencodeVersion(probeTimeoutMs) {
+  try {
+    // On Windows, npm installs `opencode` as a .cmd shim; Node's CreateProcess only
+    // auto-appends .exe, never .cmd, so launching it needs shell:true there or it
+    // ENOENTs on a working install. POSIX is unaffected. (git installs a real
+    // git.exe and must NOT get this flag — see gitTouchedFiles.)
+    const version = execFileSync("opencode", ["--version"], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+    }).trim();
+    return { version: version || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+    // exit rather than ENOENT; that is still "not installed", not a broken install.
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    // Anything else — a hung probe we killed, or a real non-zero exit — means opencode is
+    // installed but not usable. Reporting that as "unavailable" would send the caller
+    // off to reinstall a binary that is already there.
+    return { version: null, error };
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts) {
+  const argv = ["run", "--format", "json"];
+  if (opts.pure) argv.push("--pure");
+  // Resume continues an existing session; --session pins a specific id, otherwise
+  // --continue picks up the most recent one. OpenCode selects the agent for each
+  // prompt, so preserve the relay's requested autonomy on resumed turns too.
+  if (opts.session) {
+    argv.push("--session", opts.session);
+  } else if (opts.resumeLast) {
+    argv.push("--continue");
+  }
+  argv.push("--agent", opts.agent);
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.variant) argv.push("--variant", opts.variant);
+  // --auto (on by default) auto-approves permissions so a headless build run doesn't
+  // block on a prompt no one can answer; --no-auto honors the agent's own config.
+  // Never on a plan (read-only) run: --auto would approve the plan agent's ask-gated
+  // edit/bash permissions and let a "read-only" review modify the tree. A plan run
+  // only reads, so it doesn't need auto-approval anyway.
+  if (opts.auto && opts.agent !== "plan") argv.push("--auto");
+  // No message argument: the brief is piped on stdin (see dispatchToOpenCode),
+  // which avoids all argv-quoting issues with multi-line, XML-tagged briefs.
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only OpenCode's edits, not relay's artifacts.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    eventsPath: join(outDir, "events.jsonl"),
+    finalPath: join(outDir, "final.txt"),
+    briefPath: join(outDir, "brief.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  return (extra) => {
+    const resuming = Boolean(opts.session || opts.resumeLast);
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "opencode",
+      workdir: opts.cd,
+      agent: opts.agent,
+      model: opts.model,
+      variant: opts.variant,
+      auto: opts.auto,
+      resumed: resuming,
+      resumeLast: opts.resumeLast,
+      opencodeVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      eventsPath: run.eventsPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "opencode_unavailable", exitCode: 127, signal: null, sessionId: null, finalMessage: "", touchedFiles: null, cost: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `opencode` not found on PATH. Install it (npm i -g opencode-ai) and run `opencode auth login`.\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `opencode --version preflight timed out after ${probeTimeoutMs}ms; OpenCode was not dispatched`
+    : `opencode --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; OpenCode was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    cost: null,
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToOpenCode(opts, brief, run, writeResult) {
+  const argv = buildArgv(opts);
+  // Pin the working root two ways: `cwd` sets the child's real directory, and PWD
+  // is set explicitly because OpenCode can resolve its project root from the
+  // inherited PWD env — which spawn does NOT rewrite — so without it a run could
+  // operate on the orchestrator's directory instead of opts.cd (and, with --auto
+  // on, edit it unattended). Passing the path via env, not argv, keeps it clear of
+  // shell quoting.
+  // shell:true on Windows so the opencode.cmd shim resolves (see opencodeVersion).
+  // Safe: the brief is fed via child.stdin below — never argv — and argv holds only
+  // flag names, an agent enum, a model string, and a session id, with no shell
+  // metacharacters or spaceable paths.
+  const child = spawn("opencode", argv, {
+    cwd: opts.cd,
+    env: { ...process.env, PWD: opts.cd },
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = opts.session || null;
+  let totalCost = 0;
+  let sawCost = false;
+  const textParts = new Map(); // part.id -> latest text
+  const textOrder = []; // part.ids in first-seen order
+  const stderrTail = [];
+
+  const scan = makeEventScanner((event) => {
+    // Session id: real events carry `sessionID` (camelCase); plugin notify objects
+    // carry `session_id` (snake_case). Accept either.
+    const sid = event.sessionID || event.session_id;
+    if (sid) sessionId = sid;
+    // Assistant text lives in `type:"text"` events under part.text. Key by part.id
+    // so streamed updates to the same part replace rather than duplicate; preserve
+    // first-seen order so multi-segment messages assemble correctly.
+    if (event.type === "text" && event.part && event.part.type === "text") {
+      const id = event.part.id || `anon-${textOrder.length}`;
+      if (!textParts.has(id)) textOrder.push(id);
+      textParts.set(id, event.part.text ?? "");
+    }
+    if (event.type === "step_finish" && event.part && typeof event.part.cost === "number") {
+      totalCost += event.part.cost;
+      sawCost = true;
+    }
+  });
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk); // faithful raw record of the event stream
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk); // surface OpenCode progress live for the orchestrator
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textOrder.map((id) => textParts.get(id)).join("").trim();
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        if (!settled) killChild(child, "SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the opencode child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        cost: sawCost ? Number(totalCost.toFixed(6)) : null,
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; opencode was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({ status: "failed", exitCode: 1, signal: null, sessionId, finalMessage: assembleFinal(), touchedFiles: gitTouchedFiles(opts.cd), cost: sawCost ? totalCost : null, error: String(err && err.message ? err.message : err) });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    const finalMessage = assembleFinal();
+    // A timed-out run is never a success even if opencode handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
+      sessionId,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      cost: sawCost ? Number(totalCost.toFixed(6)) : null,
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `opencode did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+
+  // If the child failed to launch, writing to its stdin can emit a stray 'error'
+  // on the pipe; the 'error' handler above owns that outcome, so swallow it here.
+  child.stdin.on("error", () => {});
+  child.stdin.write(brief);
+  child.stdin.end();
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+  // --session pins a specific session and --resume-last picks the most recent; passing both is a
+  // contradiction, and buildArgv would silently prefer --session. Reject it rather than guess.
+  if (opts.session && opts.resumeLast) {
+    fail("--session and --resume-last are mutually exclusive; pass only one");
+  }
+  // OpenCode has no safe default model (a bare `opencode run` errors), so a fresh run must name one.
+  // A resumed run inherits its session's model, so --model is optional there.
+  if (!opts.model && !opts.resumeLast && !opts.session) {
+    fail("no model given: pass --model provider/model — opencode has no safe default (e.g. a plan you're subscribed to, like opencode-go/kimi-k2.7-code)");
+  }
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
+  const run = prepareRunDir(opts, brief);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  const probe = opencodeVersion(probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+
+  if (!probe.version && !probe.error) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+
+  dispatchToOpenCode(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  opencode ${result.opencodeVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an opencode error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated opencode (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.resumed) lines.push("mode: resumed existing session");
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  if (typeof result.cost === "number") lines.push(`cost: $${result.cost}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- opencode final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/pi-delegate/SKILL.md
+++ b/skills/pi-delegate/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: pi-delegate
+description: Delegate a coding task to the Pi coding agent CLI (`pi`) as a background
+  implementer, then review its diff and land it yourself. Use this whenever the user
+  wants to delegate implementation work to Pi - phrasings like "have Pi implement
+  X", "delegate this to pi", "run it...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+metadata:
+  version: 0.5.0
+---
+# Pi Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `pi` implementer (`Pi`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Delegate a bounded coding task to a separate **implementer** - the Pi
+coding agent CLI - then review what it produced and land it yourself. You write the brief and own
+the judgment; the implementer makes changes in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `pi` CLI is not installed or authenticated.
+- You need a sandboxed implementer. Pi has no sandbox and no permission modes; `--read-only`
+  restricts the tool surface, but a write-capable run executes without prompts.
+
+## Prerequisites (check once)
+
+1. Install pi with `npm install -g @earendil-works/pi-coding-agent`.
+2. Authenticate: `/login` inside pi for a subscription provider, or an API-key environment
+   variable / `pi`'s auth file for an API-key provider.
+3. Confirm `pi --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## Choose the model (optional)
+
+Omit `--model` to use pi's configured default. To pick another, choose from `pi --list-models`
+and pass an explicit id or pattern like `<provider>/<model-id>` or `sonnet:high`. The relay
+accepts letters, digits, and `. _ : / -` only (the value reaches a shell on Windows), so glob
+patterns with `*` are not forwarded.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Pi sees only the text you send plus what it can inspect in the workspace - no chat history or
+shared context. Include the goal, current state, what to change, what to leave untouched, the
+project's **actual** gates, and a report contract. Tell pi not to commit. Keep one task per brief.
+Pi auto-loads `AGENTS.md`/`CLAUDE.md` context files from the workspace and its parents, so repo
+instructions reach it without inlining. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled relay. It pipes the brief to `pi --mode json` on stdin, captures the JSON event
+stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing this
+`SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a model:                          add --model <id from pi --list-models>
+# choose a provider:                       add --provider <name>
+# read-only run (review/diagnosis):        add --read-only
+# trust project .pi resources:             add --approve
+# resume the most recent session:          add --resume-last  (delta brief only)
+# resume a specific session:               add --session <id> (delta brief only)
+# hard time limit (watchdog):              add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
+# see all options:                         node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. The relay writes artifacts under the system temp dir
+by default and never commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until pi finishes. Run it with the orchestrator's background-command facility,
+or background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes
+no result; a missing `pi` exits 127 and writes `status: "pi_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process
+exited and `result.json` exists. Pi's full report is the `finalMessage` field in `result.json`
+(also printed in full on stdout between the report markers).
+
+### 4. Review - do not trust the self-report
+
+Treat pi's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates
+pass and the diff holds. If rework is needed, send a delta brief with `--resume-last` or
+`--session <id>`, then review again.
+
+## Autonomy and permissions
+
+Pi has **no sandbox and no permission modes**. A default headless run reads, writes, edits, and
+executes shell commands with no prompts - the controls are:
+
+1. `--read-only` restricts pi's callable tools to `--tools read,grep,find,ls` across built-in,
+   extension, and custom tools. Installed extension code still runs with the user's host permissions.
+2. The relay passes `--no-approve` by default, so project `.pi` settings, extensions, and skills
+   stay untrusted. `--approve` is the explicit opt-in for a repository the user trusts.
+3. `touchedFiles` and the diff are the record of what changed. Inspect them after every run.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"),
+committing verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't
+absorb** (report pi's design decisions, defensible-but-unasked turns, and non-blocking nitpicks)
+and **stop for scope changes** (if correct completion needs going beyond the brief, ask instead of
+expanding the mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - structure, report contract,
+  real gates, stdin delivery, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - review checklist, commit
+  boundary, and rework through pi sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues,
+  constraint carry-forward, progress tracking, and the final coherence pass.
+
+
+## Limitations
+
+- Requires the `pi` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/pi-delegate/references/dispatch-and-poll.md
+++ b/skills/pi-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,146 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps pi's non-interactive JSON mode, captures its event stream, and writes a
+`result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v pi
+pi --version
+pi --list-models   # optional: pick a model id for --model
+```
+
+Install with `npm install -g @earendil-works/pi-coding-agent`. Authenticate with `/login` inside
+pi (subscription providers) or an API-key environment variable; pi stores credentials in
+`~/.pi/agent/`.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--provider <name>` | pi provider name (default: pi's own default). Token-validated. |
+| `--model <pattern>` | pi model id or pattern (default: pi's own default). Token-validated: letters, digits, `. _ : / -`. |
+| `--session <id>` | Resume a specific pi session; send only the delta brief. |
+| `--resume-last` | Continue the most recent pi session for this cwd (`pi --continue`); send only the delta brief. |
+| `--read-only` | Restrict pi's callable tools to `--tools read,grep,find,ls`. |
+| `--approve` | Trust project-local `.pi` resources for this run. The default passes `--no-approve`. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Pi has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive. The child cwd pins the workspace; pi has
+no add-dir flag and no sandbox, so reachability is simply the filesystem.
+
+Remember: pi has no permission modes. A run without `--read-only` can write and execute anything
+the user account can. `--read-only` removes write/edit/bash from Pi's callable tool surface, but
+installed extension code still runs with the user's host permissions.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an
+`--out-dir` inside the worktree can make the artifacts appear there:
+
+- `brief.txt` - the exact brief.
+- `events.jsonl` - raw pi stdout events (the session header, then every agent event).
+- `final.txt` - assistant text joined with a blank line between chunks; absent if none was emitted.
+- `stderr.txt` - complete stderr.
+- `result.json` - the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"pi"`), `status` (`completed` | `failed` | `timeout` | `aborted` | `pi_unavailable`), `exitCode`, and
+  `signal` (`null` unless the child died on a signal).
+- `workdir`, requested `provider`/`model`, `projectTrusted`, `readOnly`, `resumed`, `piVersion`,
+  `sessionId`, `startedAt`, and `finishedAt`.
+- `actualProvider`, `actualModel`, `usage`, and `stopReason` from Pi's final assistant event.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `sessionId` - parsed from the JSON stream's `session` header. Resume with `--session <id>`.
+  Note: `--continue` may mint a new session id for the continued run; the result always reports
+  the id of the run that just happened.
+- `finalMessage` - assistant text parts joined with `"\n\n"`; tool calls and tool results are
+  excluded.
+- `touchedFiles` - `git status --porcelain` lines for the **final working tree under `--cd` only**,
+  not an attribution of pi's edits: anything already dirty before dispatch shows up too. Dispatch
+  from a clean tree when you want the list to read as "what pi changed". `null` means git could
+  not report; `[]` means git ran and the tree is clean.
+- `stderrTail` - the last 20 non-empty stderr lines on any run that did not complete (`failed`,
+  `timeout`, `aborted`), except a launch failure, which reports `failed` with no `stderrTail`.
+- `error` - present for launch failures, preflight failures, when the relay watchdog fires
+  (`timeout`), and on an `aborted` run.
+
+Pi's stream carries thinking and message-update events the relay archives but does not parse.
+
+## Waiting for completion
+
+The relay blocks. Use the orchestrator's background-command facility, or background it in a
+shell and poll for `result.json`. The run is done only when the process exits and the file
+contains a `status`. The result file is written atomically, so a partial read is impossible.
+
+A pre-run usage error exits 2 and writes no result. A missing `pi` exits 127 and writes
+`status: "pi_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "pi_unavailable"` (exit 127):** install pi (`npm install -g @earendil-works/pi-coding-agent`),
+  authenticate, and re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
+  causes: an unknown `--model` (`Model "<x>" not found`), an expired login, or a provider error.
+  A final assistant event with `stopReason: "error"` or `"aborted"` is failed even if Pi exits zero.
+- **`status: "failed"` with an `error` mentioning `version preflight`:** the bounded `pi --version`
+  probe failed or hung, so pi was never dispatched. Check the install (`pi --version` yourself).
+- **`status: "aborted"`:** the relay itself was killed (its parent's timeout, a stopped task, a
+  closed terminal) and forwarded the kill to pi. The result is written before the relay exits;
+  inspect the working tree before re-dispatching. On native Windows a hard kill of the relay is
+  uncatchable (Node supports no `SIGTERM` handler there), so this status may never get written -
+  a relay process that is gone without a `result.json` is an aborted run; inspect the working
+  tree and `events.jsonl` directly.
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through
+  the OOM killer or a supervisor timeout. This is not a pi error; check host memory and
+  re-dispatch, or split the task into smaller briefs.
+- **`status: "timeout"`:** the `--timeout` watchdog killed the run; `error` reads
+  `pi did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout`
+  or split the task. On POSIX the relay sends SIGTERM to the process group, waits 10 seconds,
+  then sends SIGKILL if needed; on Windows there is no escalation phase — the whole process tree
+  is felled immediately with `taskkill /pid <pid> /t /f`.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report.
+
+## Recovering lost work
+
+`events.jsonl` in the run directory records every event the implementer streamed. If finished
+work is lost — the run killed late, or the working tree damaged afterward — read the event log
+before re-dispatching: it identifies which files and tool commands were involved, which scopes
+what needs redoing. Tool execution events carry the write/edit arguments, but treat any
+reconstruction as unverified until it matches a working-tree diff — when the tree still holds the
+work, preserve the tree rather than replaying the log.
+
+## What the relay runs
+
+The launch is equivalent to:
+
+```bash
+cat brief.txt | pi --mode json [--provider <name>] [--model <pattern>] \
+  [--session <id> | --continue] [--approve | --no-approve] [--tools read,grep,find,ls]
+```
+
+The brief rides stdin, so it is not visible in the host process list and no argv size cap
+applies. On native Windows `pi` is a `.cmd` shim, so the relay launches it with `shell:true`;
+only the token-validated `--provider`/`--model`/`--session` values ever ride argv. Before dispatch the relay
+runs a bounded `pi --version` preflight (10s cap) so a hung or crashing CLI fails fast and
+explicitly instead of hanging the run. The relay passes `--no-approve` by default, so project
+`.pi` settings, extensions, and skills stay untrusted; `--approve` opts in for a trusted repository.
+
+## The commit boundary
+
+The relay never commits. Pi edits the working tree; the orchestrator reviews, re-runs the gates,
+and commits. See [review-and-land.md](review-and-land.md).

--- a/skills/pi-delegate/references/multi-task-queues.md
+++ b/skills/pi-delegate/references/multi-task-queues.md
@@ -1,0 +1,59 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is
+the default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh pi sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture
+location, or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed pi session only for rework on the same task. Send a delta brief with
+`--resume-last`, or with `--session <id>` from that task's `result.json`. Start unrelated queue
+items in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** - queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** - what landed, what you verified, and gate outcomes.
+- **Needs your eyes** - design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** - the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/pi-delegate/references/review-and-land.md
+++ b/skills/pi-delegate/references/review-and-land.md
@@ -1,0 +1,95 @@
+# Review and land
+
+The implementer made the changes; you own the judgment. Verify against reality, never the self-report, and read
+the diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries pi's claims, not evidence. Re-run the project's actual test, lint, and build
+commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** - changes the brief excluded.
+- **Scope shortfall** - missed behavior, edges, or cleanup.
+- **Quiet judgment calls** - defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to pi as a delta brief, or fix it in the tree, and report either
+choice to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer.
+Write a clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of the
+implementer's work — the only one you can commit from, and often the only copy at all. Never run
+`git checkout`, `reset`, `clean`, or a branch switch in the workspace between those two points —
+however messy an interrupted run looks, inspect it first: `git status`, `git diff`,
+`git diff --cached` for anything the implementer staged (plain `git diff` is blind to the index),
+and open any untracked files (`??` in `git status`) directly — they are the implementer's new
+files, and no diff shows their contents. The tree is evidence, not clutter. After that inspection
+the verdict can legitimately be to discard — work built on a premise you have since corrected,
+for example — and then `git checkout`/`clean` is the right tool. The ban is on reflexive cleanup
+before anyone has looked.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove the
+unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--session <id>` instead when resuming the specific id recorded in `result.json` - the stable
+handle, since `--continue` may mint a new id for each continued run. The relay rejects
+`--resume-last` plus `--session` before launch. Rework gets the same gate rerun, test review,
+diff review, and implementer sweep.
+
+Pi has no permission modes, so a write-capable rework run executes with no prompts - keep rework
+briefs as narrow as the original. A `--read-only` run removes write/edit/bash from Pi's callable
+tool surface, including extension/custom tools; installed extension code still runs with the
+user's host permissions, so inspect `touchedFiles` and the tree after every run.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep
+them in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/pi-delegate/references/writing-the-brief.md
+++ b/skills/pi-delegate/references/writing-the-brief.md
@@ -1,0 +1,132 @@
+# Writing the brief
+
+A brief is the entire task as pi will see it. It runs in a separate session with **no memory of
+your conversation, no access to prior notes, and no shared context** - only the text you send and
+whatever it can inspect in the workspace. If a constraint is not in the brief or discoverable in
+the repo, it does not exist for pi.
+
+One shortcut: pi auto-loads `AGENTS.md` and `CLAUDE.md` context files from the workspace and its
+parent directories, so conventions written there reach pi without inlining. Restate the
+load-bearing rules in the brief anyway - the brief is the contract.
+
+## Model choice and resumed sessions
+
+Pi uses its configured default model when `--model` is omitted, so a fresh dispatch does not
+require it. Pass `--model <id>` only when the human asked for a specific model, choosing from
+`pi --list-models`. The relay forwards explicit ids and patterns (letters, digits, `. _ : / -`);
+glob patterns with `*` are rejected because the value reaches a shell on Windows.
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report pi must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics - current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+Run these before finishing and fix anything they surface, do not just report it:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree shows only the intended changes afterward.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit - the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes (include test/lint counts)
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** - add `<completeness_contract>` (resolve fully, not just the
+  first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
+  unknown).
+- **Research or recommendations** - add `<research_mode>` (separate observed facts, inferences,
+  and open questions), and dispatch with `--read-only` so Pi cannot invoke write/edit/bash tools.
+
+## Always ask for the report explicitly
+
+The relay builds `finalMessage` from assistant text in pi's JSON event stream. Without a closing
+summary, the edits may exist but the result is hard to review. The `<structured_output_contract>`
+block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy
+the actual commands into `<verification_loop>`. A brief that says only "run the tests" makes the
+implementer guess or skip them.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Pi can inspect the workspace (and auto-loads
+context files), but the important constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief -> one pi run -> one reviewed commit keeps the diff and
+rollback clean. Split mixed implementation, review, documentation, and roadmap requests into
+separate dispatches.
+
+## Premises freeze at dispatch
+
+The implementer starts from the brief's facts and there is no steering channel mid-run. Audit the
+fact block before sending — ownership, target branch, constraints, anything a judgment call rests
+on. If a premise turns out wrong while the run is live, stop the run and re-dispatch a corrected
+brief rather than discounting the output afterward; for a write-capable run, inspect the working
+tree and reconcile any partial or premise-contaminated edits — keep or revert them — before the
+re-dispatch.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+Run and make green before finishing:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+Confirm git status shows only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Stdin delivery
+
+The relay pipes the brief to pi on stdin. Unlike CLIs that take the brief as an argument, there
+is no OS argv size cap and the brief never appears in the host process list. Large context can be
+inlined, but prefer pointing pi at workspace files it can read itself. Keep secrets out of the
+brief anyway on shared machines - reference environment variables or files with tight permissions.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/pi-delegate/scripts/relay.mjs
+++ b/skills/pi-delegate/scripts/relay.mjs
@@ -1,0 +1,799 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · pi-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Pi coding agent CLI (`pi --mode json`),
+ * capture the JSON event stream, and write a structured result the orchestrating
+ * agent can review. The orchestrator runs this one command and reads the result
+ * JSON — every pi-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Smoke-tested against a current pi CLI on macOS.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `pi` and `git`, plus the platform
+ * process-termination utility when a Windows process-tree kill requires one.
+ * The `pi` process it launches does authenticate — exactly as you do at the
+ * terminal. Read this file before you run it.
+ *
+ * The brief is piped to pi on stdin, so it never appears in the host process
+ * list and no argv size cap applies. Keep secrets out of the brief anyway on
+ * shared machines — reference workspace files or environment variables instead.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Autonomy: pi has no sandbox and no permission modes — a default headless run
+ * reads, writes, edits, and runs shell commands without asking. `--read-only`
+ * restricts pi's callable tool surface to `read,grep,find,ls` across built-in,
+ * extension, and custom tools; installed extension code still runs with the
+ * user's host permissions. The relay passes `--no-approve` unless `--approve`
+ * explicitly trusts project `.pi` resources. The diff reported in
+ * `touchedFiles` is the record of what changed.
+ *
+ * pi is installed from npm, so on native Windows `pi` is a `.cmd` shim this
+ * relay launches with shell:true. Only token-validated flag values ride argv
+ * (the brief never does), which keeps that launch safe.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for pi (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --provider <name>       pi provider name (default: pi's own default).
+ *   --model <pattern>       pi model id or pattern (default: pi's own default).
+ *                           Letters, digits, and . _ : / - only.
+ *   --session <id>          Resume a specific pi session; send only the delta brief.
+ *   --resume-last           Continue the most recent pi session for this cwd
+ *                           (`pi --continue`); send only the delta brief.
+ *   --approve               Trust project-local files for this run. By default
+ *                           the relay passes --no-approve.
+ *   --read-only             Restrict pi to read,grep,find,ls (no write/edit/bash).
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). pi has no timeout
+ *                           flag; durations use h/m/s strings.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, piVersion, sessionId, finalMessage (pi's own
+ *   report), requested/actual provider and model, usage, touchedFiles (git
+ *   porcelain, null if git cannot report), readOnly, projectTrusted, and paths
+ *   to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `pi` binary exits 127;
+ * otherwise the exit code mirrors pi's own (0 success, non-zero failure), except
+ * a final assistant `error`/`aborted` event exits 1 even if pi exits 0. If the
+ * child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome — completed, failed, timeout (the --timeout watchdog
+ * fired, or the bounded --version preflight hung), aborted (the relay itself
+ * was killed and forwarded the kill to pi), or pi_unavailable.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const VERSION_TIMEOUT_MS = 10_000;
+const READ_ONLY_TOOLS = "read,grep,find,ls";
+// --model, --provider, and --session values reach a shell on win32 (shell:true for the
+// .cmd shim), so they are restricted to safe tokens.
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const IMPLEMENTER_KEY = "pi";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    provider: null,
+    model: null,
+    session: null,
+    resumeLast: false,
+    readOnly: false,
+    approve: false,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--provider": opts.provider = next(); flagged.add("provider"); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--approve": opts.approve = true; break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  for (const flag of ["model", "provider", "session"]) {
+    if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+  if (parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
+  // setTimeout overflows past 2^31 - 1 ms (~24.8 days) and fires immediately,
+  // which would read as an instant spurious timeout — reject it up front.
+  if (parseDuration(opts.timeout) > 2_147_483_647) {
+    fail(`--timeout "${opts.timeout}" exceeds the maximum schedulable watchdog (~24.8 days)`);
+  }
+  if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
+    fail(`working directory not found: ${opts.cd}`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to pi --mode json\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+async function piVersion(timeoutMs, onChild) {
+  const limit = Math.min(timeoutMs, VERSION_TIMEOUT_MS);
+  const runProbe = (command, argv, options = {}) => new Promise((resolveProbe) => {
+    const child = spawn(command, argv, {
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      ...options,
+    });
+    onChild(child);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let timer;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveProbe({ stdout, stderr, ...result });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => finish({ code: null, error, timedOut: false }));
+    child.on("close", (code) => finish({ code, error: null, timedOut }));
+    timer = setTimeout(() => {
+      timedOut = true;
+      killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+    }, limit);
+  });
+
+  // shell:true resolves pi.cmd, but a missing command is only an exit 1 from
+  // cmd.exe. Ask the in-box where.exe first so absence stays pi_unavailable.
+  if (process.platform === "win32") {
+    const wherePath = join(process.env.SystemRoot || process.env.WINDIR || "C:\\Windows", "System32", "where.exe");
+    const found = await runProbe(wherePath, ["pi"]);
+    if (found.timedOut) {
+      return { version: null, error: Object.assign(new Error("where.exe pi timed out"), { code: "ETIMEDOUT", stderr: found.stderr }) };
+    }
+    if (found.error && found.error.code !== "ENOENT") return { version: null, error: found.error };
+    if (!found.error && found.code !== 0) return { version: null, error: null };
+  }
+
+  const probe = process.platform === "win32"
+    ? await runProbe("pi --version", [], { shell: true, detached: false })
+    : await runProbe("pi", ["--version"]);
+  if (probe.timedOut) {
+    return { version: null, error: Object.assign(new Error("pi --version timed out"), { code: "ETIMEDOUT", stderr: probe.stderr }) };
+  }
+  if (probe.error && probe.error.code === "ENOENT") return { version: null, error: null };
+  if (probe.error) return { version: null, error: probe.error };
+  if (probe.code !== 0) {
+    return { version: null, error: Object.assign(new Error("pi --version failed"), { status: probe.code, stderr: probe.stderr }) };
+  }
+  return { version: probe.stdout.trim() || "unknown", error: null };
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts) {
+  // The brief rides stdin, never argv. --mode json alone is non-interactive:
+  // pi reads the piped brief, streams events, and exits.
+  const argv = ["--mode", "json"];
+  if (opts.provider) argv.push("--provider", opts.provider);
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.session) argv.push("--session", opts.session);
+  else if (opts.resumeLast) argv.push("--continue");
+  argv.push(opts.approve ? "--approve" : "--no-approve");
+  if (opts.readOnly) argv.push("--tools", READ_ONLY_TOOLS);
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  // A reused --out-dir must not leak a previous run's artifacts into this one.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "pi",
+      workdir: opts.cd,
+      provider: opts.provider,
+      model: opts.model,
+      readOnly: opts.readOnly,
+      projectTrusted: opts.approve,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      piVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    // Atomic write: a polling orchestrator never reads a half-written result.
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "pi_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    actualProvider: null,
+    actualModel: null,
+    usage: null,
+    stopReason: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `pi` not found on PATH. Install with `npm install -g @earendil-works/pi-coding-agent`, then authenticate (`/login`, or an API-key environment variable).\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(writeResult, run, error, timeoutMs) {
+  const timedOut = error && error.code === "ETIMEDOUT";
+  const stderr = String((error && error.stderr) || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `pi --version preflight timed out after ${Math.min(timeoutMs, VERSION_TIMEOUT_MS)}ms; pi was not dispatched`
+    : `pi --version preflight failed${Number.isInteger(error && error.status) ? ` with exit ${error.status}` : ""}; pi was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error && error.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    actualProvider: null,
+    actualModel: null,
+    usage: null,
+    stopReason: null,
+    finalMessage: "",
+    touchedFiles: null,
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: null,
+        actualProvider: null,
+        actualModel: null,
+        usage: null,
+        stopReason: null,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the pi version preflight; pi was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      const child = getChild();
+      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
+}
+
+function dispatchToPi(opts, brief, run, writeResult) {
+  const child = spawn("pi", buildArgv(opts), {
+    cwd: opts.cd,
+    stdio: ["pipe", "pipe", "pipe"],
+    // shell:true on win32 so the pi.cmd shim resolves. Safe: the brief is fed
+    // via stdin — never argv — and argv holds only the fixed flag names and
+    // token-validated --provider/--model/--session values.
+    shell: process.platform === "win32",
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let sessionId = null;
+  let actualProvider = null;
+  let actualModel = null;
+  let usage = null;
+  let stopReason = null;
+  let assistantError = null;
+  const textChunks = [];
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    if (event.type === "session" && typeof event.id === "string") {
+      sessionId = event.id;
+    }
+    if (event.type === "message_end" && event.message && event.message.role === "assistant") {
+      const content = event.message.content;
+      if (typeof content === "string") textChunks.push(content);
+      if (Array.isArray(content)) {
+        for (const part of content) {
+          if (part && part.type === "text" && typeof part.text === "string") textChunks.push(part.text);
+        }
+      }
+      if (typeof event.message.provider === "string") actualProvider = event.message.provider;
+      if (typeof event.message.model === "string") actualModel = event.message.model;
+      if (event.message.usage && typeof event.message.usage === "object") usage = event.message.usage;
+      if (typeof event.message.stopReason === "string") stopReason = event.message.stopReason;
+      if (typeof event.message.errorMessage === "string") assistantError = event.message.errorMessage;
+    }
+  });
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  // A fast-exiting pi (usage error, crashed startup) closes the pipe before
+  // the write; swallow EPIPE here — the exit code reports the failure.
+  child.stdin.on("error", () => {});
+  child.stdin.write(brief);
+  child.stdin.end();
+
+  const assembleFinal = () => {
+    const message = textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the pi child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        actualProvider,
+        actualModel,
+        usage,
+        stopReason,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; pi was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      actualProvider,
+      actualModel,
+      usage,
+      stopReason,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // A timed-out run is failed even if pi handles SIGTERM by exiting 0 —
+    // orchestrators key off status and the relay exit code.
+    const assistantFailed = stopReason === "error" || stopReason === "aborted";
+    const succeeded = code === 0 && !watchdogFired && !assistantFailed;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      actualProvider,
+      actualModel,
+      usage,
+      stopReason,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `pi did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...(!watchdogFired && assistantFailed ? { error: assistantError || `pi ended with stopReason "${stopReason}"` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const run = prepareRunDir(opts, brief);
+  let writeResult = makeResultWriter(opts, null, run);
+  let preflightChild = null;
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult, () => preflightChild);
+  const probe = await piVersion(timeoutMs, (child) => { preflightChild = child; });
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (!probe.version) {
+    clearPreflightSignals();
+    reportVersionFailure(writeResult, run, probe.error, timeoutMs);
+    return;
+  }
+  clearPreflightSignals();
+  dispatchToPi(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  pi ${result.piVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a pi error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated pi (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.readOnly) lines.push(`mode: read-only (tools ${READ_ONLY_TOOLS})`);
+  if (result.projectTrusted) lines.push("mode: project resources trusted (--approve)");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.actualModel) lines.push(`model: ${result.actualProvider ? `${result.actualProvider}/` : ""}${result.actualModel}`);
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- pi final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/qoder-delegate/SKILL.md
+++ b/skills/qoder-delegate/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: qoder-delegate
+description: Delegate a coding task to the Qoder CLI (`qodercli`) as a background
+  implementer, then review its diff and land it yourself. Use this whenever the user
+  asks to have Qoder implement, fix, refactor, or run a queue of coding tasks while
+  the orchestrator remains the reviewer. DO...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+metadata:
+  version: 0.5.0
+---
+# Qoder Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `qoder` implementer (`Qoder`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Delegate one bounded coding task to a separate **implementer** - Qoder CLI -
+then review what it produced and land it yourself. You write the brief and own the judgment; Qoder
+edits the working tree in its session; you verify and commit.
+
+The loop needs only shell and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- `qodercli` is not installed or authenticated.
+- You want to write the code yourself or need only an interactive Qoder session.
+
+## Prerequisites (check once)
+
+```bash
+command -v qodercli
+qodercli --version
+qodercli --list-models
+```
+
+If the binary is missing, install it from Qoder's
+[official Quick Start](https://docs.qoder.com/en/cli/quick-start). Authenticate with `qodercli login`,
+or set `QODER_PERSONAL_ACCESS_TOKEN` for automation. A successful `--list-models` confirms the current
+account can return its live model catalog.
+
+## Choose model and context window
+
+Qoder's available models can change. If the human requests a model, use its exact current value from
+`qodercli --list-models`; never invent or pin a catalog entry. Otherwise omit `--model` and let Qoder
+use its current default.
+
+`--context-window <n>` is optional. Pass a positive integer only when the human requests a size or the
+task needs an explicit budget. Qoder applies it only to supported models; surface an unsupported
+model/size error instead of silently choosing another value.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Qoder sees the brief plus what it can inspect in the workspace, not this chat. Include the goal,
+current state, what to change, what to leave untouched, the project's **actual** gates, and a closing
+report contract. Tell Qoder not to commit. Keep one task per brief. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled relay. It wraps Qoder's non-interactive `stream-json` mode and writes `result.json`.
+`<skill-dir>` is the installed folder containing this `SKILL.md`.
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a live model:                 add --model "<value from qodercli --list-models>"
+# request a supported context window: add --context-window 32768
+# resume the latest session:          add --resume-last  # delta brief only
+# resume a specific session:          add --resume <id>  # delta brief only
+# see every option:                   node .../relay.mjs --help
+```
+
+Implementation runs default to Qoder's `auto` permission mode. The relay never bypasses permissions
+unless the caller explicitly requests it, and it never commits. See
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until Qoder exits. Run it with the orchestrator's background-command facility, or
+background it in the shell and wait for `result.json`. Completion means the process exited and the
+file contains a `status`; do not trust a progress display.
+
+A pre-run usage error exits 2 and writes no result. Missing `qodercli` exits 127 and writes
+`status: "qoder_unavailable"` with installation guidance.
+
+Native Windows relay launch is not yet verified; do not claim it until a native Windows smoke passes.
+
+### 4. Review - do not trust the self-report
+
+Treat Qoder's final message and gate outcomes as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Check any `--add-dir` workspaces separately; their changes are not in the primary tree report.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits; **the orchestrator commits**. Commit only after the gates pass and the diff
+holds. If rework is needed, send a delta brief with `--resume-last` or `--resume <id>`, then review
+again.
+
+## Permission model
+
+Qoder print mode cannot show approval prompts. The relay defaults to `auto`, which makes
+non-interactive allow/deny decisions. `default` can deny actions that would require a prompt;
+`accept_edits` permits workspace edits but may deny shell actions; `dont_ask` fails closed; `plan`
+maps to `default` plus Qoder's Plan work state; and `bypass_permissions` is for explicitly trusted
+runs only.
+
+Qoder falls back to `default` when a non-default mode is requested outside a trusted directory. Check
+`actualPermissionMode` in `result.json`; no requested mode replaces diff review.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they ask for it, landing verified, gate-passing work
+is the contract. Two limits remain: **surface, do not absorb** (report Qoder's design decisions and
+non-blocking deviations) and **stop for scope changes** (ask before expanding beyond the brief). See
+[references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - brief structure, real gates,
+  report contract, secrets, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, model/context controls,
+  artifacts, result fields, sessions, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - independent review, commit boundary,
+  and rework.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues, constraint
+  carry-forward, progress tracking, and final coherence.
+
+
+## Limitations
+
+- Requires the `qoder` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/qoder-delegate/references/dispatch-and-poll.md
+++ b/skills/qoder-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,119 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps Qoder's non-interactive print mode with `stream-json` output, captures raw
+output, and writes a stable `result.json`.
+
+## Before the first run
+
+```bash
+command -v qodercli
+qodercli --version
+qodercli --list-models
+```
+
+Install and authenticate using Qoder's
+[official Quick Start](https://docs.qoder.com/en/cli/quick-start). Use `qodercli login` interactively or
+`QODER_PERSONAL_ACCESS_TOKEN` for automation.
+
+## Dispatch
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path; omit to read stdin. |
+| `--cd <dir>` | Primary working root and child cwd; defaults to current directory. |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--model <name>` | Exact live model value from `qodercli --list-models`; omit for Qoder's default. |
+| `--context-window <n>` | Positive integer requested for models that support explicit sizing. |
+| `--resume <id>` | Resume one Qoder session with a delta brief. |
+| `--resume-last` | Continue the most recent Qoder session with a delta brief. |
+| `--add-dir <dir>` | Add a workspace directory; repeatable. |
+| `--permission-mode <mode>` | `default`, `accept_edits`, `auto`, `bypass_permissions`, `dont_ask`, or `plan`; defaults to `auto`. |
+| `--timeout <dur>` | Relay watchdog; also bounds version preflight to at most 10s. Defaults to `30m`, using h/m/s syntax. |
+| `--out-dir <dir>` | Artifact directory; defaults to a fresh system-temp directory. |
+| `-h`, `--help` | Print relay help. |
+
+`--resume` and `--resume-last` are mutually exclusive. Relative `--add-dir` values resolve against
+`--cd`.
+
+## Model and context behavior
+
+Qoder's catalog is account- and time-dependent. The relay deliberately accepts a model string rather
+than maintaining a stale allowlist. It validates only that the value is non-empty; Qoder remains the
+authority on availability.
+
+The relay validates context windows as positive integers and forwards the value unchanged. Qoder
+remains the authority on whether the selected model supports it. An omitted value uses Qoder's normal
+model behavior.
+
+## Permission behavior
+
+Print mode cannot ask for approval. `auto` is the implementation default: Qoder makes
+non-interactive allow/deny decisions. `accept_edits` allows workspace edits but may deny shell actions;
+`dont_ask` fails closed; `plan` maps to `default` plus Qoder's Plan work state; and
+`bypass_permissions` is only for an explicitly trusted broad run.
+
+Outside a trusted directory, Qoder falls back from any non-default request to `default`. Compare
+`permissionMode` with `actualPermissionMode` in `result.json`. No mode replaces diff review.
+
+## Artifacts and result fields
+
+Artifacts default outside the repository:
+
+- `brief.txt` - exact dispatched brief.
+- `events.jsonl` - raw Qoder stdout events.
+- `final.txt` - final report when captured.
+- `stderr.txt` - complete stderr.
+- `result.json` - `delegate-relay.result.v1`.
+
+Important `result.json` fields:
+
+- `tool` (`"qoder"`), `status` (`completed`, `failed`, `timeout`, `aborted`, or
+  `qoder_unavailable`), `exitCode`, `signal`.
+- Requested `model`, `contextWindow`, and `permissionMode`; observed `actualModel` and
+  `actualPermissionMode` from Qoder's init event.
+- `qoderVersion`, `sessionId`, `resumed`, `startedAt`, and `finishedAt`.
+- `usage`, `resultSubtype`, `qoderErrors`, and `permissionDenials` from Qoder's result event.
+- `finalMessage` from the result event, falling back to assistant text.
+- `touchedFiles` from final `git status --porcelain` under the primary `--cd` only. Existing dirty
+  entries are included; `--add-dir` changes are not. `null` means git could not report; `[]` means the
+  tree is clean.
+- Artifact paths, plus `stderrTail` and `error` on failures.
+
+## Waiting
+
+The relay blocks. Use the orchestrator's background facility or run it in the foreground for short
+tasks. A valid run is done when the process exits and `result.json` exists. A usage error exits 2 before
+creating artifacts; missing Qoder exits 127 with `qoder_unavailable`.
+
+## Failures
+
+- **`qoder_unavailable`:** install Qoder CLI, authenticate, and re-dispatch.
+- **Preflight `failed` or `timeout`:** `qodercli --version` failed or exceeded its bound; Qoder was
+  not dispatched. Fix the installation before retrying.
+- **`failed`:** read `qoderErrors`, `permissionDenials`, `stderrTail`, `stderr.txt`, and the tail of
+  `events.jsonl`. Fix auth, model/context compatibility, permissions, or the brief, then re-dispatch.
+- **`timeout`:** increase `--timeout` or split the task. The relay terminates Qoder's process tree.
+- **`aborted`:** the orchestrator stopped the relay; review any touched files before re-dispatching.
+- **No result after the relay disappears:** treat the run as aborted and inspect the working tree and
+  `events.jsonl`. Native Windows cannot deliver Node a catchable `SIGTERM`.
+- **Empty final message:** inspect the diff; require a structured report in the next delta brief.
+
+## Recovering lost work
+
+`events.jsonl` records what Qoder streamed. If a run is interrupted, preserve the working tree first;
+use the event log to scope any redo, not as proof that edits or gates completed.
+
+## What the relay runs
+
+```bash
+qodercli --output-format stream-json --permission-mode auto \
+  [--model <name>] [--context-window <n>] [--resume <id> | -c] \
+  [--add-dir <dir> ...] -p <brief>
+```
+
+The relay spawns `qodercli` directly without a shell, never commits, and makes no network calls of its
+own. Continue with [review-and-land.md](review-and-land.md).

--- a/skills/qoder-delegate/references/multi-task-queues.md
+++ b/skills/qoder-delegate/references/multi-task-queues.md
@@ -1,0 +1,43 @@
+# Multi-task queues
+
+Scale the single-task loop through sequencing and bookkeeping, not a larger brief.
+
+## Run sequentially
+
+Dispatch one task, review it, rerun its gates, and land it before the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps review and rollback bounded.
+- A clean tree makes `touchedFiles` useful.
+- Parallelize only genuinely independent tasks in separate worktrees.
+
+## Carry constraints forward
+
+Fresh Qoder sessions do not know earlier queue decisions. Put any helper name, fixture location, or
+interface needed later into the later brief.
+
+Resume only for rework on the same task. Send a delta with `--resume-last` or `--resume <id>` from that
+task's `result.json`. Start unrelated items in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, track:
+
+- queued / at-implementer / reviewed+committed status and commit hash;
+- per-task review notes and gate outcomes;
+- design choices and questions needing human review;
+- the final cross-task verification.
+
+Update it after every landed task.
+
+## Close coherently
+
+After the last task, run the full gates once more, search repository-wide for the changed concept,
+round-trip migrations when applicable, and only then push or open a pull request.
+
+Stop and ask if a task cannot fit its brief, review invalidates the plan, or gates reveal a problem in
+already-landed work. Report the landed hashes and open question before waiting.

--- a/skills/qoder-delegate/references/review-and-land.md
+++ b/skills/qoder-delegate/references/review-and-land.md
@@ -1,0 +1,66 @@
+# Review and land
+
+Qoder did the typing; the orchestrator owns the judgment. Verify reality, not the self-report.
+
+## Review changed tests first
+
+- Treat unbriefed test edits as contract changes.
+- Treat skipped, disabled, or commented tests as failures.
+- Treat loosened assertions as weakened gates.
+
+## Re-run the gates
+
+`finalMessage` contains Qoder's claims. Run the repository's actual test, lint, typecheck, and build
+commands yourself. For specialized changes:
+
+- Round-trip migrations and schemas.
+- Search for dangling references after removals and renames.
+- Exercise stateful behavior, not only compilation.
+
+## Compare the diff to the brief
+
+Start with `touchedFiles`, then read the full diff for:
+
+- **Scope creep** - excluded changes.
+- **Scope shortfall** - missing behavior or cleanup.
+- **Quiet decisions** - defensible but unasked choices requiring review.
+
+`touchedFiles` is final tree state, not attribution. Start clean when possible and inspect every
+`--add-dir` workspace separately.
+
+## Implementer sweep
+
+Look for hardcoded success data, swallowed errors, nonexistent dependencies or APIs, dead helpers,
+duplicate patterns, tests that assert internals, speculative options, and guards that hide missing
+trust-boundary validation. Run relevant guard skills if installed.
+
+## Rework with a delta brief
+
+Continue the same Qoder session with only the correction:
+
+```bash
+echo "Keep the fix, replace the mocked DB assertion with the real migrated fixture, remove the unused import, and rerun the stated gates." |
+  node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Use `--resume <id>` for the specific `sessionId` in `result.json`. Rework receives the same independent
+gate and diff review.
+
+## Commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**. Qoder must never run `git add` or
+`git commit` for this workflow.
+
+Until then, the working tree is the authoritative copy of the implementer's work. Before any cleanup
+or branch switch, inspect `git status`, `git diff`, `git diff --cached`, and every untracked file.
+Staged and untracked work is invisible to a plain `git diff`; preserve it until the review decides
+what to keep.
+
+## Surface, do not absorb
+
+- Report Qoder's design decisions and defensible deviations.
+- Note non-blocking issues you did not block on.
+- Stop and ask when correct completion requires expanding the brief.
+
+For queues, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/qoder-delegate/references/writing-the-brief.md
+++ b/skills/qoder-delegate/references/writing-the-brief.md
@@ -1,0 +1,85 @@
+# Writing the brief
+
+A brief is the complete task Qoder receives. It has no memory of this chat; it sees only the brief,
+its resumed session when applicable, and workspace context it can inspect. A constraint not in the
+brief or repository does not exist for the implementer.
+
+## Model, context, and resumed sessions
+
+Model and context-window choices belong to dispatch, not the brief. Select a requested model from the
+fresh output of `qodercli --list-models`. Omit `--model` for Qoder's default. Pass
+`--context-window <positive-integer>` only when an explicit size is useful and let Qoder reject an
+unsupported model/size combination.
+
+A resumed session keeps context. Send only the correction with `--resume-last` or `--resume <id>`.
+
+## The shape that works
+
+```xml
+<task>
+State the concrete job, where it lives, the current behavior, what must change, and what must remain
+untouched. Keep it to one bounded task.
+</task>
+
+<verification_loop>
+Run these before finishing and fix what they surface:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+Confirm the working tree contains only intended changes.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped. Do not perform unrelated refactors, renames, or cleanup. Do NOT run git add or git
+commit; the orchestrator reviews and commits. Leave work uncommitted.
+</action_safety>
+
+<structured_output_contract>
+End with:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes with counts
+  4. Deviations, open items, or decisions needed
+</structured_output_contract>
+```
+
+For debugging, add `<completeness_contract>` so Qoder resolves the cause rather than stopping at the
+first plausible fix, and `<missing_context_gating>` so it finds missing repository facts instead of
+guessing.
+
+## Discover the real gates
+
+Read `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or the repository's equivalents before
+writing the brief. Copy the actual commands. "Run the tests" makes the implementer guess.
+
+## Honor repository conventions
+
+Qoder loads repository context such as `AGENTS.md`, but restate load-bearing constraints directly in
+the brief. This is especially important for forbidden commands, narrow file scope, data safety, and
+the no-commit boundary.
+
+## Ask for the report
+
+The relay prefers Qoder's `result.result` for `finalMessage`, then falls back to assistant text blocks.
+An explicit output contract makes the result reviewable even when the edits are correct.
+
+## One task per brief
+
+One brief -> one Qoder run -> one reviewed commit. Split mixed implementation, review, documentation,
+and roadmap requests. Resume only for rework on that same task.
+
+## Premises freeze at dispatch
+
+Audit the brief's facts before dispatch: ownership, target branch, constraints, and any premise a
+judgment call depends on. If one proves wrong during a run, stop Qoder, inspect and reconcile any
+partial edits, then dispatch a corrected brief.
+
+## Keep secrets out of argv
+
+Qoder print mode receives the brief as a command-line argument, visible through process inspection on
+the host. The relay rejects briefs over 120 KB, or 12 KB on native Windows where command lines are
+shorter. Put secrets and large context in appropriately protected workspace files or environment
+variables, then reference them by name or path.
+
+Continue with [dispatch-and-poll.md](dispatch-and-poll.md), then
+[review-and-land.md](review-and-land.md).

--- a/skills/qoder-delegate/scripts/relay.mjs
+++ b/skills/qoder-delegate/scripts/relay.mjs
@@ -1,0 +1,681 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · qoder-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to Qoder CLI (`qodercli -p`), capture the
+ * structured event stream, and write a result the orchestrator can review.
+ * The relay uses Node built-ins only and shells out only to `qodercli`, `git`,
+ * and the platform process-termination utility when needed. It makes no
+ * network calls, reads no credentials, sends no telemetry, and never commits.
+ *
+ * The brief is passed as a command-line argument. Keep secrets out of the
+ * brief on shared hosts; point Qoder at workspace files or environment
+ * variables instead.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Brief path. If omitted, read stdin.
+ *   --cd <dir>              Qoder working root (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <name>          Model from `qodercli --list-models`.
+ *   --context-window <n>    Positive integer; supported models only.
+ *   --resume <id>           Resume one Qoder session; send a delta brief.
+ *   --resume-last           Continue the latest session; send a delta brief.
+ *   --add-dir <dir>         Add a workspace directory. Repeatable.
+ *   --permission-mode <m>   default | accept_edits | auto |
+ *                           bypass_permissions | dont_ask | plan
+ *                           (default: auto).
+ *   --timeout <dur>         Relay watchdog (default: 30m; h/m/s syntax).
+ *   --out-dir <dir>         Artifact directory (default: system temp).
+ *   -h, --help              Show this help.
+ *
+ * Result: <out-dir>/result.json plus brief.txt, events.jsonl, stderr.txt, and
+ * final.txt when Qoder emits a final message. Pre-run usage errors exit 2 and
+ * write no result. Missing `qodercli` exits 127 with qoder_unavailable. Once
+ * dispatched, every outcome writes a result: completed, failed, timeout,
+ * aborted, or qoder_unavailable.
+ */
+
+import {execFileSync, spawn, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { constants, tmpdir } from "node:os";
+import {basename, join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { StringDecoder } from "node:string_decoder";
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const VERSION_TIMEOUT_MS = 10_000;
+const MAX_BRIEF_BYTES = (process.platform === "win32" ? 12 : 120) * 1024;
+const PERMISSION_MODES = new Set([
+  "default",
+  "accept_edits",
+  "bypass_permissions",
+  "dont_ask",
+  "auto",
+  "plan",
+]);
+
+const IMPLEMENTER_KEY = "qoder";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && flagged.has("readOnly")) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    contextWindow: null,
+    resume: null,
+    resumeLast: false,
+    addDirs: [],
+    permissionMode: "auto",
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--context-window": opts.contextWindow = next(); break;
+      case "--resume": opts.resume = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--add-dir": opts.addDirs.push(next()); break;
+      case "--permission-mode": opts.permissionMode = next(); flagged.add("permissionMode"); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default: fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+
+  if (opts.resumeLast && opts.resume) {
+    fail("--resume-last and --resume are mutually exclusive; pass only one");
+  }
+  if (opts.resume !== null && !opts.resume.trim()) fail("--resume must not be empty");
+  if (opts.model !== null && !opts.model.trim()) fail("--model must not be empty");
+  if (opts.contextWindow !== null && !/^[1-9]\d*$/.test(opts.contextWindow)) {
+    fail("--context-window must be a positive integer");
+  }
+  if (!PERMISSION_MODES.has(opts.permissionMode)) {
+    fail(`unsupported --permission-mode: ${opts.permissionMode}`);
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
+    fail(`working directory not found: ${opts.cd}`);
+  }
+
+  opts.addDirs = opts.addDirs.map((dir) => resolve(opts.cd, dir));
+  return opts;
+}
+
+function headerComment() {
+  const source = readFileSync(new URL(import.meta.url), "utf8");
+  const match = source.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to qodercli -p\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function qoderVersion(timeoutMs) {
+  try {
+    return {
+      version: execFileSync("qodercli", ["--version"], {
+        encoding: "utf8",
+        shell: false,
+        timeout: Math.min(timeoutMs, VERSION_TIMEOUT_MS),
+        killSignal: "SIGKILL",
+      }).trim() || "unknown",
+      error: null,
+    };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    return { version: null, error };
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, brief) {
+  const argv = ["--output-format", "stream-json", "--permission-mode", opts.permissionMode];
+  if (opts.resume) argv.push("--resume", opts.resume);
+  else if (opts.resumeLast) argv.push("-c");
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.contextWindow) argv.push("--context-window", opts.contextWindow);
+  for (const dir of opts.addDirs) argv.push("--add-dir", dir);
+  argv.push("-p", brief);
+  return argv;
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "qoder",
+      workdir: opts.cd,
+      model: opts.model,
+      contextWindow: opts.contextWindow,
+      permissionMode: opts.permissionMode,
+      resumed: Boolean(opts.resumeLast || opts.resume),
+      qoderVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "qoder_unavailable",
+    exitCode: 127,
+    signal: null,
+    sessionId: null,
+    actualModel: null,
+    actualPermissionMode: null,
+    usage: null,
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `qodercli` not found on PATH. Install from https://docs.qoder.com/en/cli/quick-start, then run `qodercli login` or set QODER_PERSONAL_ACCESS_TOKEN for automation.\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(writeResult, run, error, timeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `qodercli --version preflight timed out after ${Math.min(timeoutMs, VERSION_TIMEOUT_MS)}ms; Qoder was not dispatched`
+    : `qodercli --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Qoder was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    actualModel: null,
+    actualPermissionMode: null,
+    usage: null,
+    resultSubtype: null,
+    qoderErrors: [],
+    permissionDenials: [],
+    finalMessage: "",
+    touchedFiles: null,
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatch(opts, brief, run, writeResult) {
+  // Target Qoder's currently documented native Windows executable, keeping
+  // argv structured and avoiding a command shell on every platform.
+  const child = spawn("qodercli", buildArgv(opts, brief), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: false,
+    detached: process.platform !== "win32",
+  });
+  let sessionId = null;
+  let actualModel = null;
+  let actualPermissionMode = null;
+  let usage = null;
+  let finalResult = "";
+  let resultIsError = false;
+  let resultSubtype = null;
+  let qoderErrors = [];
+  let permissionDenials = [];
+  const textChunks = [];
+  const deltaChunks = [];
+  const stderrTail = [];
+
+  const scan = makeEventScanner((event) => {
+    const eventSessionId = event.session_id ?? event.sessionId ?? event.session?.id;
+    if (typeof eventSessionId === "string") sessionId = eventSessionId;
+    if (event.type === "system" && event.subtype === "init") {
+      if (typeof event.model === "string") actualModel = event.model;
+      const mode = event.permissionMode ?? event.permission_mode;
+      if (typeof mode === "string") actualPermissionMode = mode;
+    }
+    if (event.type === "assistant" || event.role === "assistant") {
+      const content = event.message?.content ?? event.content;
+      if (typeof content === "string") textChunks.push(content);
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block?.type === "text" && typeof block.text === "string") textChunks.push(block.text);
+        }
+      }
+    }
+    if (event.type === "content_block_delta" && typeof event.delta?.text === "string") {
+      deltaChunks.push(event.delta.text);
+    }
+    if (event.type === "result" || event.type === "final") {
+      resultSubtype = typeof event.subtype === "string" ? event.subtype : null;
+      resultIsError = event.is_error === true || event.status === "error";
+      const resultText = event.result ?? event.final_message ?? event.finalMessage;
+      if (typeof resultText === "string") finalResult = resultText;
+      if (!finalResult && typeof event.message === "string") finalResult = event.message;
+      if (!finalResult && Array.isArray(event.message?.content)) {
+        const blocks = event.message.content
+          .filter((block) => block?.type === "text" && typeof block.text === "string")
+          .map((block) => block.text);
+        if (blocks.length) finalResult = blocks.join("\n\n");
+      }
+      if (event.usage && typeof event.usage === "object") usage = event.usage;
+      if (Array.isArray(event.errors)) qoderErrors = event.errors;
+      if (Array.isArray(event.permission_denials)) permissionDenials = event.permission_denials;
+    }
+  });
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    for (const line of stderrDecoder.write(chunk).split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = finalResult || textChunks.join("\n\n") || deltaChunks.join("");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT));
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const abortedFields = () => ({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId,
+        actualModel,
+        actualPermissionMode,
+        usage,
+        resultSubtype,
+        qoderErrors,
+        permissionDenials,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; qodercli was terminated with it — inspect the working tree before re-dispatching`,
+      });
+      const result = writeResult(abortedFields());
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        writeResult(abortedFields());
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (error) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      sessionId,
+      actualModel,
+      actualPermissionMode,
+      usage,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(error?.message || error),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    if (watchdogFired) killChild(child, "SIGKILL");
+    scan(stdoutDecoder.end());
+    const stderrEnd = stderrDecoder.end();
+    if (stderrEnd.trim()) stderrTail.push(stderrEnd.trimEnd());
+    const succeeded = code === 0 && !watchdogFired && !resultIsError;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      sessionId,
+      actualModel,
+      actualPermissionMode,
+      usage,
+      resultSubtype,
+      qoderErrors,
+      permissionDenials,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `qodercli did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(exitCode);
+  });
+}
+
+function printSummary(result, resultPath) {
+  const lines = [
+    "",
+    `relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""}) · qodercli ${result.qoderVersion ?? "?"}`,
+  ];
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed qodercli (commonly an OOM killer or supervisor timeout); check host memory and inspect the working tree before re-dispatching.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated qodercli; relay watchdogs and relay signals report timeout or aborted instead.");
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  if (result.actualModel) lines.push(`model: ${result.actualModel}`);
+  if (result.contextWindow) lines.push(`context window requested: ${result.contextWindow}`);
+  if (result.sessionId) lines.push(`session id (resume with: --resume ${result.sessionId}): ${result.sessionId}`);
+  if (result.touchedFiles === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${result.touchedFiles.length}`);
+    for (const file of result.touchedFiles.slice(0, 40)) lines.push(`  ${file}`);
+    if (result.touchedFiles.length > 40) lines.push(`  ... and ${result.touchedFiles.length - 40} more`);
+  }
+  if (result.stderrTail?.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("", "--- qoder final report ---", result.finalMessage || "(no final message captured)", "--- end report ---", "");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, rerun the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe stdin)");
+  const briefBytes = Buffer.byteLength(brief, "utf8");
+  if (briefBytes > MAX_BRIEF_BYTES) {
+    fail(`brief is ${Math.round(briefBytes / 1024)}KB; keep large context in workspace files instead of argv`);
+  }
+
+  const run = prepareRunDir(opts, brief);
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const probe = qoderVersion(timeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) return reportUnavailable(writeResult, run.resultPath);
+  if (probe.error) return reportVersionFailure(writeResult, run, probe.error, timeoutMs);
+  dispatch(opts, brief, run, writeResult);
+}
+
+main();

--- a/skills/vibe-delegate/SKILL.md
+++ b/skills/vibe-delegate/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: vibe-delegate
+description: Delegate a coding task to the Mistral Vibe CLI (`vibe`) as a background
+  implementer, then review its diff and land it yourself. Use this whenever the user
+  wants to hand implementation work to Vibe — phrasings like "have Vibe implement
+  X", "delegate this to Vibe", "run it...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+metadata:
+  version: 0.5.0
+---
+# Vibe Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `vibe` implementer (`Mistral Vibe`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Hand a bounded coding task to a separate **implementer** — the Mistral
+Vibe CLI (`vibe`) — then review what it produced and land it yourself. You write the brief and own
+the judgment; Vibe does the typing in its own session; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `vibe` CLI is not installed or authenticated.
+
+## Prerequisites (check once)
+
+1. Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/), then Mistral Vibe:
+   - `uv tool install mistral-vibe`
+2. Configure your API key with `vibe --setup`, or set `MISTRAL_API_KEY` in the environment.
+3. Confirm `vibe --version` succeeds.
+4. Work in, or point `--cd` at, the target git repository.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Vibe sees only the text you send plus what it can inspect in the workspace — no chat history or shared
+context. Include the goal, current state, what to change, what to leave untouched, the project's
+**actual** gates, and a report contract. Tell Vibe not to commit. Keep one task per brief. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+Default mode cannot approve most shell commands headlessly, so the orchestrator runs the gates. Ask
+Vibe to run them only when the human explicitly authorized `--full-access`.
+
+### 2. Dispatch
+
+Use the bundled helper. It wraps Vibe's headless `--prompt` mode, captures the structured event
+stream, and writes `result.json`. (`<skill-dir>` is the installed folder containing this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# limit turns for cost control:           add --max-turns <n>
+# indicative price threshold/token cap:  add --max-price <usd> --max-tokens <n>
+# planning/read-only:                     add --plan-only
+# unrestricted shell and tools:           add --full-access (explicit authorization required)
+# resume the most recent session:         add --resume-last  (delta brief only)
+# resume a specific session:              add --session <id> (delta brief only)
+# see all options:                        node .../relay.mjs --help
+```
+
+The child process's cwd pins the workspace. The relay writes artifacts under the system temp dir by
+default and never commits. See [references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The helper blocks until Vibe finishes. Run it with the orchestrator's background-command facility, or
+background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
+result; a missing `vibe` exits 127 and writes `status: "vibe_unavailable"`.
+The watchdog writes `status: "timeout"`; terminating the relay on POSIX writes `status: "aborted"`
+after stopping Vibe's process tree.
+
+Trust process state and the working tree over a progress display. Completion means the process exited
+and `result.json` exists.
+
+### 4. Review — do not trust the self-report
+
+Treat Vibe's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+See [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates pass
+and the diff holds. If rework is needed, send a delta brief with `--resume-last` or `--session <id>`,
+then review again.
+
+## Autonomy and permissions
+
+In `--prompt` mode the relay always sets the agent profile explicitly:
+
+| Relay flag | What Vibe gets | Use when |
+| --- | --- | --- |
+| *(default)* | `--agent accept-edits` | Normal implementation — built-in file edits are approved |
+| `--plan-only` | `--agent plan` | Read-only review, exploration, or planning |
+| `--full-access` | `--agent auto-approve` | Explicitly authorized runs that need arbitrary shell/tools |
+
+Default mode lets Vibe edit files inside the target worktree. Approval-gated shell commands,
+including most project gates, are denied headlessly; the orchestrator runs the gates.
+`--full-access` disables Vibe's tool approvals and permits arbitrary shell/tool execution under the
+user account; use it only with explicit human authorization. Always inspect `touchedFiles` and the
+diff after a run.
+
+`--trust` is always passed to prevent interactive directory-trust prompts in headless runs. It is
+not a sandbox and does not grant tool permissions.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"), committing
+verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't absorb**
+(report Vibe's design decisions, defensible-but-unasked turns, and non-blocking nitpicks) and **stop
+for scope changes** (if correct completion needs going beyond the brief, ask instead of expanding the
+mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — structure, report contract,
+  real gates, argv delivery, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) — review checklist, commit boundary,
+  and rework through Vibe sessions.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — sequential queues, constraint
+  carry-forward, progress tracking, and the final coherence pass.
+
+
+## Limitations
+
+- Requires the `vibe` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/vibe-delegate/references/dispatch-and-poll.md
+++ b/skills/vibe-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,144 @@
+# Dispatch and poll
+
+`scripts/relay.mjs` wraps Vibe's headless `--prompt` mode, captures its structured stream, and writes
+a `result.json`. Run one command, then read one file.
+
+## Before the first run
+
+```bash
+command -v vibe
+vibe --version
+```
+
+Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/), then install Vibe with
+`uv tool install mistral-vibe`. Configure your API key:
+
+```bash
+vibe --setup                    # interactive setup
+export MISTRAL_API_KEY="..."    # or set it in the environment
+```
+
+Upstream Vibe works on Windows but officially supports and targets UNIX. This repository has not
+smoke-tested the relay's native Windows launch; consult the
+[official Mistral Vibe documentation](https://github.com/mistralai/mistral-vibe) for Windows guidance.
+
+## Dispatching
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+```
+
+`<skill-dir>` is the installed folder containing this skill's `SKILL.md`.
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Brief path. Omit it to read the brief from stdin. |
+| `--cd <dir>` | Working root and child process cwd (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Applies that lane's dials; fails if the lane's `implementer` is not this relay. Explicit dial flags win. |
+| `--max-turns <n>` | Maximum number of Vibe agent turns (`--max-turns`). Useful for cost control. |
+| `--max-price <usd>` | Positive, indicative cost threshold in USD; not a hard budget (`--max-price`). |
+| `--max-tokens <n>` | Positive maximum cumulative session tokens (`--max-tokens`). |
+| `--session <id>` | Resume a specific Vibe session (`--resume SESSION_ID`); send only the delta brief. |
+| `--resume-last` | Resume the most recent Vibe session (`--continue`); send only the delta brief. |
+| `--plan-only` | Use Vibe's read-only `plan` agent. |
+| `--full-access` | Use Vibe's `auto-approve` agent; arbitrary shell/tools run under the user account. |
+| `--enabled-tools <tool>` | Enable only this tool (`--enabled-tools`). Repeatable. |
+| `--disabled-tools <tool>` | Disable this tool (`--disabled-tools`). Repeatable. |
+| `--timeout <dur>` | Relay watchdog (default: `30m`; h/m/s strings). Vibe has no timeout flag. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh directory under the system temp dir). |
+| `-h`, `--help` | Print the relay's header help. |
+
+`--session` and `--resume-last` are mutually exclusive, as are `--plan-only` and `--full-access`.
+The relay always passes `--trust` so headless runs do not prompt for directory trust. That flag is not
+a sandbox or tool permission.
+
+Default mode uses `accept-edits`: Vibe's built-in file edits are approved, while approval-gated shell
+commands — including most project gates — are denied headlessly rather than hanging. The orchestrator
+runs the gates. Use `--full-access` only with explicit human authorization; it selects
+`auto-approve`, which approves all tool executions. Inspect `touchedFiles` and the diff after every run.
+
+## Artifacts and result fields
+
+Artifacts live outside the repo by default, so they do not appear in `touchedFiles`; an `--out-dir`
+inside the worktree can make the artifacts appear there:
+
+- `brief.txt` — the exact brief.
+- `events.jsonl` — raw Vibe stdout in streaming JSON format.
+- `final.txt` — the last non-empty assistant message; absent if none was emitted.
+- `stderr.txt` — complete stderr.
+- `result.json` — the stable `delegate-relay.result.v1` contract.
+
+`result.json` fields:
+
+- `schema`, `tool` (`"vibe"`), `status` (`completed` | `failed` | `timeout` | `aborted` |
+  `vibe_unavailable`), `exitCode`, and `signal` (`null` unless the child died on a signal).
+- `workdir`, `agent` (`"accept-edits"`, `"plan"`, or `"auto-approve"`), `maxTurns`, `maxPrice`,
+  `maxTokens`, `resumed`, `vibeVersion`, `sessionId`, `startedAt`, and `finishedAt`.
+- `briefPath`, `finalPath`, `eventsPath`, and `stderrPath`.
+- `finalMessage` — the last non-empty assistant content string; tool calls and tool results are excluded.
+- `touchedFiles` — `git status --porcelain` lines for the **final working tree under `--cd`**. Not
+  an attribution of Vibe's edits: anything already dirty before dispatch shows up too. Dispatch from
+  a clean tree when you want the list to read as "what Vibe changed". `null` means git could not
+  report; `[]` means git ran and the tree is clean.
+- `stderrTail` — the last 20 non-empty stderr lines on a run that did not complete.
+- `error` — present for launch failures, `timeout`, and `aborted`.
+
+Vibe's streaming output does not expose its session id, so `sessionId` is always `null` for schema
+compatibility. Use `--resume-last`; retain `--session <id>` only for an id obtained outside the relay.
+
+## Waiting for completion
+
+The helper blocks. Use the orchestrator's background-command facility, or background it in a shell and
+poll for `result.json`. The run is done only when the process exits and the file contains a `status`.
+
+A pre-run usage error exits 2 and writes no result. A missing `vibe` exits 127 and writes
+`status: "vibe_unavailable"`.
+
+## When a run misbehaves
+
+- **`status: "vibe_unavailable"` (exit 127):** `vibe` isn't on PATH. Install
+  [`uv`](https://docs.astral.sh/uv/getting-started/installation/), run
+  `uv tool install mistral-vibe`, and configure `MISTRAL_API_KEY`, then re-dispatch.
+- **`status: "failed"`:** read `stderrTail`, `stderrPath`, and the tail of `events.jsonl`. Common
+  causes: an unconfigured or expired API key, an invalid model, or a trust-folder prompt that was
+  not suppressed (the relay passes `--trust`, but check that the binary supports it).
+- **`status: "aborted"`:** the relay itself was killed and terminated Vibe's process tree. Inspect the
+  working tree before re-dispatching. Native Windows has no catchable `SIGTERM`; a relay that vanishes
+  there without `result.json` is an aborted run, so inspect the tree and `events.jsonl` directly.
+- **`status: "failed"` with `signal: "SIGKILL"`:** the host killed the process, commonly through the
+  OOM killer or a supervisor timeout. This is not a Vibe error; check host memory and re-dispatch, or
+  split the task into smaller briefs.
+- **`status: "timeout"`:** `error` reads
+  `vibe did not finish within --timeout <dur>; killed by the relay watchdog`. Increase `--timeout` or
+  split the task. The relay sends SIGTERM, waits 10 seconds, then sends SIGKILL if needed.
+- **Empty `finalMessage`:** inspect `touchedFiles` and the diff. Add a
+  `<structured_output_contract>` to the next brief to require a closing report. The streaming events
+  in `events.jsonl` are the source of truth for diagnosing missing messages.
+
+## Recovering lost work
+
+`events.jsonl` records every message Vibe streamed. If finished work is lost — the run ended late or
+the tree was damaged afterward — read it before re-dispatching to scope which files and tools were
+involved. It may not contain the edit contents, so treat reconstruction as unverified until it matches
+a working-tree diff; when the tree still holds the work, preserve the tree rather than replaying the log.
+
+## What the relay runs
+
+The argv is equivalent to:
+
+```bash
+vibe --output streaming --agent <accept-edits|plan|auto-approve> --trust \
+  [--max-turns <n>] [--max-price <usd>] [--max-tokens <n>] \
+  [--resume SESSION_ID | --continue] \
+  [--enabled-tools TOOL ...] [--disabled-tools TOOL ...] \
+  --prompt=<brief>
+```
+
+The prompt rides argv and is visible in the host process list. The relay rejects briefs over 120 KB
+on POSIX or 12 KB on Windows before launch because the platforms cap command arguments. It spawns the
+native `vibe` binary directly with `--cd` as cwd; no shell or Vibe timeout flag is involved.
+
+## The commit boundary
+
+The relay never commits. Vibe edits the working tree; the orchestrator reviews, re-runs the gates, and
+commits. See [review-and-land.md](review-and-land.md).

--- a/skills/vibe-delegate/references/multi-task-queues.md
+++ b/skills/vibe-delegate/references/multi-task-queues.md
@@ -1,0 +1,59 @@
+# Multi-task queues
+
+The single-task loop scales to a queue: a removal across layers, a migration across files, or a
+refactor sweep. Sequencing and bookkeeping make it trustworthy.
+
+## Run sequentially, one commit per task
+
+Run tasks **one at a time, in dependency order**, landing each after review and gates before
+dispatching the next:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief task-01.txt --cd /path/to/repo
+```
+
+- Later briefs can rely on earlier work only after it lands.
+- One commit per task keeps history reviewable and each step revertible.
+- A clean tree before each dispatch keeps `touchedFiles` honest.
+
+Use parallel runs only for genuinely independent tasks in separate working trees. Sequential is the
+default because it preserves clean task boundaries.
+
+## Carry decided constraints forward
+
+Fresh Vibe sessions do not remember earlier tasks. If task 2 chooses a helper name, fixture location,
+or interface that task 5 needs, write that fact into task 5's brief.
+
+Use a resumed Vibe session only for rework on the same task. Send a delta brief with `--resume-last`;
+use `--session <id>` only for an id obtained outside the relay because Vibe's stream does not expose
+one. Start unrelated queue items in fresh sessions.
+
+## Keep a progress file
+
+For more than two or three tasks, maintain one progress file beside the work:
+
+- **Status table** — queued / at-implementer / reviewed+committed, with the commit hash.
+- **Per-task review notes** — what landed, what you verified, and gate outcomes.
+- **Needs your eyes** — design decisions, non-blocking nitpicks, and questions for the human.
+- **End-of-run checklist** — the final cross-task verification.
+
+Update it when each task lands, not in one batch at the end.
+
+## Close with a coherence check
+
+After the last task:
+
+- Run the full test/build once more.
+- Search repo-wide for the thing the queue changed.
+- Replay migrations from a clean state and check drift when applicable.
+- Push and open or update the PR only after the final tree is coherent.
+
+## When to stop and ask
+
+Proceed on work that follows from the agreed plan. Stop and surface when:
+
+- A task cannot be completed correctly within its brief.
+- Review calls the plan itself into question.
+- Gates reveal a problem affecting already-landed tasks.
+
+Report the landed state, commit hashes, and open question, then wait.

--- a/skills/vibe-delegate/references/review-and-land.md
+++ b/skills/vibe-delegate/references/review-and-land.md
@@ -1,0 +1,87 @@
+# Review and land
+
+Vibe did the typing; you own the judgment. Verify against reality, never the self-report, and read the
+diff as generated code because a green gate cannot catch every failure mode.
+
+## Check tests before trusting gates
+
+If the diff touches existing tests, review those edits first:
+
+- Treat unbriefed test edits as a contract change, not part of the fix.
+- Treat newly skipped, disabled, or commented-out tests as failing until proven otherwise.
+- Treat loosened assertions the same way: contains/truthy replacing exact matches, broadened error
+  types, and widened tolerances all weaken the gate.
+
+## Re-run the gates yourself
+
+`result.json` carries Vibe's claims, not evidence. Re-run the project's actual test, lint, and build
+commands in the working tree and read their output. Passing is necessary, not sufficient.
+
+For changes with a specialized verification shape:
+
+- **Migrations or schema:** round-trip them and check for drift.
+- **Removals or renames:** grep for dangling references.
+- **Stateful behavior:** exercise the behavior, not just compilation.
+
+## Read the diff against the brief
+
+Start with `touchedFiles`, open the diff, and compare it to the brief:
+
+- **Scope creep** — changes the brief excluded.
+- **Scope shortfall** — missed behavior, edges, or cleanup.
+- **Quiet judgment calls** — defensible but unasked decisions that need review.
+
+## The implementer sweep
+
+Check every diff for patterns gates often miss:
+
+- Hardcoded success or fixture data on a real-work path.
+- Catch-all error handling that returns a default instead of propagating or recovering.
+- Imports, dependencies, methods, and signatures not present in the installed version.
+- Unused imports, uncalled helpers, unreachable branches, and scaffolding comments.
+- A second client, error idiom, or logging style beside the repo's existing one.
+- Tests that assert internals instead of behavior, or near-duplicate test bodies.
+- Optional parameters, config flags, and abstractions with no caller.
+- Guards for impossible cases that hide trust-boundary validation.
+
+Send anything blocking back to Vibe as a delta brief, or fix it in the tree, and report either choice
+to the human. Run relevant guard skills if installed.
+
+## The commit boundary
+
+When the gates pass and the diff holds, **the orchestrator commits**, never the implementer. Write a
+clear message describing what landed.
+
+From dispatch until that commit, the uncommitted working tree is the authoritative copy of Vibe's
+work. Never reflexively run `git checkout`, `reset`, `clean`, or switch branches after an interrupted
+run. Inspect `git status`, `git diff`, `git diff --cached` for staged changes, and open every untracked
+file (`??`) directly because no diff shows its contents. After inspection, discarding a bad or
+premise-contaminated change can be correct; the rule is to preserve the evidence until it is reviewed.
+
+## Rework: send the delta
+
+Continue the same session with only the correction:
+
+```bash
+echo "The fix is right, but the test mocks the DB session. Use the real migrated fixture and remove
+the unused import." | node "<skill-dir>/scripts/relay.mjs" --resume-last --cd /path/to/repo
+```
+
+Vibe's stream does not expose a session id, so use `--resume-last` normally. Use `--session <id>` only
+when the id came from outside the relay. Rework gets the same gate rerun, test review, diff review, and
+implementer sweep.
+
+Default `accept-edits` runs cannot execute most gates headlessly; the orchestrator runs them.
+`--full-access` permits arbitrary shell/tool execution and requires explicit human authorization.
+
+## Surface, do not absorb
+
+The human opted into delegation, so committing verified, gate-passing work is the contract. Keep them
+in the loop when the work changes shape:
+
+- Report design decisions and defensible-but-unrequested turns.
+- Note non-blocking nitpicks you did not block on.
+- Stop and ask if correct completion requires going beyond the brief.
+
+For a queue, keep these notes in the progress file described in
+[multi-task-queues.md](multi-task-queues.md).

--- a/skills/vibe-delegate/references/writing-the-brief.md
+++ b/skills/vibe-delegate/references/writing-the-brief.md
@@ -1,0 +1,131 @@
+# Writing the brief
+
+A brief is the entire task as Vibe will see it. It runs in a separate session with **no memory of your
+conversation, no access to prior notes, and no shared context** — only the text you send and whatever
+it can inspect in the workspace. If a constraint is not in the brief or discoverable in the repo, it
+does not exist for Vibe.
+
+## Resumed sessions
+
+A resumed run keeps the session context. Send only the delta brief with `--resume-last` or
+`--session <id>`.
+
+## The shape that works
+
+Use a compact, block-structured brief. State the task, what done means, the few constraints that
+matter, and the report Vibe must return.
+
+```xml
+<task>
+One or two sentences: the concrete job and where it lives. Then the specifics — current state, what to
+change, and explicitly what to leave untouched. The leave-untouched list prevents unrelated refactors.
+</task>
+
+<verification_loop>
+These are the real project gates the orchestrator will run after dispatch:
+  <the project's real test command>
+  <the project's real lint/format command>
+  <the project's real build/typecheck command>
+If shell execution was explicitly authorized for this run, run them and fix what they surface.
+Otherwise do not claim they ran; perform the inspections available to you and report the gates as not run.
+</verification_loop>
+
+<action_safety>
+Keep changes scoped to the task. No unrelated refactors, renames, or cleanup unless required for
+correctness. Do NOT run git add or git commit — the orchestrator commits after reviewing. Leave the
+work uncommitted in the working tree.
+</action_safety>
+
+<structured_output_contract>
+End with a report in this exact shape:
+  1. What changed and why
+  2. Files touched
+  3. Gate outcomes with counts, or exactly which gates were not run
+  4. Anything you deviated on, left open, or want a decision on
+</structured_output_contract>
+```
+
+Add extra blocks only when the task needs them:
+
+- **Debugging or open-ended fixes** — add `<completeness_contract>` (resolve fully, not just the
+  first plausible cause) and `<missing_context_gating>` (find missing repo facts or state what is
+  unknown).
+- **Research or recommendations** — add `<research_mode>` (separate observed facts, inferences, and
+  open questions).
+
+## Always ask for the report explicitly
+
+The relay uses Vibe's last non-empty assistant message as `finalMessage`. Without a
+closing summary, the edits may exist but the result is hard to review. The
+`<structured_output_contract>` block makes the expected report explicit.
+
+## Discover the real gates
+
+Read the repo's `AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, or equivalent first and copy the
+actual commands into `<verification_loop>`. Default `accept-edits` runs cannot execute most gates
+headlessly, but naming them lets the orchestrator run the same commands after dispatch. Ask Vibe to
+run them only when the human explicitly authorized `--full-access`.
+
+## Honor repo conventions
+
+Restate the load-bearing house rules in the brief. Vibe can inspect the workspace, but the important
+constraints should be directly in front of it.
+
+## One task per brief
+
+Keep each brief bounded. One brief → one Vibe run → one reviewed commit keeps the diff and rollback
+clean. Split mixed implementation, review, documentation, and roadmap requests into separate
+dispatches.
+
+## Premises freeze at dispatch
+
+Vibe starts from the brief's facts and there is no steering channel mid-run. Audit ownership, target
+branch, constraints, and other judgment-bearing premises before dispatch. If one proves wrong while
+the run is live, stop it and inspect the working tree before sending a corrected brief; reconcile any
+partial or premise-contaminated edits rather than discounting them after the fact.
+
+## A worked example
+
+```xml
+<task>
+In the payments service at services/billing/, the refund path double-charges when a refund is retried
+after a network timeout. Make refund submission idempotent: check for an existing refund by idempotency
+key before creating a new one. Touch only services/billing/refund.py and its tests. Leave the charge
+path, API routes, and data models untouched.
+</task>
+
+<verification_loop>
+The orchestrator will run:
+  pytest tests/billing/ -q
+  ruff check services/billing/
+If shell execution is authorized for this run, run them and fix failures. Otherwise report them as
+not run and confirm only refund.py and its test file changed.
+</verification_loop>
+
+<action_safety>
+Scope strictly to the refund idempotency fix. No unrelated refactors. Do NOT git add or commit; leave
+changes in the working tree for review.
+</action_safety>
+
+<structured_output_contract>
+Report: (1) the root cause and fix, (2) files touched, (3) pytest and ruff outcomes with counts or
+that they were not run,
+(4) anything left open or needing a decision.
+</structured_output_contract>
+```
+
+## Argv delivery limits
+
+Vibe's headless mode requires the brief as a command-line argument via `--prompt`. The relay reads a
+file or stdin for convenience, then passes the text with `--prompt=<brief>`. The equals form binds a
+brief that starts with `-` instead of treating it as another flag.
+
+This has two consequences:
+
+- The brief is visible in the host process list (`ps`, `/proc`). Keep secrets out of it on shared
+  machines; reference workspace files or environment variables instead.
+- A brief over 120 KB on POSIX or 12 KB on Windows is rejected before launch because the platforms
+  cap command arguments. Put large context in the workspace and tell Vibe which file to read.
+
+Dispatch with [dispatch-and-poll.md](dispatch-and-poll.md), then review and commit with
+[review-and-land.md](review-and-land.md).

--- a/skills/vibe-delegate/scripts/relay.mjs
+++ b/skills/vibe-delegate/scripts/relay.mjs
@@ -1,0 +1,756 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · vibe-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Mistral Vibe CLI (`vibe --prompt`),
+ * capture the run, and write a structured result the orchestrating agent can
+ * review. The orchestrator runs this one command and reads the result JSON —
+ * every Vibe-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `vibe`, `git`, and Windows `taskkill` for
+ * process-tree termination. The `vibe` process it launches does authenticate —
+ * exactly as you do at the terminal. Read this file before you run it.
+ *
+ * Note: `vibe --prompt` takes the prompt as a command-line argument, so the
+ * brief is visible in the host process list (`ps`, /proc). On a shared machine
+ * keep secrets out of the brief — reference them by a path or environment
+ * variable the workspace can read.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Default mode uses Vibe's `accept-edits` agent, which auto-approves its
+ * built-in file edits while other tools remain unapproved in headless mode.
+ * `--full-access` explicitly opts into `auto-approve`; `--plan-only` selects
+ * Vibe's read-only `plan` agent.
+ *
+ * Upstream Vibe works on Windows but officially supports and targets UNIX. This
+ * repository has not smoke-tested the relay's native Windows launch.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>           Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>               Working root for Vibe (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --max-turns <n>          Maximum number of Vibe agent turns (--max-turns).
+ *   --max-price <usd>        Indicative cost threshold in USD (--max-price);
+ *                            not a hard budget.
+ *   --max-tokens <n>         Maximum cumulative session tokens (--max-tokens).
+ *   --session <id>           Resume a specific Vibe session (--resume SESSION_ID);
+ *                            send only the delta brief.
+ *   --resume-last            Resume the most recent Vibe session (--continue);
+ *                            send only the delta brief.
+ *   --plan-only              Use Vibe's read-only plan agent.
+ *   --full-access            Use Vibe's auto-approve agent; all tool executions
+ *                            are approved. Mutually exclusive with --plan-only.
+ *   --enabled-tools <tool>   Enable only this tool (--enabled-tools). Repeatable.
+ *   --disabled-tools <tool>  Disable this tool (--disabled-tools). Repeatable.
+ *   --timeout <dur>          Relay-side watchdog (default: 30m). Vibe has no
+ *                            timeout flag; durations use h/m/s strings.
+ *   --out-dir <dir>          Where to write run artifacts (default: a fresh dir
+ *                            under the system temp dir).
+ *   -h, --help               Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, vibeVersion, agent, finalMessage (the last
+ *   assistant message), touchedFiles (git porcelain, null if git cannot report),
+ *   and paths to brief.txt, final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `vibe` binary exits 127;
+ * otherwise the exit code mirrors Vibe's own (0 success, non-zero failure). If
+ * the child dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the run artifacts are prepared,
+ * `result.json` is written on every outcome — completed, failed, timeout, aborted, or
+ * vibe_unavailable.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const MAX_BRIEF_BYTES = (process.platform === "win32" ? 12 : 120) * 1024;
+const PROBE_TIMEOUT_MS = 10_000;
+
+const IMPLEMENTER_KEY = "vibe";
+
+function makeLineScanner(onObject) {
+  let buf = "";
+  return (chunk) => {
+    if (!chunk) return;
+    let start = 0;
+    for (;;) {
+      const end = chunk.indexOf("\n", start);
+      if (end === -1) break;
+      const line = buf + chunk.slice(start, end);
+      buf = "";
+      const trimmed = line.trim();
+      if (trimmed) {
+        try { onObject(JSON.parse(trimmed)); } catch { /* skip non-JSON lines */ }
+      }
+      start = end + 1;
+    }
+    buf += chunk.slice(start);
+    if (buf.length > MAX_BUFFERED_CHARS) buf = "";
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (
+      field === "planOnly" &&
+      (flagged.has("planOnly") || flagged.has("readOnly") || flagged.has("fullAccess"))
+    ) {
+      continue;
+    }
+    if (
+      field === "readOnly" &&
+      (flagged.has("readOnly") || flagged.has("fullAccess"))
+    ) {
+      continue;
+    }
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    maxTurns: null,
+    maxPrice: null,
+    maxTokens: null,
+    session: null,
+    resumeLast: false,
+    planOnly: false,
+    fullAccess: false,
+    enabledTools: [],
+    disabledTools: [],
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--max-turns": {
+        const v = next();
+        const n = Number(v);
+        if (!/^[1-9]\d*$/.test(v) || !Number.isSafeInteger(n)) {
+          fail(`--max-turns must be a positive safe integer; got: ${v}`);
+        }
+        opts.maxTurns = n;
+        break;
+      }
+      case "--max-price": {
+        const v = next();
+        const n = Number(v);
+        if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(v) || !Number.isFinite(n) || n <= 0) {
+          fail(`--max-price must be a positive decimal number; got: ${v}`);
+        }
+        opts.maxPrice = n;
+        break;
+      }
+      case "--max-tokens": {
+        const v = next();
+        const n = Number(v);
+        if (!/^[1-9]\d*$/.test(v) || !Number.isSafeInteger(n)) {
+          fail(`--max-tokens must be a positive safe integer; got: ${v}`);
+        }
+        opts.maxTokens = n;
+        break;
+      }
+      case "--session": opts.session = next(); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--plan-only": opts.planOnly = true; flagged.add("planOnly"); flagged.add("readOnly"); break;
+      case "--full-access":
+        opts.fullAccess = true;
+        flagged.add("fullAccess");
+        flagged.add("planOnly");
+        flagged.add("readOnly");
+        break;
+      case "--enabled-tools": opts.enabledTools.push(next()); break;
+      case "--disabled-tools": opts.disabledTools.push(next()); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  if (opts.resumeLast && opts.session) {
+    fail("--resume-last and --session are mutually exclusive; pass only one");
+  }
+  if (opts.session !== null && !opts.session.trim()) fail("--session must not be empty");
+  if (opts.planOnly && opts.fullAccess) {
+    fail("--plan-only and --full-access are mutually exclusive");
+  }
+  if (opts.enabledTools.some((tool) => !tool.trim())) fail("--enabled-tools must not be empty");
+  if (opts.disabledTools.some((tool) => !tool.trim())) fail("--disabled-tools must not be empty");
+  // The watchdog is relay-only (vibe has no timeout flag), so a malformed
+  // --timeout must fail loudly here — a silent 30m fallback would be wrong.
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  try {
+    if (!statSync(opts.cd).isDirectory()) fail(`--cd is not a directory: ${opts.cd}`);
+  } catch {
+    fail(`--cd directory not found: ${opts.cd}`);
+  }
+  if (opts.outDir && existsSync(opts.outDir)) {
+    try {
+      if (!statSync(opts.outDir).isDirectory()) fail(`--out-dir is not a directory: ${opts.outDir}`);
+    } catch {
+      fail(`cannot inspect --out-dir: ${opts.outDir}`);
+    }
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to vibe --prompt\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function vibeVersion(timeoutMs) {
+  try {
+    return {
+      version: execFileSync("vibe", ["--version"], {
+        encoding: "utf8",
+        timeout: Math.min(timeoutMs, PROBE_TIMEOUT_MS),
+        killSignal: "SIGKILL",
+      }).trim() || "unknown",
+      error: null,
+    };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    return { version: null, error };
+  }
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function agentName(opts) {
+  if (opts.planOnly) return "plan";
+  if (opts.fullAccess) return "auto-approve";
+  return "accept-edits";
+}
+
+function buildArgv(opts, brief) {
+  const argv = [
+    "--output", "streaming",
+    "--agent", agentName(opts),
+    "--trust",
+  ];
+  if (opts.maxTurns != null) argv.push("--max-turns", String(opts.maxTurns));
+  if (opts.maxPrice != null) argv.push("--max-price", String(opts.maxPrice));
+  if (opts.maxTokens != null) argv.push("--max-tokens", String(opts.maxTokens));
+  if (opts.session) argv.push("--resume", opts.session);
+  else if (opts.resumeLast) argv.push("--continue");
+  for (const tool of opts.enabledTools) argv.push("--enabled-tools", tool);
+  for (const tool of opts.disabledTools) argv.push("--disabled-tools", tool);
+  // Use --prompt=<brief>, not a separate ["--prompt", brief] pair: the equals
+  // form binds a brief that starts with "-" instead of letting it parse as a flag.
+  argv.push(`--prompt=${brief}`);
+  return argv;
+}
+
+function extractFromEvent(obj, textChunks) {
+  if (!obj || typeof obj !== "object") return;
+
+  // Primary format: { role: "assistant", content: "..." }
+  if (obj.role === "assistant") {
+    const content =
+      typeof obj.content === "string"
+        ? obj.content
+        : Array.isArray(obj.content)
+          ? obj.content
+              .filter((c) => c && c.type === "text")
+              .map((c) => (typeof c.text === "string" ? c.text : ""))
+              .join("")
+          : "";
+    if (content) textChunks.push(content);
+    return;
+  }
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir =
+    opts.outDir ||
+    join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "vibe",
+      workdir: opts.cd,
+      agent: agentName(opts),
+      maxTurns: opts.maxTurns,
+      maxPrice: opts.maxPrice,
+      maxTokens: opts.maxTokens,
+      resumed: Boolean(opts.resumeLast || opts.session),
+      sessionId: null,
+      vibeVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(opts, writeResult, resultPath) {
+  const result = writeResult({
+    status: "vibe_unavailable",
+    exitCode: 127,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+  });
+  printSummary(result, resultPath);
+  process.stderr.write(
+    "relay: `vibe` not found on PATH. Install `uv`, run `uv tool install mistral-vibe`, and configure MISTRAL_API_KEY.\n",
+  );
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, timeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `vibe --version preflight timed out after ${Math.min(timeoutMs, PROBE_TIMEOUT_MS)}ms; Vibe was not dispatched`
+    : `vibe --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; Vibe was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    ...(stderr ? { stderrTail: stderr.split("\n").slice(-20) } : {}),
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the vibe version preflight; Vibe was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.off(sig, handler);
+  };
+}
+
+function dispatchToVibe(opts, brief, run, writeResult, onReady) {
+  const child = spawn("vibe", buildArgv(opts, brief), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32",
+  });
+
+  const textChunks = [];
+  const stderrTail = [];
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  const scan = makeLineScanner((obj) => extractFromEvent(obj, textChunks));
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textChunks.at(-1) || "";
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const exitCode = 128 + (constants.signals[sig] || 15);
+      let finalized = false;
+      const finishAbort = () => {
+        if (finalized) return;
+        finalized = true;
+        if (sigkillTimer) clearTimeout(sigkillTimer);
+        killChild(child, "SIGKILL");
+        const result = writeResult({
+          status: "aborted",
+          exitCode,
+          signal: sig,
+          finalMessage: assembleFinal(),
+          touchedFiles: gitTouchedFiles(opts.cd),
+          stderrTail: stderrTail.slice(-20),
+          error: `the relay was killed by ${sig}; vibe was terminated with it — inspect the working tree before re-dispatching`,
+        });
+        printSummary(result, run.resultPath);
+        process.exit(exitCode);
+      };
+      child.once("exit", finishAbort);
+      killChild(child);
+      sigkillTimer = setTimeout(finishAbort, 2000);
+    });
+  }
+  onReady();
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // Force a delimiter so a final event without a trailing newline still parses:
+    // the line scanner retains an un-newlined tail, and end() alone can hand it "".
+    scan(`${stdoutDecoder.end()}\n`);
+    const stderrEnd = stderrDecoder.end();
+    if (stderrEnd.trim()) stderrTail.push(stderrEnd.trimEnd());
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired
+        ? {
+            error: `vibe did not finish within --timeout ${opts.timeout}; killed by the relay watchdog`,
+          }
+        : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+  if (brief.includes("\0")) fail("brief contains a NUL byte, which cannot be passed in --prompt");
+
+  // vibe --prompt takes the prompt as a CLI argument, so the brief rides argv.
+  // The OS caps command arguments; reject a huge brief before an opaque spawn
+  // failure (Windows has the smaller limit).
+  const briefBytes = Buffer.byteLength(brief, "utf8");
+  if (briefBytes > MAX_BRIEF_BYTES) {
+    fail(
+      `brief is ${Math.round(briefBytes / 1024)}KB; keep large context in workspace files instead of argv`,
+    );
+  }
+
+  const run = prepareRunDir(opts, brief);
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  let writeResult = makeResultWriter(opts, null, run);
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult);
+  const probe = vibeVersion(timeoutMs);
+  // execFileSync defers JS signal handlers; yield once so a signal received
+  // during the bounded preflight becomes "aborted" before any dispatch.
+  await new Promise((resolve) => setImmediate(resolve));
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    return reportUnavailable(opts, writeResult, run.resultPath);
+  }
+  if (probe.error) {
+    clearPreflightSignals();
+    return reportVersionFailure(opts, writeResult, run, probe.error, timeoutMs);
+  }
+  dispatchToVibe(opts, brief, run, writeResult, clearPreflightSignals);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(
+    `relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  vibe ${result.vibeVersion ?? "?"}`,
+  );
+  if (result.signal === "SIGKILL" && result.status === "failed") {
+    lines.push(
+      "hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a vibe error; check host memory and re-dispatch, or split the task into smaller briefs.",
+    );
+  }
+  if (result.signal === "SIGTERM" && result.status === "failed") {
+    lines.push(
+      "hint: something outside the relay terminated vibe; relay watchdogs and relay signals report timeout or aborted instead.",
+    );
+  }
+  if (result.resumed) lines.push("mode: resumed an existing session");
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- vibe final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push(
+    "relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.",
+  );
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/warp-delegate/SKILL.md
+++ b/skills/warp-delegate/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: warp-delegate
+description: Delegate a coding task to the Warp Agent CLI (`oz`) as a background implementer,
+  then review its diff and land it yourself. Use this whenever the user wants to hand
+  implementation work to Warp - phrasings like "have Warp implement X", "delegate
+  this to the Warp CLI", "run it...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `oz` CLI (Warp Agent CLI) installed and authenticated
+  (`oz login`, or `WARP_API_KEY` for a headless host; Warp AI features need an eligible
+  Warp plan or your own provider key), Node 18+, and git. The orchestrating agent
+  must be able to run shell commands and read files. Shell examples assume bash/zsh
+  (macOS/Linux, or Git Bash/WSL on Windows).
+metadata:
+  version: 0.5.0
+---
+# Warp Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `warp` implementer (`Warp Agent CLI`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. Delegate a bounded coding task to a separate **implementer** - the
+Warp Agent CLI - then review what it produced and land it yourself. You write the brief and own the
+judgment; the implementer makes changes in its own conversation; you verify and commit.
+
+The loop needs only a shell command and file access, so any comparable orchestrator can drive it.
+
+## The binary is `oz`, not `warp`
+
+Warp ships two different programs, and only one of them can be delegated to:
+
+- **`oz`** - the Warp Agent CLI. Headless and scriptable; `oz agent run` executes an agent against a
+  local directory. **This is what the relay drives.**
+- **`warp`** - the interactive Warp TUI. It requires a terminal device, has no prompt or print flag
+  (its only options are `--resume`, `--auto-approve`, `--api-key`, and the provider-key commands),
+  and exits with `Device not configured` when stdin is a pipe. It cannot be relayed.
+
+If `oz` is missing but `warp` is installed, you have the TUI, not the CLI.
+
+## When NOT to use this
+
+- The task is small enough to do inline; delegation overhead is not worth it.
+- The `oz` CLI is not installed or authenticated.
+- You need a sandboxed or read-only implementer. `oz agent run` has **no sandbox, no permission
+  mode, and no read-only run** - see [Autonomy and permissions](#autonomy-and-permissions).
+- The work must stay off Warp's servers. `oz agent run` uploads an end-of-run workspace snapshot
+  unless `--no-snapshot` is passed, and conversations live server-side.
+
+## Prerequisites (check once)
+
+1. Install the Warp Agent CLI - see <https://docs.warp.dev/cli/>.
+2. Authenticate: `oz login`, or set `WARP_API_KEY` for CI, a container, or any headless host.
+3. Confirm the account has AI quota. **A working login is not enough** - unlike the other CLIs in
+   this package. `oz whoami` can succeed while every dispatch fails with `In order to use Warp's AI
+   features, subscribe to a Warp plan, or bring your own inference.` Warp records this internally as
+   `QuotaLimit` / "lack of AI quota", so it is a credit condition on the account rather than a
+   CLI-specific entitlement: `oz` runs the same agent harness as the Warp app and draws on the same
+   account, plan, and credits. Check that `oz whoami` names the account holding the plan - if it
+   does not, `oz logout && oz login` fixes it. Otherwise confirm the plan's AI credits are not
+   spent, or store your own provider key -
+   `warp --set-provider-api-key <openai|anthropic|google|grok>`, or `/api-keys` inside the TUI.
+   Bring-your-own-key needs no paid Warp plan.
+4. Confirm `oz --version` succeeds and `oz whoami` prints your user.
+5. Work in, or point `--cd` at, the target git repository.
+
+On macOS the CLI is distributed as a signed Developer ID binary; a first run may be held by
+Gatekeeper until it is approved.
+
+## Choose the model (optional)
+
+Omit `--model` to use Warp's configured default. To pick another, choose an id from `oz model list`
+and pass it verbatim. The relay accepts letters, digits, and `. _ : / -` only, so a value cannot be
+mistaken for another `oz` flag.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 require judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+Warp sees only the text you send plus what it can inspect in the workspace - no chat history or
+shared context. Include the goal, current state, what to change, what to leave untouched, the
+project's **actual** gates, and a report contract. Tell it not to commit. Keep one task per brief.
+The brief is delivered as the `--prompt` value on argv, so it is visible in the host process list -
+keep secrets out of it and reference workspace files instead. See
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+Use the bundled relay. It runs `oz agent run --output-format ndjson`, captures the event stream, and
+writes `result.json`. (`<skill-dir>` is the installed folder containing this `SKILL.md`.)
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# choose a model:                          add --model <id from oz model list>
+# use an agent profile:                    add --profile <id>
+# label the run:                           add --name <label>
+# continue an existing conversation:       add --conversation <id> (delta brief only)
+# base the run on a Warp skill:            add --skill <name|repo:name|org/repo:name>
+# start MCP servers:                       add --mcp <path-or-inline-json>  (repeatable)
+# suppress the workspace snapshot upload:  add --no-snapshot
+# hard time limit (watchdog):              add --timeout 2h  (the 30m default suits short runs; implementation briefs routinely need 1-2h)
+# see all options:                         node .../relay.mjs --help
+```
+
+The relay pins the workspace with both the child process's cwd and Warp's own `--cwd`. It writes
+artifacts under the system temp dir by default and never commits. See
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until `oz` finishes. Run it with the orchestrator's background-command facility, or
+background it in the shell and poll for `result.json`. A pre-run usage error exits 2 and writes no
+result; a missing `oz` exits 127 and writes `status: "warp_unavailable"`.
+
+Trust process state and the working tree over a progress display. Completion means the process
+exited and `result.json` exists. Warp's report is the `finalMessage` field in `result.json` (also
+printed on stdout between the report markers); the raw event stream is always in `events.jsonl`.
+
+### 4. Review - do not trust the self-report
+
+Treat Warp's final message and gate claims as claims:
+
+- Re-run the project's gates yourself.
+- Read the diff against the brief, starting with `touchedFiles`.
+- Run relevant guard skills if installed.
+- Round-trip migrations and grep for dangling references after removals or renames.
+
+Because there is no read-only mode to fall back on, the diff is the **only** record you get - and it
+records what git can see in the workspace afterward, not everything the run did. Dispatch from a
+clean tree so the two are as close as they can be. See
+[references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+The implementer edits the working tree; **the orchestrator commits.** Commit only after the gates
+pass and the diff holds. If rework is needed, send a delta brief with `--conversation <id>` using the
+`conversationId` from `result.json`, then review again.
+
+## Autonomy and permissions
+
+`oz agent run` has **no sandbox, no permission mode, and no read-only mode**. A headless run reads,
+writes, edits, and executes commands with your own user permissions and never prompts. There is
+nothing in the CLI to restrict that surface, so this relay ships no `--read-only` flag - offering one
+would imply an enforcement that does not exist. The controls you actually have are:
+
+1. **Scope by directory.** `--cd` pins the workspace, and the relay passes it to Warp's own `--cwd`.
+   Treat this as *aim*, not a fence: on oz 0.2026.05.27 shell commands did run in the pinned
+   workspace, but the agent's file tool resolved bare relative paths against `$HOME`. Name absolute
+   paths in the brief - see [references/writing-the-brief.md](references/writing-the-brief.md).
+2. **Review the diff.** `touchedFiles` is `git status --porcelain` taken after the run - post-run,
+   git-visible worktree state, not a log of what the agent did. It cannot show an ignored file, an
+   edit the run made and then reverted, or a write outside the repository (see item 1), and it
+   carries anything that was already dirty before dispatch. Dispatch from a clean tree so those are
+   the same set, and treat the diff as the best available record, not a complete one.
+3. **Snapshot egress.** `--no-snapshot` forwards Warp's flag so the end-of-run workspace snapshot is
+   not uploaded. Without it, the upload is Warp's default.
+
+`--auto-approve` belongs to the interactive `warp` TUI and has no bearing on `oz agent run`.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have ("run this queue", "proceed"),
+committing verified, gate-passing work is the agreed contract. Two limits remain: **surface, don't
+absorb** (report Warp's design decisions, defensible-but-unasked turns, and non-blocking nitpicks)
+and **stop for scope changes** (if correct completion needs going beyond the brief, ask instead of
+expanding the mandate). See [references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) - structure, report contract,
+  real gates, argv delivery, and delta briefs.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) - flags, artifacts,
+  `result.json`, polling, and failure recovery.
+- [references/review-and-land.md](references/review-and-land.md) - review checklist, commit
+  boundary, and rework through Warp conversations.
+- [references/multi-task-queues.md](references/multi-task-queues.md) - sequential queues,
+  constraint carry-forward, progress tracking, and the final coherence pass.
+
+
+## Limitations
+
+- Requires the `warp` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/warp-delegate/references/dispatch-and-poll.md
+++ b/skills/warp-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,163 @@
+# Dispatch and poll
+
+The relay is the only Warp-specific machinery in this skill. It launches `oz agent run`, captures
+the event stream, and writes one result file the orchestrator can read.
+
+## What the relay runs
+
+```text
+oz agent run --output-format ndjson --cwd <cd> [--model …] [--profile …] [--name …]
+             [--conversation …] [--skill …] [--mcp … …] [--no-snapshot] --prompt <brief>
+```
+
+`--output-format ndjson` makes Warp emit one JSON object per line, so a long run reports progress
+instead of buffering to the end. The workspace is pinned twice: the child process's cwd and Warp's
+own `--cwd`.
+
+## Flags
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Path to the brief. Omit to read it from stdin. |
+| `--cd <dir>` | Working root (default: current directory). Also passed as Warp's `--cwd`. |
+| `--lane <name>` | Resolve dials from a `delegate-setup` fleet lane. Explicit flags win. |
+| `--model <id>` | Warp model id from `oz model list`. Letters, digits, and `. _ : / -` only. |
+| `--profile <id>` | Warp agent profile. |
+| `--name <label>` | Labels the run in Warp's own run list. |
+| `--conversation <id>` | Continue an existing Warp conversation. Send a delta brief only. |
+| `--skill <spec>` | Warp skill as the base prompt: `name`, `repo:name`, or `org/repo:name`. |
+| `--mcp <spec>` | MCP config path or inline JSON. Repeatable. |
+| `--no-snapshot` | Forward Warp's `--no-snapshot` so no end-of-run workspace snapshot is uploaded. |
+| `--timeout <dur>` | Relay watchdog, h/m/s (default `30m`). Warp has no timeout flag of its own. |
+| `--out-dir <dir>` | Artifact directory (default: a fresh dir under the system temp dir). |
+
+Values for `--model`, `--profile`, and `--conversation` are token-validated. `--skill`, `--mcp`, and
+`--name` accept freer text but must not start with `-`, which `oz` would read as another flag.
+
+## Artifacts
+
+Written to `--out-dir`:
+
+- `brief.txt` — exactly what was sent.
+- `events.jsonl` — the raw ndjson stream, byte for byte. The fallback whenever a parsed field looks
+  wrong.
+- `final.txt` — the assembled report, when one was captured.
+- `stderr.txt` — everything Warp wrote to stderr.
+- `result.json` — the structured result, written atomically via a temp file and rename, so a polling
+  reader never sees a half-written file.
+
+## `result.json`
+
+Schema id `delegate-relay.result.v1`. Synthetic example:
+
+```json
+{
+  "schema": "delegate-relay.result.v1",
+  "tool": "oz",
+  "status": "completed",
+  "exitCode": 0,
+  "signal": null,
+  "ozVersion": "Oz v0.0000.00.00.00.00.stable_01",
+  "workdir": "/path/to/repo",
+  "model": null,
+  "profile": null,
+  "snapshotDisabled": false,
+  "resumed": false,
+  "runId": "00000000-0000-0000-0000-000000000000",
+  "runUrl": "https://oz.warp.dev/runs/00000000-0000-0000-0000-000000000000",
+  "conversationId": null,
+  "finalMessage": "Changed src/export/csv.ts …",
+  "touchedFiles": [" M src/export/csv.ts", "?? src/export/csv.test.ts"],
+  "startedAt": "2026-01-01T00:00:00.000Z",
+  "finishedAt": "2026-01-01T00:04:12.000Z"
+}
+```
+
+Field notes:
+
+- **`status`** — `completed`, `failed`, `timeout`, `aborted`, or `warp_unavailable`.
+- **`touchedFiles`** — `git status --porcelain` lines. `null` when git cannot report (not a
+  repository, git missing); `[]` when the tree is genuinely clean. `[]` and `null` mean different
+  things — do not collapse them.
+- **`runId` / `runUrl`** — from Warp's `run_started` system event. `runUrl` opens the run in Warp.
+- **`conversationId`** — the handle to pass back as `--conversation` for rework. Present only when
+  Warp emitted it on the stream.
+- **`finalMessage`** — Warp's own report. Assembled from the text-bearing events in the stream; see
+  the caveat below.
+- **`stderrTail`** — last 20 stderr lines, included on every non-clean outcome.
+
+### What `finalMessage` actually contains
+
+Confirmed against a live edit run on oz 0.2026.05.27. The stream carries:
+
+| Event | Meaning |
+| --- | --- |
+| `{"type":"system","event_type":"run_started","run_id":…,"run_url":…}` | Run registered. |
+| `{"type":"system","event_type":"conversation_started","conversation_id":…}` | The `--conversation` handle. Re-emitted on a resumed run carrying the *same* id, so `conversationId` stays stable across a rework chain. |
+| `{"type":"agent","text":…}` | Agent output. **This is what `finalMessage` is built from.** |
+| `{"type":"agent_reasoning","text":…}` | Private reasoning. Same shape, deliberately **excluded**. |
+| `{"type":"tool_call"\|"tool_result"\|"tool_error",…}` | Tool traffic. No `text` field. |
+
+Two consequences:
+
+- **`finalMessage` is the whole narration, not just the closing report.** Warp emits no distinct
+  final-message event, so every `agent` chunk is concatenated — including running commentary like
+  "Now let me run both gates." This is why the brief must specify a report contract: `FILES:` /
+  `GATES:` / `NOTES:` at the end gives you a stable anchor to read instead of parsing prose.
+- **`agent_reasoning` must stay excluded.** It carries a `text` field of exactly the same shape, so
+  matching on `text` alone splices the model's reasoning into the report.
+
+Past those two rules the extraction stays tolerant — it also accepts `agent_output`, `content`, and
+a nested `message.content` — so a renamed output event still reports rather than yielding an empty
+`finalMessage`. If one ever does come back empty on a successful run, `events.jsonl` holds the raw
+stream and `collectText` is the one place to correct.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Warp exited 0 and reported no stream error. |
+| `1` | Generic failure, or a stream-reported agent error even when `oz` exited 0. |
+| `2` | Usage error — bad flag, bad `--timeout`, missing or empty brief. **No result file is written.** |
+| `124` | The bounded `oz --version` preflight timed out; Warp was never dispatched. |
+| `127` | `oz` is not on PATH. A result file **is** written, with `status: "warp_unavailable"`. |
+| `128 + n` | The child died on signal *n*; `signal` records which. |
+
+## Polling
+
+The relay blocks until the run ends. Background it and poll for `result.json`:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo \
+  --out-dir /tmp/warp-run-1 &
+until [ -f /tmp/warp-run-1/result.json ]; do sleep 5; done
+```
+
+Completion means the process exited **and** `result.json` exists. Do not infer completion from
+stdout going quiet — a long tool call looks identical to a finished run.
+
+## Timeouts and aborts
+
+`oz` has no timeout flag, so the watchdog is the relay's. When `--timeout` expires the relay kills
+the whole process group (SIGTERM, then SIGKILL after 10s) and writes `status: "timeout"`.
+
+If the relay itself is killed, it still writes `status: "aborted"`, forwards the kill to `oz`, and
+re-snapshots `touchedFiles` after a 2-second grace window so files flushed during shutdown are
+recorded. On Windows the process tree is felled with `taskkill /t /f`; Windows delivers no catchable
+SIGTERM, so the aborted path cannot be driven there.
+
+**A timed-out or aborted run leaves a partially edited tree.** Inspect `git status` and `git diff`
+before re-dispatching. If the state is incoherent, discard it against the recorded baseline rather
+than stashing — a bare `git stash` leaves behind every file the run created. See
+[review-and-land.md](review-and-land.md#rework-through-a-conversation).
+
+## Failure recovery
+
+| Symptom | What it means | Do |
+| --- | --- | --- |
+| `warp_unavailable`, exit 127 | `oz` is not on PATH | Install the Warp Agent CLI; check `oz --version`. |
+| stderr `subscribe to a Warp plan, or bring your own inference` | Authenticated, but the account has no AI quota. Warp logs it as `QuotaLimit` / "lack of AI quota". `oz` shares the Warp app's account, plan, and credits, so this is a credit condition, not a CLI-only gate | Check `oz whoami` names the account holding the plan - if not, `oz logout && oz login`. Otherwise confirm its AI credits are not spent, or store your own provider key: `warp --set-provider-api-key <openai\|anthropic\|google\|grok>` (or `/api-keys` in the TUI). Bring-your-own-key needs no paid plan. Warp's log is at `~/Library/Logs/oz/warp.log` on macOS. |
+| `Device not configured` | The `warp` TUI was launched, not `oz` | Use `oz`; the TUI cannot be relayed. |
+| exit 2, no result file | Usage error | Read the relay's stderr line; fix the flag. |
+| `status: "timeout"` | The watchdog fired | Raise `--timeout`, or split the brief. |
+| Empty `finalMessage`, exit 0 | Text extraction missed the event shape | Read `events.jsonl`; see the caveat above. |

--- a/skills/warp-delegate/references/multi-task-queues.md
+++ b/skills/warp-delegate/references/multi-task-queues.md
@@ -1,0 +1,80 @@
+# Multi-task queues
+
+A queue is a list of briefs run through Warp one at a time, each reviewed before the next is
+dispatched. It is the shape to reach for when the user hands you a backlog rather than a single
+task.
+
+## Run them sequentially
+
+Dispatch one brief, review it, land it, then dispatch the next. Parallel runs against the same
+working tree interleave edits into a diff nobody can review — and because `oz agent run` has no
+sandbox, there is nothing to keep two runs out of each other's files.
+
+If tasks are genuinely independent and you want them concurrent, give each its own checkout (a git
+worktree) and its own `--cd`. Otherwise, keep the queue serial.
+
+## Carry constraints forward
+
+Each brief is self-contained, so a constraint discovered in task 2 does not reach task 5 by itself.
+Keep a short running list and paste the relevant lines into every subsequent brief:
+
+- Conventions you had to correct in an earlier review ("use the existing `Result` type, not
+  exceptions").
+- Files that are off-limits for the whole queue.
+- Gates that turned out to be slow, flaky, or need a flag.
+- Decisions already made, so a later task does not relitigate them.
+
+A constraint that had to be corrected twice belongs in the repository's own skill directory
+(`.agents/skills/`, `.warp/skills/`) instead — then pass it with `--skill` and stop re-pasting it.
+
+## One out-dir per task
+
+Give every dispatch its own `--out-dir` so artifacts do not overwrite each other:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief briefs/03-stream-export.txt \
+  --cd /path/to/repo --out-dir /tmp/warp-queue/03 --name "queue-03-stream-export"
+```
+
+`--name` labels the run in Warp's own run list, which makes a queue far easier to follow later.
+Keeping the out-dirs numbered means `result.json`, `events.jsonl`, and `final.txt` for any task stay
+recoverable after the queue has moved on.
+
+## Track progress where the user can see it
+
+Maintain a visible checklist — the orchestrator's task list, or a scratch file — with one line per
+task and its state: pending, dispatched, under review, landed, or abandoned. Record the commit sha
+as each task lands, and the reason whenever one is abandoned.
+
+## When a task fails
+
+Do not roll straight into the next brief. Decide first:
+
+- **Rework** — the diff is close. Continue the conversation with `--conversation <id>` and a delta
+  brief.
+- **Re-scope** — the task was too big or the brief was wrong. Split it and requeue the parts.
+- **Abandon** — it depends on something that is not true yet. Record why and move on.
+
+A failed task that leaves a dirty tree must be cleaned up before the next dispatch. `git status`
+should be clean, or clean except for work you have deliberately kept.
+
+## Stop the queue when
+
+- Two consecutive tasks fail for the same underlying reason — the shared assumption is wrong, and
+  the remaining briefs probably inherit it.
+- A task reveals the plan itself is wrong. Re-plan with the user rather than working the list.
+- The gates start failing for reasons unrelated to the current task; something earlier in the queue
+  broke and the diff is no longer trustworthy.
+
+## Final coherence pass
+
+Ten individually correct diffs can still add up to an incoherent whole. When the queue is done,
+review the aggregate — `git diff <first-commit>~1..HEAD`:
+
+- Duplicated helpers that separate tasks each introduced.
+- Naming that drifted between early and late tasks.
+- Docs, types, or tests that an earlier task's assumption made stale.
+- Dead code left by a later task superseding an earlier one.
+
+Fix these yourself if small. If the cleanup is substantial, it is one more brief — dispatch it with
+the aggregate diff as the current state.

--- a/skills/warp-delegate/references/review-and-land.md
+++ b/skills/warp-delegate/references/review-and-land.md
@@ -1,0 +1,123 @@
+# Review and land
+
+Warp edits the working tree. **You commit.** That boundary is the point of the skill: the
+implementer produces a diff, and a reviewer who did not write it decides whether it ships.
+
+## Why the review is not optional here
+
+Every delegate skill asks you to verify the implementer's claims. Warp raises the stakes: `oz agent
+run` has no sandbox, no permission mode, and no read-only run, so nothing constrained what the run
+could touch while it worked. The diff is not a courtesy record — it is the only record.
+
+## The checklist
+
+Work through these in order. Stop at the first one that fails and decide whether to rework or
+discard.
+
+1. **Read `result.json` first.** If there is no `result.json`, stop: a usage error exits 2 before
+   Warp is ever dispatched and writes none, so an absent file means the run did not happen — read the
+   relay's stderr, not the tree. Otherwise require `status: "completed"` and `exitCode: 0` before
+   going further. `failed`, `timeout`, `aborted`, and `warp_unavailable` all mean the run did not
+   finish on its own terms, and `timeout` and `aborted` additionally mean the tree may be mid-edit
+   and incoherent. Rework or discard from the baseline rather than reviewing a partial run.
+2. **Start from `touchedFiles`.** It is `git status --porcelain` taken after the run: post-run,
+   git-visible worktree state, not a log of what the agent did. It cannot show an ignored file, an
+   edit the run made and then reverted, or a write outside the repository, and it includes anything
+   already dirty before dispatch. Start there, but do not read it as the complete set. `null` means
+   git could not report — inspect the tree by hand. `[]` on a run that claimed edits is a
+   contradiction worth chasing.
+3. **Re-run the gates yourself.** Do not accept "tests pass" from `finalMessage`. Run the project's
+   actual lint, typecheck, build, and test commands and read the output. Take "actual" from
+   `CONTRIBUTING.md`, the CI config, or `package.json`: a project's gate set often includes a
+   packaging, manifest, or schema validation step that lint and test do not cover, and that is
+   exactly the gate a run can break without any test going red.
+4. **Read the whole diff against the brief.** `git diff` and `git diff --staged` — then open every
+   `??` path in `touchedFiles` directly, including everything inside an untracked directory. Neither
+   diff command shows the contents of an untracked file, so a file Warp created is invisible to both
+   and would otherwise reach your commit unread. Ask of each hunk and each new file: did the brief
+   ask for this? Changes outside the brief's stated scope are the thing to catch.
+5. **Check what should NOT have changed.** Lockfiles, CI config, formatter config, unrelated
+   modules, and anything the brief listed under "leave untouched".
+6. **Grep for dangling references** after any removal or rename — imports, string keys, docs.
+7. **Round-trip migrations.** Apply and roll back before trusting a schema change.
+8. **Run guard skills** if the repository has them installed.
+9. **Confirm nothing was committed.** `git log -1` should still be your last commit. The relay never
+   commits; if a commit exists, the agent made it despite the brief — treat that as a finding.
+
+## Reading `finalMessage` correctly
+
+`finalMessage` is Warp's self-report: a claim, not evidence. Read it for two things only —
+
+- **Decisions it made that the brief did not specify.** These are the parts you most need to surface
+  to the user.
+- **What it says it could not do.** Usually accurate, and it tells you where to look first.
+
+Everything else in it — "all tests pass", "no other files changed" — is a hypothesis your gates and
+your diff read either confirm or refute. If `finalMessage` is empty on a run that exited 0, read
+`events.jsonl` rather than assuming the run did nothing.
+
+## Rework through a conversation
+
+When the diff is close but wrong, continue the same conversation rather than starting cold:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief delta-brief.txt --cd /path/to/repo \
+  --conversation "$(jq -r .conversationId /tmp/warp-run-1/result.json)"
+```
+
+Warp still holds the earlier exchange, so send only the delta — what was wrong, what to change, what
+to leave alone. See [writing-the-brief.md](writing-the-brief.md#delta-briefs).
+
+If `conversationId` is `null`, the stream did not carry one; dispatch a fresh run with a brief that
+restates the corrected requirements.
+
+Discard rather than rework when the diff misunderstood the goal, wanders far outside the brief, or
+would take longer to correct than to redo.
+
+Discard against a known baseline, never with a blanket revert. `git checkout -- .` is the wrong
+reach: it leaves staged and untracked files behind, so the tree stays dirty for the next dispatch,
+and it destroys any uncommitted work of your own that predates the run. Dispatch from a clean tree —
+commit your own changes, or `git stash push --include-untracked` them. A bare `git stash` leaves
+untracked files in place, and those resurface as `??` entries in `touchedFiles`, where the cleanup
+below would delete work the run never made. Confirm `git status --porcelain` prints nothing before
+dispatching, so that everything dirty afterward is Warp's, then drop exactly what the run
+introduced, reading the paths off `touchedFiles`:
+
+```bash
+git restore --staged --worktree -- <tracked paths>   # the ' M' / 'M ' entries
+git clean -f -- <untracked paths>                    # the '??' entries
+```
+
+A `??` entry can name a whole directory rather than each file under it; passing that path removes
+the directory and its contents, since `-d` only governs the no-pathspec case. The exception is a
+nested git repository — if the run scaffolded one, `git clean -f` skips it and `-ff` is required.
+
+If dispatching from a clean tree is not an option, give Warp its own `git worktree` instead: then
+discarding is `git worktree remove --force`, and your work was never in reach. Either way, rewrite
+the brief before dispatching again.
+
+## Landing
+
+Commit once the gates pass and the diff holds. Write the commit message yourself: it should describe
+the change, not the delegation. Do not credit the tool in the message unless the project's own
+convention asks for it.
+
+## Surface, don't absorb
+
+Delegation is something the human opted into, and committing verified, gate-passing work is the
+agreed contract. Two limits stay with you:
+
+- **Surface, don't absorb.** Report Warp's design decisions, its defensible-but-unasked turns, and
+  the non-blocking nitpicks you chose not to fix. Silently smoothing them over hides the
+  implementer's judgment from the person who owns the code.
+- **Stop for scope changes.** If finishing correctly requires going beyond the brief — a dependency
+  bump, a schema change, an interface the brief did not mention — ask rather than expanding the
+  mandate yourself.
+
+Snapshot egress is a decision you make **before** dispatch, not something you report after it. `oz
+agent run` uploads an end-of-run workspace snapshot by default, so reading `snapshotDisabled: false`
+off a finished run tells you only that the upload already happened. If the repository is sensitive,
+pass `--no-snapshot` on the dispatch and confirm `snapshotDisabled: true` in `result.json` before
+going further. Keep reporting the field either way — it is the evidence of which way the run went.
+
+Also surface the `runUrl` when someone will want to inspect the run in Warp.

--- a/skills/warp-delegate/references/writing-the-brief.md
+++ b/skills/warp-delegate/references/writing-the-brief.md
@@ -1,0 +1,105 @@
+# Writing the brief
+
+The brief is the whole contract. Warp sees only the text you send plus whatever it can inspect in
+the workspace — no chat history, no shared context, none of the reasoning that led you here.
+
+## How the brief reaches Warp
+
+`oz agent run` requires one of `--prompt`, `--saved-prompt`, `--task-id`, or `--skill`. Its
+`-f/--file` config path does **not** satisfy that requirement, so there is no stdin or file channel
+for the task text: the relay passes the brief as the `--prompt` value on argv.
+
+Two consequences that do not apply to the other skills in this package:
+
+- **The brief is visible in the host process list** (`ps`, Activity Monitor, Task Manager) for as
+  long as the run is live. Keep credentials, tokens, and customer data out of it. Point Warp at a
+  file in the repo or an environment variable instead of inlining a secret.
+- **A very large brief can hit the OS argument limit.** Practical briefs are far below it, but a
+  brief that inlines whole files can trip it. Reference paths rather than pasting file contents —
+  Warp can read the workspace itself.
+
+Because the brief rides argv, the relay never launches `oz` through a shell on any platform.
+
+## Structure
+
+Cover these in order. Skip a heading only when it genuinely does not apply.
+
+1. **Goal** — one sentence on the outcome, not the mechanics.
+2. **Current state** — where the code is now, and the paths that matter. **Name the workspace root
+   as an absolute path**, and prefer absolute paths for the files you call out. `--cwd` is not
+   uniformly honoured: on a verified run against oz 0.2026.05.27, shell commands executed in the
+   pinned workspace (`pwd` returned it), but the agent stated its working directory was `/` and its
+   file-reading tool resolved bare relative paths against `$HOME` — so `src/strings.js` was first
+   read as `/Users/<you>/src/strings.js`. The agent recovered by running `pwd` and retrying, but it
+   burned a turn, and in a home directory that happened to hold a matching path it would have read
+   the wrong file. There is no sandbox to catch that.
+3. **What to change** — the specific edits, in the order they make sense.
+4. **What to leave untouched** — files, patterns, and public interfaces that must not move. Warp has
+   no sandbox, so this is a written boundary, not an enforced one.
+5. **Gates** — the project's *actual* commands. Read them out of `package.json`, `Makefile`, or the
+   CI config; do not invent `npm test` because it is conventional.
+6. **Report contract** — what the final message must state (below).
+7. **Do not commit** — say it explicitly. Committing is the orchestrator's job.
+
+## The report contract
+
+Ask for a final message that states, plainly:
+
+- What changed, file by file.
+- Which gate commands were run, and their exact outcome.
+- Anything the run could not do, and why.
+- Any decision it made that the brief did not specify.
+
+The relay captures that message as `finalMessage` in `result.json` and as `final.txt`. Treat it as a
+claim to verify, never as verification — see [review-and-land.md](review-and-land.md).
+
+## Repository context files
+
+Warp reads skills from `.agents/skills/`, `.warp/skills/`, `.claude/skills/`, and `.codex/skills/`.
+If the repository carries conventions in one of those, name it with the relay's `--skill` flag
+(`name`, `repo:name`, or `org/repo:name`) so it becomes the base prompt and your brief stays the
+task. Anything not in one of those locations — a plain `CONTRIBUTING.md`, for instance — must be
+referenced by path in the brief; do not assume it is loaded.
+
+## One task per brief
+
+A brief that carries two unrelated changes produces a diff you cannot review cleanly and a
+conversation you cannot resume precisely. Split them and queue the parts — see
+[multi-task-queues.md](multi-task-queues.md).
+
+## Delta briefs
+
+When you continue a conversation with `--conversation <id>`, Warp still holds the earlier exchange.
+Send only what changed:
+
+- What you reviewed and what was wrong — be specific about the file and the symptom.
+- What to do about it.
+- What to leave alone from the previous round.
+- The gates to re-run.
+
+Do not re-send the original brief. Restating a satisfied requirement invites Warp to redo work that
+was already correct.
+
+## Worked example
+
+```text
+Goal: make the CSV export stream instead of buffering the whole result set.
+
+Current state: src/export/csv.ts builds one string in memory (see toCsv) and
+returns it from the /export route in src/routes/export.ts.
+
+Change:
+- Rewrite toCsv to return a Readable that yields one row at a time.
+- Update the /export route to pipe that stream to the response.
+- Keep the column order and the quoting behaviour exactly as they are now.
+
+Leave untouched: the public signature of toCsv's caller in src/routes/export.ts
+beyond the pipe change, and every file under src/import/.
+
+Gates: `npm run lint`, `npm run typecheck`, `npm test -- export`.
+
+Report: list each file you changed, quote the exact output of each gate command,
+and state anything you could not finish.
+
+Do not commit. Leave the changes in the working tree.
+```

--- a/skills/warp-delegate/scripts/relay.mjs
+++ b/skills/warp-delegate/scripts/relay.mjs
@@ -1,0 +1,820 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · warp-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Warp Agent CLI (`oz agent run
+ * --output-format ndjson`), capture the newline-delimited JSON event stream,
+ * and write a structured result the orchestrating agent can review. The
+ * orchestrator runs this one command and reads the result JSON — every
+ * Warp-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `oz` and `git`, plus the platform
+ * process-termination utility when a Windows process-tree kill requires one.
+ * The `oz` process it launches does authenticate — exactly as you do at the
+ * terminal. Read this file before you run it.
+ *
+ * Brief delivery: `oz agent run` requires one of --prompt/--saved-prompt/
+ * --task-id/--skill, and its -f/--file config path does NOT satisfy that
+ * requirement, so the brief rides argv as the --prompt value. Two consequences
+ * the other relays in this package do not have: the brief is visible in the
+ * host process list while the run is live, and a very large brief can hit the
+ * OS argv limit. Keep secrets out of the brief — reference workspace files or
+ * environment variables instead — and on a shared machine prefer a short brief
+ * that points `oz` at files in the repo. Because the brief rides argv, this
+ * relay never launches `oz` through a shell on any platform.
+ *
+ * Workspace snapshots: `oz agent run` uploads an end-of-run workspace snapshot
+ * by default. The relay does not change that default — it is the CLI's own
+ * behavior — but --no-snapshot forwards Warp's flag when you do not want the
+ * upload. Decide deliberately for private repositories.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's job
+ * — after it reviews the diff and re-runs the project gates.
+ *
+ * Autonomy: `oz agent run` has NO sandbox, NO permission mode, and NO
+ * read-only mode. A headless run reads, writes, edits, and executes commands
+ * with the user's own permissions and never prompts. This relay therefore
+ * offers no --read-only flag: there is nothing in the CLI to enforce it, and
+ * advertising one would be a lie. (`--auto-approve` belongs to the interactive
+ * `warp` TUI, not to `oz agent run`.) The diff reported in `touchedFiles` is
+ * the record of what changed — inspect it after every run.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, read it from stdin.
+ *   --cd <dir>              Working root for oz (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --model <id>            Warp model id (default: Warp's own). See `oz model list`.
+ *   --profile <id>          Warp agent profile id.
+ *   --name <name>           Label for the run (Warp's `--name`).
+ *   --conversation <id>     Continue an existing Warp conversation; send only the delta brief.
+ *   --skill <spec>          Warp skill used as the base prompt (`name`, `repo:name`, `org/repo:name`).
+ *   --mcp <spec>            MCP server config path or inline JSON. Repeatable.
+ *   --no-snapshot           Forward Warp's --no-snapshot (disable the end-of-run snapshot upload).
+ *   --timeout <dur>         Relay-side watchdog (default: 30m). Durations use h/m/s strings.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir
+ *                           under the system temp dir).
+ *   -h, --help              Show this help.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, ozVersion, runId, runUrl, conversationId,
+ *   finalMessage (the agent's own report), model, touchedFiles (git porcelain,
+ *   null if git cannot report), snapshotDisabled, and paths to brief.txt,
+ *   final.txt, events.jsonl, and stderr.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief) exits 2
+ * before any run and writes no result file; a missing `oz` binary exits 127;
+ * otherwise the exit code mirrors oz's own (0 success, non-zero failure),
+ * except a stream-reported agent error exits 1 even if oz exits 0. If the child
+ * dies on a signal, the exit code is 128 plus the signal number and
+ * `result.json` records the signal. Once the brief validates, `result.json` is
+ * written on every outcome — completed, failed, timeout (the --timeout watchdog
+ * fired, or the bounded --version preflight hung), aborted (the relay itself
+ * was killed and forwarded the kill to oz), or warp_unavailable.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import {join, resolve, basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+const MAX_BUFFERED_CHARS = 1_048_576;
+
+const DEFAULT_TIMEOUT = "30m";
+const MAX_TIMER_MS = 2_147_483_647;
+const VERSION_TIMEOUT_MS = 10_000;
+// Values that ride argv beside the brief. `oz` is launched without a shell, so
+// the risk is not quoting but flag injection: a value starting with "-" would be
+// read by oz as another option. Require a leading alphanumeric.
+const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const IMPLEMENTER_KEY = "warp";
+
+function makeEventScanner(onObject) {
+  let buf = "";
+  let index = 0;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  return (chunk) => {
+    if (!chunk) return;
+    buf += chunk;
+    for (;;) {
+      while (index < buf.length) {
+        const ch = buf[index];
+        // Only track strings inside an object (depth > 0). At depth 0 we are
+        // skipping a junk prefix, and an unmatched `"` there must not swallow the
+        // real `{...}` that follows in the same chunk.
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+          if (depth > 0) inString = true;
+        } else if (ch === "{") {
+          if (depth === 0) start = index;
+          depth += 1;
+        } else if (ch === "}") {
+          if (depth > 0) {
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+              const slice = buf.slice(start, index + 1);
+              try { onObject(JSON.parse(slice)); } catch { /* skip malformed */ }
+              start = -1;
+            }
+          }
+        }
+        index += 1;
+      }
+      if (depth === 0 || start === -1 || buf.length - start <= MAX_BUFFERED_CHARS) break;
+      // A complete object may exceed the retained-input cap within this chunk.
+      // Drop only an oversized partial, then rescan its suffix so a later
+      // concatenated event is not lost.
+      buf = buf.slice(start + MAX_BUFFERED_CHARS);
+      index = 0;
+      start = -1;
+      depth = 0;
+      inString = false;
+      escaped = false;
+    }
+    if (depth > 0 && start !== -1) {
+      if (start > 0) {
+        buf = buf.slice(start);
+        index -= start;
+        start = 0;
+      }
+    } else {
+      buf = "";
+      index = 0;
+      start = -1;
+    }
+  };
+}
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    // Warp exposes no read-only, sandbox, or permission-mode flag on `oz agent
+    // run`, so those dials cannot be honoured here. Dropping one silently would
+    // run a lane the user believes is restricted, so refuse instead.
+    if (["readOnly", "sandbox", "permissionMode", "force", "effort", "variant", "provider"].includes(field)) {
+      fail(`lane "${opts.lane}" sets the ${field} dial, which the Warp Agent CLI has no flag for; remove it from the lane or use a different implementer`);
+    }
+    opts[field] = value;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    model: null,
+    profile: null,
+    name: null,
+    conversation: null,
+    skill: null,
+    mcp: [],
+    noSnapshot: false,
+    timeout: DEFAULT_TIMEOUT,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--model": opts.model = next(); flagged.add("model"); break;
+      case "--profile": opts.profile = next(); break;
+      case "--name": opts.name = next(); break;
+      case "--conversation": opts.conversation = next(); break;
+      case "--skill": opts.skill = next(); break;
+      case "--mcp": opts.mcp.push(next()); break;
+      case "--no-snapshot": opts.noSnapshot = true; break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  for (const flag of ["model", "profile", "conversation"]) {
+    if (opts[flag] !== null && !SAFE_TOKEN.test(opts[flag])) {
+      fail(`--${flag} value contains unsupported characters (allowed: letters, digits, . _ : / -)`);
+    }
+  }
+  // --skill and --mcp legitimately carry characters the token rule rejects (an
+  // inline MCP JSON blob, a path). Only a leading "-" is dangerous: oz would
+  // read the value as the next option.
+  for (const [flag, values] of [["skill", opts.skill === null ? [] : [opts.skill]], ["mcp", opts.mcp]]) {
+    for (const value of values) {
+      if (value === "" || value.startsWith("-")) {
+        fail(`--${flag} value must be non-empty and must not start with "-"`);
+      }
+    }
+  }
+  if (opts.name !== null && (opts.name === "" || opts.name.startsWith("-"))) {
+    fail('--name value must be non-empty and must not start with "-"');
+  }
+  if (parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is not a duration; use h/m/s strings like 30m, 90s, or 1h30m`);
+  }
+  if (parseDuration(opts.timeout) === 0) fail("--timeout must be greater than zero");
+  // setTimeout overflows past 2^31 - 1 ms (~24.8 days) and fires immediately,
+  // which would read as an instant spurious timeout — reject it up front.
+  if (parseDuration(opts.timeout) > 2_147_483_647) {
+    fail(`--timeout "${opts.timeout}" exceeds the maximum schedulable watchdog (~24.8 days)`);
+  }
+  if (!existsSync(opts.cd) || !statSync(opts.cd).isDirectory()) {
+    fail(`working directory not found: ${opts.cd}`);
+  }
+  return opts;
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs - dispatch a brief to oz agent run\n";
+  return `${match[1].replace(/^\s*\* ?/gm, "").trim()}\n`;
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+async function probeOzVersion(timeoutMs, onChild) {
+  const limit = Math.min(timeoutMs, VERSION_TIMEOUT_MS);
+  const runProbe = (command, argv, options = {}) => new Promise((resolveProbe) => {
+    const child = spawn(command, argv, {
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      ...options,
+    });
+    onChild(child);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let timer;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveProbe({ stdout, stderr, ...result });
+    };
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => finish({ code: null, error, timedOut: false }));
+    child.on("close", (code) => finish({ code, error: null, timedOut }));
+    timer = setTimeout(() => {
+      timedOut = true;
+      killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+    }, limit);
+  });
+
+  // `oz` installs as a native binary on the platforms this relay targets, so
+  // there is no .cmd shim to resolve and the probe runs without a shell — the
+  // same launch discipline the dispatch uses because the brief rides argv.
+  const probe = await runProbe("oz", ["--version"]);
+  if (probe.timedOut) {
+    return { version: null, error: Object.assign(new Error("oz --version timed out"), { code: "ETIMEDOUT", stderr: probe.stderr }) };
+  }
+  if (probe.error && probe.error.code === "ENOENT") return { version: null, error: null };
+  if (probe.error) return { version: null, error: probe.error };
+  if (probe.code !== 0) {
+    return { version: null, error: Object.assign(new Error("oz --version failed"), { status: probe.code, stderr: probe.stderr }) };
+  }
+  return { version: probe.stdout.trim() || "unknown", error: null };
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, brief) {
+  // ndjson streams one event object per line, so a long run reports progress
+  // instead of buffering to the end. The brief is the --prompt value: `oz agent
+  // run` requires one of --prompt/--saved-prompt/--task-id/--skill, and -f/--file
+  // does not satisfy that requirement.
+  const argv = ["agent", "run", "--output-format", "ndjson", "--cwd", opts.cd];
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.profile) argv.push("--profile", opts.profile);
+  if (opts.name) argv.push("--name", opts.name);
+  if (opts.conversation) argv.push("--conversation", opts.conversation);
+  if (opts.skill) argv.push("--skill", opts.skill);
+  for (const spec of opts.mcp) argv.push("--mcp", spec);
+  if (opts.noSnapshot) argv.push("--no-snapshot");
+  argv.push("--prompt", brief);
+  return argv;
+}
+
+/**
+ * Pull agent-visible text out of one ndjson event.
+ *
+ * Verified against a live edit run on oz 0.2026.05.27: the report is carried by
+ * `{"type":"agent","text":…}` events, and system events are `type: "system"`
+ * with an `event_type` of `run_started` / `conversation_started`.
+ *
+ * `agent_reasoning` events carry a `text` field of the SAME shape but hold the
+ * model's private reasoning, not its report — matching on `text` alone splices
+ * that reasoning into finalMessage. They are dropped by type. Tool traffic
+ * (`tool_call`, `tool_result`, `tool_error`) carries no `text` and so needs no
+ * exclusion; it stays in events.jsonl.
+ *
+ * Everything past that stays tolerant rather than pinned to `type === "agent"`,
+ * so a renamed or added output event still reports instead of yielding an empty
+ * finalMessage; events.jsonl always keeps the raw stream.
+ */
+function collectText(event, push) {
+  if (!event || typeof event !== "object") return;
+  if (event.type === "system" || event.type === "agent_reasoning") return;
+  const pushString = (value) => { if (typeof value === "string" && value.trim()) push(value); };
+  if (typeof event.agent_output === "string") { pushString(event.agent_output); return; }
+  if (typeof event.text === "string") { pushString(event.text); return; }
+  if (typeof event.content === "string") { pushString(event.content); return; }
+  if (Array.isArray(event.content)) {
+    for (const part of event.content) if (part && part.type === "text") pushString(part.text);
+    return;
+  }
+  const message = event.message;
+  if (message && typeof message === "object") {
+    if (typeof message.content === "string") { pushString(message.content); return; }
+    if (Array.isArray(message.content)) {
+      for (const part of message.content) if (part && part.type === "text") pushString(part.text);
+    }
+  }
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    briefPath: join(outDir, "brief.txt"),
+    finalPath: join(outDir, "final.txt"),
+    eventsPath: join(outDir, "events.jsonl"),
+    stderrPath: join(outDir, "stderr.txt"),
+    resultPath: join(outDir, "result.json"),
+  };
+  // A reused --out-dir must not leak a previous run's artifacts into this one.
+  rmSync(run.finalPath, { force: true });
+  rmSync(run.resultPath, { force: true });
+  writeFileSync(run.briefPath, brief, "utf8");
+  writeFileSync(run.eventsPath, "", "utf8");
+  writeFileSync(run.stderrPath, "", "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run) {
+  return (extra) => {
+    const result = {
+      schema: "delegate-relay.result.v1",
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      tool: "oz",
+      workdir: opts.cd,
+      model: opts.model,
+      profile: opts.profile,
+      snapshotDisabled: opts.noSnapshot,
+      resumed: Boolean(opts.conversation),
+      ozVersion: version,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      eventsPath: run.eventsPath,
+      stderrPath: run.stderrPath,
+      ...extra,
+    };
+    // Atomic write: a polling orchestrator never reads a half-written result.
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({
+    status: "warp_unavailable",
+    exitCode: 127,
+    signal: null,
+    runId: null,
+    runUrl: null,
+    conversationId: null,
+    stderrTail: [],
+    finalMessage: "",
+    touchedFiles: null,
+  });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: `oz` not found on PATH. Install the Warp Agent CLI (https://docs.warp.dev/cli/), then authenticate with `oz login` (or set WARP_API_KEY on a headless host).\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(writeResult, run, error, timeoutMs) {
+  const timedOut = error && error.code === "ETIMEDOUT";
+  const stderr = String((error && error.stderr) || "").trim();
+  if (stderr) writeFileSync(run.stderrPath, `${stderr}\n`, "utf8");
+  const message = timedOut
+    ? `oz --version preflight timed out after ${Math.min(timeoutMs, VERSION_TIMEOUT_MS)}ms; oz was not dispatched`
+    : `oz --version preflight failed${Number.isInteger(error && error.status) ? ` with exit ${error.status}` : ""}; oz was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error && error.status) ? error.status : 1,
+    signal: null,
+    runId: null,
+    runUrl: null,
+    conversationId: null,
+    finalMessage: "",
+    touchedFiles: null,
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function installPreflightSignalHandlers(opts, run, writeResult, getChild) {
+  let active = true;
+  const handlers = new Map();
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    const handler = () => {
+      if (!active) return;
+      active = false;
+      const result = writeResult({
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        runId: null,
+        runUrl: null,
+        conversationId: null,
+        stderrTail: [],
+        finalMessage: "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        error: `the relay was killed by ${sig} during the oz version preflight; oz was not dispatched`,
+      });
+      printSummary(result, run.resultPath);
+      const child = getChild();
+      if (child) killChild(child, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+      process.exit(result.exitCode);
+    };
+    handlers.set(sig, handler);
+    process.on(sig, handler);
+  }
+  return () => {
+    active = false;
+    for (const [sig, handler] of handlers) process.removeListener(sig, handler);
+  };
+}
+
+function dispatchToOz(opts, brief, run, writeResult) {
+  const child = spawn("oz", buildArgv(opts, brief), {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    // Never shell:true. The brief is an argv value here, and a shell would
+    // reinterpret it. `oz` is a native binary, so no shim resolution needs one.
+    detached: process.platform !== "win32", // POSIX: lead a new process group so killChild can fell the whole tree
+  });
+
+  let runId = null;
+  let runUrl = null;
+  let conversationId = null;
+  let streamError = null;
+  const textChunks = [];
+  const stderrTail = [];
+  const scan = makeEventScanner((event) => {
+    if (event && typeof event === "object") {
+      if (typeof event.run_id === "string") runId = event.run_id;
+      if (typeof event.run_url === "string") runUrl = event.run_url;
+      if (typeof event.conversation_id === "string") conversationId = event.conversation_id;
+      if (event.type === "error" || event.event_type === "run_failed") {
+        const detail = typeof event.message === "string" ? event.message
+          : typeof event.error === "string" ? event.error : null;
+        streamError = detail || `oz reported ${event.event_type || event.type}`;
+      }
+    }
+    collectText(event, (text) => textChunks.push(text));
+  });
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  // Files get the raw bytes; only in-memory parsing goes through the decoders.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout.on("data", (chunk) => {
+    appendFileSync(run.eventsPath, chunk);
+    scan(stdoutDecoder.write(chunk));
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendFileSync(run.stderrPath, chunk);
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  const assembleFinal = () => {
+    const message = textChunks.join("\n\n");
+    if (message) writeFileSync(run.finalPath, message, "utf8");
+    return message;
+  };
+
+  let settled = false;
+  let watchdogFired = false;
+  let sigkillTimer = null;
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const watchdogTimer = setTimeout(() => {
+    watchdogFired = true;
+    child.once("exit", () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    });
+    killChild(child);
+    sigkillTimer = setTimeout(() => {
+      if (!settled) killChild(child, "SIGKILL");
+    }, 10_000);
+  }, timeoutMs);
+
+  const clearWatchdog = () => {
+    clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the oz child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        runId,
+        runUrl,
+        conversationId,
+        finalMessage: assembleFinal(),
+        touchedFiles: gitTouchedFiles(opts.cd),
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; oz was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({
+      status: "failed",
+      exitCode: 1,
+      signal: null,
+      runId,
+      runUrl,
+      conversationId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      stderrTail: stderrTail.slice(-20),
+      error: String(err && err.message ? err.message : err),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    // A timed-out run is failed even if oz handles SIGTERM by exiting 0 —
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired && !streamError;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    const exitCode = succeeded ? 0 : mapped === 0 ? 1 : mapped;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode,
+      signal: signal ?? null,
+      runId,
+      runUrl,
+      conversationId,
+      finalMessage: assembleFinal(),
+      touchedFiles: gitTouchedFiles(opts.cd),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `oz did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+      ...(!watchdogFired && streamError ? { error: streamError } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  const timeoutMs = parseDuration(opts.timeout) ?? parseDuration(DEFAULT_TIMEOUT);
+  const run = prepareRunDir(opts, brief);
+  let writeResult = makeResultWriter(opts, null, run);
+  let preflightChild = null;
+  const clearPreflightSignals = installPreflightSignalHandlers(opts, run, writeResult, () => preflightChild);
+  const probe = await probeOzVersion(timeoutMs, (child) => { preflightChild = child; });
+  writeResult = makeResultWriter(opts, probe.version, run);
+  if (!probe.version && !probe.error) {
+    clearPreflightSignals();
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (!probe.version) {
+    clearPreflightSignals();
+    reportVersionFailure(writeResult, run, probe.error, timeoutMs);
+    return;
+  }
+  clearPreflightSignals();
+  dispatchToOz(opts, brief, run, writeResult);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  oz ${result.ozVersion ?? "?"}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not an oz error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated oz (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  lines.push("mode: full local tool access — the Warp Agent CLI has no sandbox, permission mode, or read-only run");
+  if (result.snapshotDisabled) lines.push("mode: end-of-run workspace snapshot upload disabled (--no-snapshot)");
+  if (result.resumed) lines.push("mode: continued an existing conversation");
+  if (result.model) lines.push(`model: ${result.model}`);
+  if (result.conversationId) lines.push(`conversation id (continue with: --conversation ${result.conversationId}): ${result.conversationId}`);
+  if (result.runId) lines.push(`run id: ${result.runId}`);
+  if (result.runUrl) lines.push(`run url: ${result.runUrl}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable - inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  ... and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- oz final report ---");
+  lines.push(result.finalMessage || "(no final message captured — read events.jsonl for the raw stream)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/skills/zcode-delegate/SKILL.md
+++ b/skills/zcode-delegate/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: zcode-delegate
+description: Delegate a coding task to the Z.AI ZCode CLI as a background implementer,
+  then review its diff and land it yourself. Use this whenever the user wants to hand
+  implementation work to ZCode — phrasings like "have ZCode do X", "delegate this
+  to ZCode", "run it through ZCode", or...
+risk: safe
+category: agent-orchestration
+source: https://github.com/amElnagdy/delegate-skills
+source_repo: amElnagdy/delegate-skills
+source_type: community
+date_added: '2026-08-25'
+license: MIT
+license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE
+compatibility: Requires the `zcode` CLI (Z.AI ZCode) with a configured model provider,
+  Node 18+, and git. ZCode ships its CLI inside the desktop app rather than on PATH
+  or npm — see Prerequisites. The orchestrating agent must be able to run shell commands
+  and read files. Shell examples assume bash/zsh (macOS/Linux, or Git Bash/WSL on
+  Windows).
+metadata:
+  version: 0.5.0
+---
+# ZCode Delegate
+
+## When to Use
+
+- You want to delegate a bounded coding task to a separate `zcode` implementer (`Z.AI ZCode`) and then review its diff yourself.
+- The user explicitly asked for delegation to this implementer (not for the current agent to implement directly).
+
+You are the **orchestrator**. This skill lets you hand a bounded coding task to a separate
+**implementer** — the Z.AI ZCode CLI — then review what it produced and land it yourself. You write
+the brief and own the judgment; ZCode does the typing; you verify and commit.
+
+Nothing here is specific to one orchestrating agent. The loop needs only the ability to run a shell
+command and read a file. (It is designed for and run on Claude Code; treat other orchestrators as
+designed-for, not yet proven.)
+
+## When NOT to use this
+
+- The task is small enough to just do inline — delegation overhead is not worth it.
+- ZCode is not installed, or its CLI has no model provider configured.
+- You want to write the code yourself, or you only need a review.
+
+## Prerequisites (check once)
+
+1. **ZCode is installed.** The CLI ships **inside the desktop app** — it is not on PATH and not on
+   npm. The relay resolves it in this order: `--zcode-path <file>` or `ZCODE_CLI` first, then PATH,
+   then the installed app bundle. On Linux the app is an AppImage with no fixed install path, so
+   the flag or the environment variable is required there — the relay guesses nothing.
+2. **A model provider is configured for the CLI**, with a key it can actually reach. Being signed
+   into the desktop app is *not* enough — see below.
+3. You are in (or will point `--cd` at) the target git repository.
+
+The relay records the CLI version and how it was resolved into `result.json`, so a surprising
+install is visible after the fact.
+
+## Authenticating the headless CLI
+
+**Signing into the ZCode desktop app does not authenticate the CLI this relay drives.** The CLI
+keeps its own config at `~/.zcode/cli/config.json`, separate from the desktop app's, and nothing
+bridges the two. `zcode login` is the intended path, but where it fails with `OAuth response is
+not valid JSON` the way in is a Z.AI API key.
+
+Two pieces are needed, and they are separate:
+
+1. **The provider block** must exist in `~/.zcode/cli/config.json`. It defines the provider, its
+   endpoint and its models — the environment cannot supply this:
+
+   ```jsonc
+   {
+     "provider": {
+       "zai": {
+         "kind": "anthropic",
+         "options": { "apiKeyRequired": true, "baseURL": "https://api.z.ai/api/anthropic" },
+         "models": { "glm-5.1": { "name": "GLM-5.1" } }
+       }
+     },
+     "model": { "main": "zai/glm-5.1" }
+   }
+   ```
+
+2. **The key** can live either in `provider.zai.options.apiKey` in that file, or in the
+   environment as any one of `ZAI_API_KEY`, `ZCODE_API_KEY`, or `ANTHROPIC_API_KEY`. Prefer the
+   environment — it keeps the secret off disk.
+
+If a run fails with `Model provider is missing an API key: <provider>`, the provider block resolved
+but no key was found: set one of those variables and re-run.
+
+## Autonomy — read this before dispatching
+
+ZCode's own term is **mode**. It has four values; only two are usable headlessly.
+
+| mode | Behaviour |
+| --- | --- |
+| `yolo` | **Writes.** ZCode's own default for `--prompt`, and this relay's write-capable default. |
+| `plan` | **Refuses edits.** What `--read-only` selects. |
+| `build` | **Rejected by this relay.** No permission client exists headlessly, so tools are blocked and the run exits 0 having done nothing. |
+| `edit` | Rejected for the same reason. |
+
+Two limits stated plainly, because ZCode cannot enforce them:
+
+- **`plan` mode refused edits in testing, but the relay does not treat that as a guarantee.** It
+  takes a Git fingerprint before the run and reports a tri-state `readOnlyViolation` afterwards.
+  Confirm `touchedFiles` came back empty rather than assuming no edits.
+- **ZCode has no `--allowed-tools`.** Only the `--disallowed-tools` denylist exists, and it *is*
+  genuinely enforced. An explicit allowlisted tool surface is therefore impossible here — do not
+  assume one.
+
+## The loop
+
+Run these five steps per task. Steps 1, 4, and 5 are your judgment; 2 and 3 are mechanical.
+
+### 1. Write the brief
+
+ZCode sees **only** what you send — no repo memory, no chat history. Everything the task needs goes
+in the brief: the goal, the current state, what to change, what to leave untouched, the project's
+**actual** gate commands (discover them from the repo's CLAUDE.md/AGENTS.md/Makefile — do not
+assume), and a report contract. Tell ZCode it will **not** commit. One task per brief. The relay
+delivers the brief as an attached file, so the command line no longer bounds its length — the
+model's context window still does. Full guidance and a template:
+[references/writing-the-brief.md](references/writing-the-brief.md).
+
+### 2. Dispatch
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+# read-only (review/diagnosis, no edits):   add --read-only
+# continue a specific session:              add --session <sess_...>  (from result.json; send only the delta brief)
+# continue the latest session for --cd:     add --resume-last
+# withhold tools (denylist):                add --disallowed-tools "Write,Edit,Bash"
+# point at the CLI explicitly:              add --zcode-path /path/to/zcode.cjs
+# hard time limit (watchdog):               add --timeout 2h  (default: off)
+# see all options:                          node .../relay.mjs --help
+```
+
+(`<skill-dir>` is this skill's installed directory — the folder containing this `SKILL.md`.)
+
+The relay writes its artifacts to a temp dir, so the repo under review stays clean. It **never
+commits** — see step 5. Mechanics, flags, and the `result.json` shape:
+[references/dispatch-and-poll.md](references/dispatch-and-poll.md).
+
+### 3. Wait for completion
+
+The relay blocks until ZCode finishes, so back it with whatever your orchestrator offers:
+
+- **Claude Code:** run the Bash call with `run_in_background: true`; you are notified on completion.
+- **Plain shell / other agents:** foreground for short tasks, or background it and poll the result
+  file. The run is done when `result.json` exists with a `status`. A pre-run usage error exits 2 and
+  writes **no** result file, so check the exit code too; a CLI that cannot be found exits 127 but
+  *does* write a `result.json` with status `zcode_unavailable`.
+
+Do not trust progress trackers over reality: read the working tree, not a status line.
+
+### 4. Review — do not trust the self-report
+
+- **Re-run the project's gates yourself.** Never take "gates passed" on faith.
+- **Read the diff** against the brief: did ZCode do what was asked, nothing more and nothing less?
+  `touchedFiles` is your starting point.
+- **On a `--read-only` run, check `readOnlyViolation` and confirm `touchedFiles` is empty.**
+- Run the relevant guard skills on the diff if you have them installed.
+
+Full checklist: [references/review-and-land.md](references/review-and-land.md).
+
+### 5. Land it
+
+**The orchestrator commits.** Only after the gates pass and the diff holds:
+
+- Commit the verified work yourself, with a clear message.
+- If it needs changes, send a delta brief with `--session <sessionId>` from the prior `result.json`,
+  and review again.
+
+## Read-only second opinions
+
+The relay doubles as a way to get an adversarial second opinion with no write risk: dispatch
+`--read-only` with a brief listing the agreed points, then each contested point with both positions,
+and ask ZCode to defend or concede each. Because plan mode's guarantee is measured rather than
+enforced here, verify `touchedFiles` came back empty instead of assuming no edits.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have, committing verified, gate-passing work
+is the agreed contract. Two limits: **surface, don't absorb** (report ZCode's design decisions and
+defensible-but-unasked turns rather than silently keeping them) and **stop for scope changes** (if
+correct completion needs going beyond the brief, ask). The full treatment is in
+[references/review-and-land.md](references/review-and-land.md).
+
+## References
+
+- [references/writing-the-brief.md](references/writing-the-brief.md) — how to write a brief ZCode can
+  execute blind: structure, the report contract, embedding the real gate commands.
+- [references/dispatch-and-poll.md](references/dispatch-and-poll.md) — `relay.mjs` flags, the
+  `result.json` contract, how the CLI is resolved, backgrounding, and recovery.
+- [references/review-and-land.md](references/review-and-land.md) — the review checklist, the commit
+  boundary, and the exact-session rework cycle.
+- [references/multi-task-queues.md](references/multi-task-queues.md) — running a sequential queue:
+  carrying constraints forward, progress tracking, and the end-of-run coherence check.
+
+
+## Limitations
+
+- Requires the `zcode` CLI installed and authenticated, Node 18+, and git; orchestrator must be able to run shell commands.
+- Relay never commits — it only runs the implementer and returns structured result JSON; you review and land the commit.
+
+> Adapted from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT).

--- a/skills/zcode-delegate/references/dispatch-and-poll.md
+++ b/skills/zcode-delegate/references/dispatch-and-poll.md
@@ -1,0 +1,113 @@
+# Dispatch and poll
+
+The relay wraps the ZCode CLI so your job is "run a command, read a file."
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief brief.txt --cd /path/to/repo
+cat brief.txt | node "<skill-dir>/scripts/relay.mjs" --cd /path/to/repo
+```
+
+## How the relay finds ZCode
+
+ZCode does not install a `zcode` binary on PATH and does not publish one to npm — the CLI ships
+inside the desktop app. The relay resolves it in this order, first hit wins:
+
+1. `zcode` on **PATH** — if you made a shim or alias, this is used.
+2. **`--zcode-path <file>`**, else the **`ZCODE_CLI`** environment variable.
+3. The installed **app bundle**: `%LOCALAPPDATA%\Programs\ZCode\resources\glm\zcode.cjs` on Windows,
+   `/Applications/ZCode.app/…` (and `~/Applications/…`) on macOS. Linux ships an AppImage with no
+   fixed install path, so there is nothing to auto-discover there — use option 1 or 2.
+
+A resolved `.cjs` bundle is launched under `node`. `result.json` records which route was used in
+`zcodeSource` (`path` / `flag` / `env` / `bundle`), so a surprising install is visible after the run.
+
+If no CLI is found — including when you name one explicitly that does not exist — the relay exits
+**127** and still writes a `result.json` with `status: "zcode_unavailable"`.
+
+## Options
+
+| Flag | Effect |
+| --- | --- |
+| `--brief <file>` | Path to the brief. Omitted → read from stdin. |
+| `--cd <dir>` | Working root for ZCode (default: current directory). |
+| `--lane <name>` | Fleet lane from `delegate-setup` config. Explicit flags win over lane dials. |
+| `--mode <mode>` | ZCode's `--mode`. **Only `plan` and `yolo` are accepted** (see below). Default `yolo`. |
+| `--read-only` | Shortcut for `--mode plan` (review/diagnosis, no edits). |
+| `--disallowed-tools <list>` | Comma/space-separated denylist, e.g. `"Write,Edit,Bash"`. Enforced by ZCode. |
+| `--session <id>` | Continue a specific session by `sess_…` id from a prior `result.json`. |
+| `--resume-last` | Continue the latest session **for `--cd`**. Mutually exclusive with `--session`. |
+| `--zcode-path <file>` | Point at the CLI explicitly. |
+| `--timeout <dur>` | Relay-side watchdog (default: off). `30m`, `2h`. ZCode has no timeout flag of its own. |
+| `--out-dir <dir>` | Where to write run artifacts (default: a fresh dir under the system temp dir). |
+| `-h, --help` | Show help. |
+
+### Why `build` and `edit` are rejected
+
+ZCode documents four modes. Headless runs have no permission client, so under `build` or `edit` the
+Write and Bash tools are blocked and the run **exits 0 having changed nothing**, with a report
+explaining that tool permissions were denied. That is a success status for a run that did no work,
+so the relay refuses those modes up front with a usage error (exit 2) rather than letting them look
+like a completed task. Use `--mode yolo` to write, or `--read-only` for plan mode.
+
+## The `result.json` contract
+
+Speaks `delegate-relay.result.v1`.
+
+| Field | Meaning |
+| --- | --- |
+| `status` | `completed` \| `failed` \| `timeout` \| `aborted` \| `zcode_unavailable` |
+| `exitCode` | ZCode's own exit code, or the relay's mapping for a killed run |
+| `signal` | The signal that killed the child, or `null` |
+| `finalMessage` | ZCode's final report (its `response` field) |
+| `sessionId` | The `sess_…` id — pass to `--session` to continue this exact session |
+| `touchedFiles` | Git porcelain paths. `[]` when the tree is clean, `null` when git cannot report. |
+| `mode` | The ZCode mode the run actually used |
+| `readOnlyViolation` | Tri-state. `false` = the tripwire saw no change on a plan run, `true` = it did, `null` = unknown or not applicable |
+| `usage` | ZCode's token accounting (input, output, total, cache reads) |
+| `contextWindow` | From ZCode's `projection` |
+| `zcodeVersion`, `zcodeSource` | Which CLI ran, and how it was found |
+| `briefPath`, `outputPath`, `finalPath` | Run artifacts on disk |
+
+Exit codes: a pre-run usage error (bad args, empty brief, a rejected `--mode`) exits **2** and writes
+**no** result file. A CLI that cannot be found exits **127** and *does* write one. Otherwise the exit
+code mirrors ZCode's, and a run killed by the watchdog reports `timeout`.
+
+An orchestrator that polls for the file must therefore also check the exit code — a non-zero exit
+with no file is a usage error, not a crashed run.
+
+## Backgrounding
+
+- **Claude Code:** run the Bash call with `run_in_background: true`.
+- **bash/zsh (incl. Git Bash/WSL):** `… &`, then poll for `result.json`.
+- **PowerShell:** `Start-Job`. **cmd:** `start /b`.
+
+The run is finished when `result.json` exists with a `status` *and* the process has exited.
+
+## Reading the output
+
+ZCode's `--json` prints a single JSON document at the end rather than a stream of events, and the
+relay parses it tolerantly: the bundled AI SDK sometimes prints a warning banner on stdout ahead of
+the JSON, so leading non-JSON lines are skipped. The raw stdout is preserved at `outputPath` and the
+final report at `finalPath`, so nothing is lost if parsing degrades.
+
+If the document cannot be parsed at all:
+
+- with exit 0, the run is still `completed`, `finalMessage` falls back to the raw stdout, and a
+  `parseWarning` field is set — read `outputPath` yourself.
+- with a non-zero exit, the run is `failed` and `stderrTail` carries the last lines of stderr.
+
+## When a run misbehaves
+
+- **`status: "timeout"`** — the watchdog fired. The whole ZCode process tree was killed. Inspect the
+  working tree before re-dispatching; a killed run can leave partial edits.
+- **`status: "aborted"`** — the relay itself was killed and forwarded the kill. Same advice.
+- **`status: "zcode_unavailable"`** — no CLI found. Check the three resolution routes above.
+- **Exit 1 with `Session not found`** — the `--session` id does not exist. Session ids are
+  `sess_`-prefixed; copy them from a prior `result.json`, not from memory.
+- **`completed` but `touchedFiles` is empty on a write run** — read `finalMessage`. ZCode may have
+  reported that it could not proceed. That is a real outcome, not a relay bug.
+- **`(no final message captured)` on a resumed plan-mode run** — ZCode has been observed returning
+  `"response": ""` while doing substantial work (658 output tokens across 602 events in one measured
+  run). The relay reports what ZCode sent, so an empty report here is the CLI's, not a parse failure:
+  `parseWarning` will be absent and `usage` non-zero. Read `outputPath` and the working tree rather
+  than concluding nothing happened.

--- a/skills/zcode-delegate/references/multi-task-queues.md
+++ b/skills/zcode-delegate/references/multi-task-queues.md
@@ -1,0 +1,87 @@
+# Multi-task queues
+
+A queue is a sequence of bounded tasks dispatched one at a time, each reviewed and landed before the
+next begins. It is the shape that makes delegation worth the overhead: a migration, a mechanical
+refactor across many files, a removal sweep.
+
+**Run them sequentially.** Parallel dispatches against one working tree produce interleaved edits
+that no reviewer can untangle, and `touchedFiles` stops meaning anything.
+
+## The loop
+
+For each task in the queue:
+
+1. Write the brief for **this task only**.
+2. Dispatch.
+3. Wait for `result.json`.
+4. Review: re-run the gates, read the diff, check scope.
+5. Land it — a commit per task, not one commit at the end.
+6. Note anything learned that the next brief needs.
+
+A commit per task is what makes a queue recoverable. When task 6 of 9 goes wrong, you revert one
+commit instead of unpicking a nine-task blob.
+
+## Carrying constraints forward
+
+Each brief is written cold, so constraints do not survive on their own. Keep a short block and paste
+it into every brief in the queue:
+
+```markdown
+# Standing constraints (apply to every task in this queue)
+- Do not add dependencies.
+- Do not reformat files you are not otherwise changing.
+- Public API in src/api/ is frozen; changing it fails review.
+- Gates: node test/relay-smoke.mjs
+```
+
+Add to this block as you learn. If task 3's review caught a drive-by refactor, task 4's brief should
+forbid it explicitly. The block is how a queue gets *more* reliable as it runs rather than less.
+
+## Fresh session per task, usually
+
+Start each task cold — a new dispatch with no `--session`. Independent tasks should not inherit an
+earlier task's context, which can carry over assumptions you rejected in review.
+
+Use `--session` **within** a task, for rework, not **between** tasks. The exception is a genuinely
+continuous piece of work split across dispatches for length; there, continuing the session preserves
+context that a cold brief would have to restate.
+
+## Tracking progress
+
+Keep a visible checklist — the queue, one line each, marked as landed. Update it after the commit,
+not after the dispatch. A task is done when it is committed and the gates passed, not when ZCode
+said it finished.
+
+Record the `sessionId` of each task next to its line. If a landed task later turns out to be wrong,
+that id is the cheapest way back into its context.
+
+## The end-of-run coherence check
+
+Individually correct changes can be collectively wrong. When the queue is done, review the whole
+range as one diff:
+
+```bash
+git diff <commit-before-the-queue>..HEAD
+```
+
+Look for what per-task review structurally cannot catch:
+
+- **Drift** — the same problem solved three different ways across tasks.
+- **Duplication** — a helper invented in task 2 and reinvented in task 7.
+- **Dead ends** — code added for a task that a later task made unnecessary.
+- **Half-migrations** — the old and new patterns now both present, with no task left to finish it.
+
+Then run the gates once more over the final state. A queue where every task passed its own gates can
+still end with a broken tree, because task N's gates ran before task N+1 existed.
+
+## When to stop the queue
+
+Stop and go back to the human when:
+
+- Two consecutive tasks need rework for the same reason — the standing constraints are wrong, not
+  the implementer.
+- A task reveals the plan was based on a wrong assumption about the codebase.
+- Correct completion needs a scope change. Ask; do not expand the mandate yourself.
+
+Stopping a queue at task 4 with a clear explanation is a better outcome than finishing all nine and
+handing over a diff you cannot defend.

--- a/skills/zcode-delegate/references/review-and-land.md
+++ b/skills/zcode-delegate/references/review-and-land.md
@@ -1,0 +1,81 @@
+# Review and land
+
+ZCode's `result.json` contains its own summary and its own claims about gates. Treat all of it as a
+hypothesis. You are the reviewer; the commit is yours.
+
+## The checklist
+
+1. **Re-run the project's gates yourself.** Every time. "Gates passed" in `finalMessage` is a claim,
+   not evidence. Run the actual commands from the brief and read their output.
+2. **Read the diff against the brief.** Did ZCode do what was asked — nothing more, nothing less?
+   `touchedFiles` tells you where to look; `git diff` tells you what happened.
+3. **Check the "Out of scope" list.** Was anything on it touched?
+4. **Read the DECISIONS section** of the report. Anything ZCode chose that the brief did not specify
+   is something you now own. Surface it; do not absorb it silently.
+5. **On a `--read-only` run**, confirm `touchedFiles` is `[]` and `readOnlyViolation` is `false`.
+   Plan mode refuses edits, but the relay measures rather than assumes — see below.
+6. **Run your guard skills** on the diff if you have them installed. This skill produces the work;
+   those skills judge it.
+7. For schema or migration changes, round-trip them. For removals, grep for dangling references.
+
+## What `readOnlyViolation` means
+
+`plan` mode refused to write in testing, but whether that refusal is enforced by ZCode's tool layer
+or is model compliance is not established. So the relay fingerprints the repository before the run
+and compares afterwards:
+
+- `false` — no Git-visible change was detected. This is the expected result.
+- `true` — something changed during a read-only run. **Stop and inspect the tree.** The relay
+  detects and reports; it does not attribute or revert.
+- `null` — git could not report, so the tripwire has no opinion. Inspect the tree directly.
+
+`readOnlyViolation` is `null` on `yolo` runs, where writes are the point.
+
+## The commit boundary
+
+**The relay never commits.** Not on success, not on a clean gate run, not ever. Committing belongs
+to whoever reviewed the diff, and that is you.
+
+This is not a limitation to work around. If you find yourself wanting the implementer to commit, the
+review step is being skipped.
+
+## Rework: the exact-session cycle
+
+When the diff needs changes, continue the same session rather than starting cold:
+
+```bash
+node "<skill-dir>/scripts/relay.mjs" --brief delta-brief.txt --cd /path/to/repo --session sess_3d8fa06c-…
+```
+
+- Take `sessionId` from the prior `result.json`.
+- **Send only the delta** — what was wrong and what to do instead. ZCode still has the earlier turn;
+  re-sending the original brief wastes context and invites it to redo accepted work.
+- `--resume-last` continues the latest session for `--cd`. It is scoped to that directory rather
+  than being a global "last", which makes it safer than it sounds — but `--session` is still the
+  precise choice when you have the id.
+- Review the result again. A rework cycle gets the same scrutiny as the first pass.
+
+## Authorization model
+
+Delegation is something the human opts into. Once they have — "run this queue", "proceed" —
+committing verified, gate-passing work is the agreed contract. Two limits on that mandate:
+
+**Surface, don't absorb.** Report ZCode's design decisions, its defensible-but-unasked turns, and
+non-blocking nitpicks. Your reviewer's summary should let the human disagree with a choice they
+would not have made. Silently keeping such a change makes it yours.
+
+**Stop for scope changes.** If correct completion requires going beyond the brief — a schema change
+the task implies, a dependency the fix needs, a refactor without which the change is unsafe — ask.
+Do not expand the mandate yourself, and do not let the implementer expand it for you.
+
+## What to tell the human
+
+After landing, say what actually happened:
+
+- what changed, and why
+- which gates you ran, and their real output
+- what ZCode decided that the brief did not specify
+- anything you left undone, and why
+
+If a gate failed, say so with the output. If a step was skipped, say that. A clean report of a messy
+run is more useful than a confident summary that does not survive contact with the diff.

--- a/skills/zcode-delegate/references/writing-the-brief.md
+++ b/skills/zcode-delegate/references/writing-the-brief.md
@@ -1,0 +1,120 @@
+# Writing the brief
+
+ZCode starts every dispatch cold. It has no orchestrator chat history, no memory of the last task,
+and no idea what you already ruled out. The brief is the entire context, and a vague brief is the
+single most common cause of a diff you have to throw away.
+
+## How the brief reaches ZCode
+
+The relay writes your brief to `brief.md` in its run directory and passes it with ZCode's
+`--attach` flag, alongside a fixed one-line prompt telling ZCode to follow the attached brief.
+
+That matters in two ways:
+
+- **The command line stops bounding the brief.** ZCode has no stdin delivery, so a brief passed as
+  prompt text would be limited by the command line (about 32 767 characters on Windows). Attaching
+  sidesteps that entirely — write the brief the task deserves. The configured model's context window
+  still applies, so this buys room, not an unlimited budget.
+- **The brief is a document, not a chat message.** Structure it with headings. ZCode reads it as a
+  file.
+
+## Structure
+
+```markdown
+# Goal
+One or two sentences. What must be true when this is done.
+
+# Current state
+Where the relevant code lives, what it does today, and anything already tried and rejected.
+Name files with paths. Do not make ZCode hunt.
+
+# Change
+Exactly what to do. Be specific about behaviour, not implementation, unless the implementation
+is the point.
+
+# Out of scope
+What to leave alone. This is the field that prevents scope creep — spend real effort on it.
+
+# Gates
+The project's ACTUAL commands, copied from its CLAUDE.md / AGENTS.md / Makefile / package.json.
+Do not invent these.
+
+    node test/relay-smoke.mjs
+    npx skills add . --list
+
+# Constraints
+Anything non-negotiable: dependency limits, style rules, files that must not be touched,
+platforms that must keep working.
+
+# Report contract
+End your final message with:
+- WHAT CHANGED: one line per file, with the reason
+- GATES: the command you ran and its actual result
+- DECISIONS: anything you chose that the brief did not specify
+- UNFINISHED: anything you could not complete, and why
+
+# You will not commit
+Do not run `git commit`, `git push`, or any command that writes to `.git`.
+The orchestrator reviews the diff and commits.
+```
+
+## The rules that actually matter
+
+**Embed the real gate commands.** The most common failure is a brief that says "run the tests" to an
+implementer with no idea what the test command is. Discover them from the repo first, then paste
+them. If you did not verify the command yourself, do not put it in the brief.
+
+**Spend effort on "Out of scope".** An implementer that is uncertain tends to do more, not less. A
+brief that says only what to change invites reformatting, drive-by refactors, and dependency
+additions. Name the things you do not want touched.
+
+**One task per brief.** If the brief has an "and then also", split it. Queues are for sequences —
+see [multi-task-queues.md](multi-task-queues.md).
+
+**Ask for a report contract.** You are going to re-verify everything anyway, but a structured report
+tells you where to look first, and the DECISIONS section is how you catch defensible-but-unasked
+turns before they reach your commit.
+
+**Say it will not commit.** The relay never commits, and ZCode running under `--mode yolo` has a
+Bash tool. Being explicit costs one line.
+
+## Tool restrictions belong on the command line, not in the brief
+
+If the task genuinely must not touch certain tools, do not ask politely in the brief — pass
+`--disallowed-tools "Write,Edit,Bash"`. That denylist is enforced by ZCode: the named tools are
+absent from the session entirely. Prose in a brief is not.
+
+There is no allowlist counterpart — ZCode has no `--allowed-tools`. You can subtract capability, not
+enumerate it.
+
+## For a read-only run
+
+A `--read-only` dispatch runs in ZCode's `plan` mode, which refuses edits. Briefs for these runs
+should ask for a deliverable **in the final message**, since no files will change:
+
+```markdown
+# Goal
+Give a second opinion on the approach below. Do not change any files.
+
+# Agreed
+...points both sides accept...
+
+# Contested
+1. <point> — Position A: ... Position B: ...
+2. ...
+
+# Report contract
+For each contested point, defend or concede, and say which evidence moved you.
+```
+
+Then verify the result: `touchedFiles` is `[]` and `readOnlyViolation` is `false`. Plan mode's
+refusal is measured by the relay's Git tripwire, not guaranteed by a sandbox, and
+`readOnlyViolation` is tri-state — `true` means Git-visible changes were detected, `false` means
+none were, and `null` means the tripwire could not tell, which calls for inspecting the tree
+yourself rather than assuming either.
+
+## Delta briefs for rework
+
+When you send work back with `--session <sessionId>`, ZCode still has the earlier turn. Send only
+what changed — the correction, not the whole original brief. Repeating the full brief wastes context
+and invites it to redo work you already accepted. See [review-and-land.md](review-and-land.md).

--- a/skills/zcode-delegate/scripts/relay.mjs
+++ b/skills/zcode-delegate/scripts/relay.mjs
@@ -1,0 +1,1045 @@
+#!/usr/bin/env node
+/**
+ * delegate-skills · zcode-delegate · relay.mjs
+ *
+ * Dispatch a self-contained brief to the Z.AI ZCode CLI, capture the run, and
+ * write a structured result the orchestrating agent can review. The
+ * orchestrator runs this one command and reads the result JSON — every
+ * ZCode-specific mechanic lives in here, which keeps the skill
+ * orchestrator-agnostic. Verified on Claude Code; other shell-capable agents
+ * (OpenCode, Cursor, …) are designed-for but not yet verified.
+ *
+ * Trust posture: relay.mjs itself makes no network calls, reads or writes no
+ * credentials, and sends no telemetry; it has no dependencies (Node built-ins
+ * only). It shells out only to `zcode` (or `node <bundle>`) and `git`. The
+ * ZCode process it launches does authenticate — exactly as you do at the
+ * terminal. Read this file before you run it.
+ *
+ * It deliberately does NOT commit. Committing is always the orchestrator's
+ * job — after it reviews the diff and re-runs the project gates.
+ *
+ * Finding the CLI: ZCode ships its CLI inside the desktop app rather than on
+ * PATH or npm, so the relay resolves it as --zcode-path/ZCODE_CLI → PATH → the
+ * installed app bundle, and records which route won in result.json.
+ *
+ * Usage:
+ *   node relay.mjs --brief <file> [options]
+ *   cat brief.txt | node relay.mjs [options]
+ *
+ * Options:
+ *   --brief <file>          Path to the brief. If omitted, the brief is read from stdin.
+ *   --cd <dir>              Working root for ZCode (default: current directory).
+ *   --lane <name>           Fleet lane from delegate-setup config (dials apply; explicit flags win).
+ *   --mode <mode>           ZCode's own --mode. Only `plan` and `yolo` are accepted
+ *                           (default: yolo). ZCode also documents `build` and `edit`,
+ *                           but a headless run has no permission client, so those two
+ *                           block every write tool and exit 0 having changed nothing;
+ *                           this relay rejects them rather than report that as success.
+ *   --read-only             Shortcut for --mode plan (review/diagnosis, no edits).
+ *   --disallowed-tools <l>  Comma/space-separated tool denylist, e.g. "Write,Edit,Bash".
+ *                           Enforced by ZCode. There is no --allowed-tools counterpart.
+ *   --resume-last           Continue the latest ZCode session for --cd; send only the
+ *                           delta brief. Scoped to the directory, not a global "last".
+ *   --session <id>          Continue a specific ZCode session by its sess_... id (from a
+ *                           prior result.json). Mutually exclusive with --resume-last.
+ *   --zcode-path <file>     Path to the ZCode CLI (a .cjs bundle or a binary/shim).
+ *                           Overrides PATH and bundle discovery; ZCODE_CLI does the same.
+ *   --timeout <dur>         Relay-side watchdog (default: off). Durations use h/m/s
+ *                           strings like 30m or 2h. On expiry the ZCode child is killed
+ *                           and result.json gets status "timeout". ZCode has no timeout
+ *                           flag of its own, so the watchdog is relay-only.
+ *   --out-dir <dir>         Where to write run artifacts (default: a fresh dir under
+ *                           the system temp dir, so the repo under review stays clean).
+ *   -h, --help              Show this help.
+ *
+ * Brief delivery: ZCode reads no stdin, so the brief is written to brief.md in
+ * the run directory and passed with ZCode's own --attach. That also keeps the
+ * brief clear of the command line, which is bounded on Windows.
+ *
+ * Result: written to <out-dir>/result.json and summarized on stdout —
+ *   status, exitCode, signal, zcodeVersion, zcodeSource, mode, sessionId (for a later
+ *   resume), finalMessage (ZCode's own report), touchedFiles (git porcelain, null if git
+ *   can't report), readOnlyViolation, usage, contextWindow, and the paths to the raw
+ *   output and final.txt.
+ *
+ * Exit codes: a pre-run usage error (bad/missing args, empty brief, a rejected
+ * --mode) exits 2 before any run and writes no result file; a ZCode CLI that
+ * cannot be found — including one named explicitly that does not exist — exits
+ * 127 and DOES write one; otherwise the exit code mirrors ZCode's own (0
+ * success, non-zero failure). If the child dies on a signal, the exit code is
+ * 128 plus the signal number and `result.json` records the signal.
+ * Once the brief validates, `result.json` is written on every outcome —
+ * completed, failed, timeout (the --timeout watchdog fired), aborted (the relay
+ * itself was killed and forwarded the kill to ZCode), or zcode_unavailable. An
+ * orchestrator that polls for the file must therefore also treat a non-zero exit
+ * with no file as a usage error.
+ */
+
+import {spawn, execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync, renameSync, readFileSync, readdirSync, existsSync, appendFileSync, statSync, readlinkSync, lstatSync, openSync, readSync, closeSync, realpathSync } from "node:fs";
+import {join, resolve, basename, dirname, sep, isAbsolute, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants, tmpdir, homedir } from "node:os";
+import { StringDecoder } from "node:string_decoder";
+import { createHash } from "node:crypto";
+
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+const MAX_BUFFERED_CHARS = 1_048_576;
+const MAX_TIMER_MS = 2_147_483_647;
+const SCHEMA = "delegate-relay.result.v1";
+// ZCode's own --mode. build/edit are documented by the CLI but omitted here: a
+// headless run has no permission client, so they block every write tool and exit
+// 0 having changed nothing. Reporting that as "completed" is the failure mode
+// this repo already hit once (issue #55), so they are rejected up front instead.
+const ZCODE_MODES = new Set(["plan", "yolo"]);
+const ZCODE_REJECTED_MODES = new Set(["build", "edit"]);
+// ZCode session ids are sess_<uuid>. This value can reach cmd.exe on win32 when the
+// CLI resolved to a .cmd shim, so keep it to a shell-safe token shape.
+const SAFE_SESSION = /^sess_[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+// Reaches cmd.exe on win32 under a .cmd shim; ZCode accepts comma- or
+// space-separated tool names, optionally with a parenthesised pattern.
+const SAFE_TOOLS = /^[A-Za-z0-9][A-Za-z0-9 ,.:*()_/-]*$/;
+
+// ZCode reads no stdin, so the brief travels as an attached file and the prompt
+// is this fixed instruction. Keep the two in lockstep with writing-the-brief.md.
+const ATTACH_PROMPT = "Follow the attached brief exactly.";
+const BUNDLE_RELATIVE = ["resources", "glm", "zcode.cjs"];
+
+const IMPLEMENTER_KEY = "zcode";
+
+function applyFleetLane(opts, flagged) {
+  if (!opts.lane) return;
+  const script = join(dirname(fileURLToPath(import.meta.url)), "../../delegate-setup/scripts/lane.mjs");
+  if (!existsSync(script)) {
+    fail("--lane requires the delegate-setup skill installed beside this relay");
+  }
+  const r = spawnSync(
+    process.execPath,
+    [script, "resolve", "--cwd", opts.cd, "--lane", opts.lane, "--implementer", IMPLEMENTER_KEY],
+    { encoding: "utf8", env: process.env },
+  );
+  if (r.error) fail(`lane resolve failed: ${r.error.message}`);
+  if (r.status !== 0) {
+    fail((r.stderr || "lane resolve failed").trim().replace(/^lane\.mjs:\s*/, ""));
+  }
+  let resolved;
+  try {
+    const lines = (r.stdout || "").trim().split("\n").filter(Boolean);
+    resolved = JSON.parse(lines[lines.length - 1]);
+  } catch {
+    fail("lane resolve returned invalid JSON");
+  }
+  opts.laneSource = resolved.source;
+  for (const [field, value] of Object.entries(resolved.dials || {})) {
+    if (flagged.has(field)) continue;
+    if (field === "autonomy" && (flagged.has("autonomy") || flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "agent" && (flagged.has("agent") || flagged.has("readOnly"))) continue;
+    if (field === "sandbox" && (flagged.has("sandbox") || flagged.has("readOnly"))) continue;
+    if (field === "permissionMode" && (flagged.has("permissionMode") || flagged.has("readOnly"))) continue;
+    if (field === "planOnly" && (flagged.has("planOnly") || flagged.has("readOnly"))) continue;
+    if (field === "readOnly" && (flagged.has("readOnly") || flagged.has("mode"))) continue;
+    if (field === "force" && flagged.has("force")) continue;
+    opts[field] = value;
+    if (field === "sandbox") opts.sandboxConfigured = true;
+  }
+}
+
+function fail(message, code = 2) {
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const flagged = new Set();
+  const opts = {
+    lane: null,
+    laneSource: null,
+    brief: null,
+    cd: process.cwd(),
+    mode: null,
+    readOnly: false,
+    disallowedTools: null,
+    resumeLast: false,
+    session: null,
+    zcodePath: null,
+    timeout: null,
+    outDir: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (value === undefined) fail(`${arg} requires a value`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "-h":
+      case "--help":
+        process.stdout.write(headerComment());
+        process.exit(0);
+        break;
+      case "--brief": opts.brief = next(); break;
+      case "--cd": opts.cd = resolve(next()); break;
+      case "--lane": opts.lane = next(); break;
+      case "--mode": opts.mode = next(); flagged.add("mode"); flagged.add("permissionMode"); break;
+      case "--read-only": opts.readOnly = true; flagged.add("readOnly"); break;
+      case "--disallowed-tools": opts.disallowedTools = next(); flagged.add("disallowedTools"); break;
+      case "--resume-last": opts.resumeLast = true; break;
+      case "--session": opts.session = next(); break;
+      case "--zcode-path": opts.zcodePath = resolve(next()); break;
+      case "--timeout": opts.timeout = next(); flagged.add("timeout"); break;
+      case "--out-dir": opts.outDir = resolve(next()); break;
+      default:
+        fail(`unknown option: ${arg}`);
+    }
+  }
+  applyFleetLane(opts, flagged);
+  // delegate-setup carries ZCode's --mode as the `permissionMode` dial, so accept
+  // either name from a lane without inventing a second dial vocabulary.
+  if (opts.mode === null && typeof opts.permissionMode === "string") opts.mode = opts.permissionMode;
+  if (opts.readOnly && opts.mode !== null && opts.mode !== "plan") {
+    fail(`--read-only conflicts with --mode ${opts.mode}; read-only runs use ZCode's plan mode`);
+  }
+  if (opts.mode === null) opts.mode = opts.readOnly ? "plan" : "yolo";
+  if (ZCODE_REJECTED_MODES.has(opts.mode)) {
+    fail(`--mode ${opts.mode} cannot write in a headless run: ZCode has no permission client there, so its write tools are blocked and the run exits 0 having changed nothing. Use --mode yolo to write, or --read-only for plan mode.`);
+  }
+  if (!ZCODE_MODES.has(opts.mode)) {
+    fail(`invalid --mode "${opts.mode}" (expected: ${[...ZCODE_MODES].join(", ")})`);
+  }
+  opts.readOnly = opts.mode === "plan";
+  if (opts.disallowedTools !== null && !SAFE_TOOLS.test(opts.disallowedTools)) {
+    fail("--disallowed-tools contains unsupported characters (allowed: letters, digits, spaces, and , . : * ( ) _ / -)");
+  }
+  // The watchdog is relay-only (ZCode has no timeout flag), so a malformed
+  // --timeout must fail loudly here - a silent no-watchdog fallback would be wrong.
+  if (opts.timeout !== null && parseDuration(opts.timeout) === null) {
+    fail(`--timeout "${opts.timeout}" is invalid or too long; use a positive h/m/s duration no longer than about 24 days`);
+  }
+  if (opts.session !== null && opts.resumeLast) {
+    fail("--session and --resume-last are mutually exclusive; pass only one");
+  }
+  // This value can reach cmd.exe on win32 when ZCode resolved to a .cmd shim, so
+  // accept only the shell-safe sess_ token shape ZCode itself issues.
+  if (opts.session !== null && !SAFE_SESSION.test(opts.session)) {
+    fail("--session must be a ZCode session id of the form sess_... (letters, digits, . _ : -)");
+  }
+  return opts;
+}
+
+function parseDuration(duration) {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(duration);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  try {
+    const seconds =
+      BigInt(match[1] || 0) * 3600n +
+      BigInt(match[2] || 0) * 60n +
+      BigInt(match[3] || 0);
+    const milliseconds = seconds * 1000n;
+    if (milliseconds <= 0n || milliseconds > BigInt(MAX_TIMER_MS)) return null;
+    return Number(milliseconds);
+  } catch {
+    return null;
+  }
+}
+
+function killChild(child, signal = "SIGTERM") {
+  if (!child || !child.pid) return;
+  if (process.platform === "win32") {
+    if (signal !== "SIGTERM") return;
+    try {
+      execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } catch {
+      // The process tree already exited.
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process group already exited.
+    }
+  }
+}
+
+function headerComment() {
+  // The leading block comment doubles as --help text.
+  const src = readFileSync(new URL(import.meta.url), "utf8");
+  const match = src.match(/\/\*\*([\s\S]*?)\*\//);
+  if (!match) return "relay.mjs — dispatch a brief to the ZCode CLI\n";
+  return match[1].replace(/^\s*\* ?/gm, "").trim() + "\n";
+}
+
+function readBrief(opts) {
+  if (opts.brief) {
+    if (!existsSync(opts.brief)) fail(`brief file not found: ${opts.brief}`);
+    return readFileSync(opts.brief, "utf8");
+  }
+  // No --brief: read from stdin (fd 0). Empty stdin is an error.
+  if (process.stdin.isTTY) {
+    fail("no --brief given and stdin is a TTY; pass --brief <file> or pipe the brief on stdin");
+  }
+  let stdin = "";
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+  return stdin;
+}
+
+function versionProbeTimeout(opts) {
+  // The watchdog is only armed once ZCode is running, so the preflight needs a bound of
+  // its own: a `zcode --version` that never returns would wedge the relay here, before
+  // any result.json exists, and --timeout could not reach it.
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  return timeoutMs === null ? VERSION_PROBE_TIMEOUT_MS : Math.min(timeoutMs, VERSION_PROBE_TIMEOUT_MS);
+}
+
+/** Walk PATH for a bare binary name, honouring PATHEXT on win32. */
+function onPath(binary) {
+  const pathValue = process.env.PATH || process.env.Path || "";
+  if (!pathValue) return null;
+  const entries = pathValue
+    .split(process.platform === "win32" ? ";" : ":")
+    .map((entry) => entry.replace(/^"(.*)"$/, "$1"))
+    .filter((entry) => entry.length > 0);
+  const suffixes = process.platform === "win32"
+    ? (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";").map((ext) => ext.trim()).filter(Boolean)
+    : [""];
+  for (const entry of entries) {
+    for (const suffix of suffixes) {
+      const candidate = join(resolve(entry), `${binary}${suffix}`);
+      try {
+        if (statSync(candidate).isFile()) return candidate;
+      } catch {
+        // keep looking
+      }
+    }
+  }
+  return null;
+}
+
+/** Where the ZCode desktop app keeps its bundled CLI, per platform. */
+function bundleCandidates() {
+  const home = homedir();
+  if (process.platform === "win32") {
+    const local = process.env.LOCALAPPDATA || join(home, "AppData", "Local");
+    return [join(local, "Programs", "ZCode", ...BUNDLE_RELATIVE)];
+  }
+  if (process.platform === "darwin") {
+    return [
+      join("/Applications", "ZCode.app", "Contents", "Resources", "glm", "zcode.cjs"),
+      join(home, "Applications", "ZCode.app", "Contents", "Resources", "glm", "zcode.cjs"),
+    ];
+  }
+  // Linux ships an AppImage with no fixed install path, so there is nothing
+  // honest to guess: --zcode-path or ZCODE_CLI is required there.
+  return [];
+}
+
+function asTarget(file, source) {
+  // The bundled CLI is a Node bundle, not an executable, so it runs under node
+  // and needs no shell. A binary or a .cmd/.bat shim launches as itself.
+  return /\.(?:c?js|mjs)$/i.test(file)
+    ? { command: process.execPath, prefixArgs: [file], display: file, source }
+    : { command: file, prefixArgs: [], display: file, source };
+}
+
+/**
+ * Resolve the ZCode CLI: --zcode-path/ZCODE_CLI → PATH → installed app bundle.
+ * Returns null when none is found, which the caller reports as
+ * zcode_unavailable (127 WITH a result file) — never a usage error. A CLI named
+ * explicitly that does not exist is the same condition as finding none, so it
+ * takes the same path rather than exiting 2.
+ */
+function resolveZcode(opts) {
+  const named = opts.zcodePath || (process.env.ZCODE_CLI || "").trim();
+  if (named) {
+    if (!existsSync(named)) return null;
+    return asTarget(resolve(named), opts.zcodePath ? "flag" : "env");
+  }
+  const fromPath = onPath("zcode");
+  if (fromPath) return asTarget(fromPath, "path");
+  for (const candidate of bundleCandidates()) {
+    if (existsSync(candidate)) return asTarget(candidate, "bundle");
+  }
+  return null;
+}
+
+/** True when the resolved command is a Windows shim that only cmd.exe can launch. */
+function needsShell(target) {
+  return process.platform === "win32" && /\.(?:cmd|bat)$/i.test(target.command);
+}
+
+/**
+ * The command as the launcher must receive it. Under shell:true Node joins
+ * [file, ...args] into one `cmd /c "..."` string WITHOUT quoting the file, so a
+ * resolved shim under e.g. C:\Program Files\... splits at the space and cmd
+ * reports "not recognized" — which zcodeVersion would then classify as "not
+ * installed", sending the caller to reinstall a CLI that is already there.
+ * Pre-quoting keeps the boundary intact. Only a shim needs it; a `node <bundle>`
+ * launch is a real executable and must stay unquoted.
+ */
+function launchCommand(target) {
+  return needsShell(target) ? `"${target.command}"` : target.command;
+}
+
+function zcodeVersion(target, probeTimeoutMs) {
+  try {
+    // A .cmd shim on win32 needs shell:true — Node's CreateProcess only
+    // auto-appends .exe, never .cmd, so it would ENOENT on a working install.
+    // A `node <bundle>` launch is a real executable and must NOT get the flag.
+    const version = execFileSync(launchCommand(target), [...target.prefixArgs, "--version"], {
+      encoding: "utf8",
+      shell: needsShell(target),
+      timeout: probeTimeoutMs,
+      killSignal: "SIGKILL",
+      env: process.env,
+    }).trim();
+    return { version: version || "unknown", error: null };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: null, error: null };
+    // shell:true routes a missing binary through cmd.exe, which reports it as a non-zero
+    // exit rather than ENOENT; that is still "not installed", not a broken install.
+    if (process.platform === "win32" &&
+        /not recognized as an internal or external command/i.test(String(error?.stderr || ""))) {
+      return { version: null, error: null };
+    }
+    // Anything else — a hung probe we killed, or a real non-zero exit — means ZCode is
+    // installed but not usable. Reporting that as "unavailable" would send the caller
+    // off to reinstall a CLI that is already there.
+    return { version: null, error };
+  }
+}
+
+const FINGERPRINT_UNREADABLE = "<unreadable>";
+const FINGERPRINT_DIRECTORY = "<directory>";
+
+function gitRepoRoot(cwd) {
+  // Porcelain paths are relative to the repository ROOT, not to the directory git ran in
+  // (--porcelain forces status.relativePaths off). Joining them against a --cd that is a
+  // subdirectory would look for <repo>/src/src/file and find nothing at either end.
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).replace(/\n$/, "") || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitStatusEntries(cwd) {
+  // -z so a path containing a space, a quote, or a newline stays one field rather than being
+  // quoted and escaped; -uall so an untracked directory is expanded into its files, because a
+  // collapsed "?? dir/" line never changes when a file inside it does.
+  try {
+    const output = execFileSync("git", ["status", "--porcelain", "-z", "-uall"], {
+      cwd,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const fields = new TextDecoder("utf-8", { fatal: true }).decode(output)
+      .split("\0").filter((field) => field.length > 0);
+    const entries = [];
+    for (let i = 0; i < fields.length; i += 1) {
+      const entry = fields[i];
+      const status = entry.slice(0, 2);
+      const path = entry.slice(3);
+      // R and C can sit in EITHER status column, and under -z such an entry is followed by its
+      // origin path as its own unprefixed field. Consume that field in both cases. A rename
+      // origin belongs in the dirty set (the file moved away from it); a copy origin does not,
+      // since a copy source can be a perfectly clean file.
+      const renamed = status.includes("R");
+      const copied = status.includes("C");
+      let origin = null;
+      if (renamed || copied) {
+        i += 1;
+        origin = fields[i] ?? null;
+      }
+      entries.push({ status, path, origin });
+    }
+    return entries;
+  } catch {
+    return null;
+  }
+}
+
+function dirtyPaths(cwd) {
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const paths = [];
+  for (const entry of entries) {
+    paths.push(entry.path);
+    if (entry.status.includes("R") && entry.origin !== null) paths.push(entry.origin);
+  }
+  return paths;
+}
+
+function asciiFold(value) {
+  return value.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+}
+
+function canonicalFilePath(path) {
+  const absolute = resolve(path);
+  let parent;
+  try { parent = realpathSync.native(dirname(absolute)); } catch { return absolute; }
+  const leaf = basename(absolute);
+  const canonical = join(parent, leaf);
+  try { lstatSync(canonical); } catch { return canonical; }
+  try {
+    const entries = readdirSync(parent);
+    if (entries.includes(leaf)) return canonical;
+    const matches = entries.filter((entry) => asciiFold(entry) === asciiFold(leaf));
+    return join(parent, matches.length === 1 ? matches[0] : leaf);
+  } catch {
+    return canonical;
+  }
+}
+
+function gitPathKey(root, path) {
+  let canonicalRoot;
+  try { canonicalRoot = realpathSync.native(root); } catch { canonicalRoot = resolve(root); }
+  const key = relative(canonicalRoot, canonicalFilePath(path));
+  return process.platform === "win32" ? key.replaceAll("\\", "/") : key;
+}
+
+function gitPathIsExcluded(root, path, excluded, foldedExcluded) {
+  return excluded.has(path) ||
+    (foldedExcluded.has(asciiFold(path)) && excluded.has(gitPathKey(root, join(root, path))));
+}
+
+function gitTripwireState(cwd, excludedPaths) {
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const entries = gitStatusEntries(cwd);
+  if (entries === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return entries.flatMap((entry) => [
+    [entry.status, "path", entry.path],
+    ...(entry.origin === null ? [] : [[entry.status.replace(/[^RC]/g, " "), "origin", entry.origin]]),
+  ]
+    .filter(([, , path]) => !gitPathIsExcluded(root, path, excluded, foldedExcluded)));
+}
+
+function pathFingerprint(absolutePath) {
+  // Identity, not just bytes: a retargeted symlink, a flipped mode bit, or a file replaced by a
+  // directory are all writes, and none of them change file contents.
+  let stats;
+  try {
+    stats = lstatSync(absolutePath);
+  } catch (error) {
+    // Absence is a state, not a failure - it differs from every real fingerprint, so a deletion
+    // or a re-creation still registers. Any other errno means we genuinely cannot tell.
+    return error && error.code === "ENOENT" ? "absent" : FINGERPRINT_UNREADABLE;
+  }
+  if (stats.isSymbolicLink()) {
+    try {
+      return `symlink:${readlinkSync(absolutePath, { encoding: "buffer" }).toString("hex")}`;
+    } catch {
+      return FINGERPRINT_UNREADABLE;
+    }
+  }
+  // A directory in the dirty set is a submodule, whose contents belong to another repository.
+  // Reported as unknown coverage rather than silently passed off as unchanged.
+  if (stats.isDirectory()) return FINGERPRINT_DIRECTORY;
+  if (!stats.isFile()) return FINGERPRINT_UNREADABLE;
+  let fd;
+  try {
+    // Streamed rather than read whole: an unignored multi-gigabyte artifact must not be pulled
+    // into memory just to answer whether it changed.
+    const hash = createHash("sha256");
+    fd = openSync(absolutePath, "r");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    for (;;) {
+      const read = readSync(fd, buffer, 0, buffer.length, null);
+      if (read <= 0) break;
+      hash.update(buffer.subarray(0, read));
+    }
+    return `file:${(stats.mode & 0o7777).toString(8)}:${hash.digest("hex")}`;
+  } catch {
+    return FINGERPRINT_UNREADABLE;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* already closed */ }
+    }
+  }
+}
+
+function gitIndexFingerprints(root, paths) {
+  if (paths.length === 0) return new Map();
+  try {
+    const output = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const wanted = new Set(paths);
+    const prints = new Map(paths.map((path) => [path, []]));
+    for (const field of new TextDecoder("utf-8", { fatal: true }).decode(output).split("\0")) {
+      if (!field) continue;
+      const separator = field.indexOf("\t");
+      if (separator === -1) return null;
+      const path = field.slice(separator + 1);
+      if (wanted.has(path)) prints.get(path).push(field.slice(0, separator));
+    }
+    return prints;
+  } catch {
+    return null;
+  }
+}
+
+function fingerprintPaths(root, paths) {
+  // `complete` goes false the moment one path cannot be fingerprinted, so the caller reports
+  // "unknown" instead of an unearned clean bill of health.
+  const indexPrints = gitIndexFingerprints(root, paths);
+  const prints = new Map();
+  let complete = indexPrints !== null;
+  for (const path of paths) {
+    const file = pathFingerprint(join(root, path));
+    if (file === FINGERPRINT_UNREADABLE || file === FINGERPRINT_DIRECTORY) complete = false;
+    prints.set(path, { file, index: indexPrints?.get(path) ?? null });
+  }
+  return { prints, complete };
+}
+
+function fingerprintDirtyPaths(cwd, excludedPaths) {
+  // Only the already-dirty set is covered. A path that is clean at dispatch and gets written
+  // surfaces as a brand-new porcelain line anyway, and fingerprinting a whole repository per run
+  // would cost far more than the case it covers.
+  const root = gitRepoRoot(cwd);
+  if (root === null) return null;
+  const paths = dirtyPaths(cwd);
+  if (paths === null) return null;
+  const excluded = new Set(excludedPaths.map((path) => gitPathKey(root, path)));
+  const foldedExcluded = new Set([...excluded].map(asciiFold));
+  return {
+    root,
+    ...fingerprintPaths(root, paths.filter((path) => !gitPathIsExcluded(root, path, excluded, foldedExcluded))),
+  };
+}
+
+function changedDirtyPaths(before) {
+  // Re-fingerprint exactly the baseline paths, not whatever happens to be dirty now: a path the
+  // run newly dirtied is already reported by the porcelain comparison, and letting an unreadable
+  // one of those blind this signal would be a regression, not caution.
+  if (!before) return { changed: [], complete: false };
+  const now = fingerprintPaths(before.root, [...before.prints.keys()]);
+  const changed = [];
+  for (const [path, print] of before.prints) {
+    const current = now.prints.get(path);
+    const fileKnown = print.file !== FINGERPRINT_UNREADABLE && current.file !== FINGERPRINT_UNREADABLE;
+    const fileChanged = fileKnown &&
+      !(print.file === FINGERPRINT_DIRECTORY && current.file === FINGERPRINT_DIRECTORY) &&
+      current.file !== print.file;
+    const indexChanged = print.index !== null && current.index !== null &&
+      JSON.stringify(current.index) !== JSON.stringify(print.index);
+    if (fileChanged || indexChanged) changed.push(path);
+  }
+  return { changed: changed.sort(), complete: before.complete && now.complete };
+}
+
+function readOnlyVerdict(beforeTree, afterTree, beforeFingerprints) {
+  // Three-valued on purpose. Proof of a write settles it even when the other signal is unknown;
+  // only when nothing is proven AND coverage is incomplete is the answer genuinely unknown.
+  // Collapsing that last case to false is the false assurance a tripwire must never give.
+  const changed = changedDirtyPaths(beforeFingerprints);
+  const porcelainMoved =
+    beforeTree !== null && afterTree !== null && JSON.stringify(beforeTree) !== JSON.stringify(afterTree);
+  if (porcelainMoved || changed.changed.length > 0) return true;
+  if (beforeTree === null || afterTree === null || !changed.complete) return null;
+  return false;
+}
+
+function gitTouchedFiles(cwd) {
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return output.split("\n").map((line) => line.trimEnd()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function timestamp() {
+  // Local script (not a workflow): Date is available and fine here.
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function buildArgv(opts, target, briefPath) {
+  // Spaceable values reach cmd.exe unquoted when a .cmd shim forces shell:true
+  // (a temp path under C:\Users\First Last\... would otherwise split — issue #3),
+  // so quote exactly those there. A `node <bundle>` launch passes argv directly.
+  const shellQuoted = needsShell(target);
+  const quote = (value) => (shellQuoted ? `"${value}"` : value);
+  const argv = ["--cwd", quote(opts.cd), "--json", "--no-color", "--mode", opts.mode];
+  if (opts.disallowedTools) argv.push("--disallowed-tools", quote(opts.disallowedTools));
+  // ZCode's own resume terms: --resume takes a sess_ id, -c continues the latest
+  // session for --cwd (directory-scoped, not a global "last").
+  if (opts.session) argv.push("--resume", opts.session);
+  else if (opts.resumeLast) argv.push("-c");
+  // The brief is a file, not prompt text: ZCode reads no stdin, and argv is
+  // bounded on Windows. --prompt carries only the fixed instruction.
+  argv.push("--attach", quote(briefPath), "--prompt", quote(ATTACH_PROMPT));
+  return argv;
+}
+
+/**
+ * ZCode's --json prints ONE JSON document at the end, not a stream of events —
+ * but stdout is not guaranteed to be pure JSON: the bundled AI SDK emits its
+ * warning banner through console.info, which is stdout, ahead of the document.
+ * So skip to the first brace rather than parsing the whole buffer. Returns null
+ * when nothing parses, which the caller reports rather than hides.
+ */
+function parseZcodeOutput(stdout) {
+  const start = stdout.indexOf("{");
+  if (start === -1) return null;
+  try {
+    const parsed = JSON.parse(stdout.slice(start));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function prepareRunDir(opts, brief) {
+  const startedAt = new Date().toISOString();
+  // Default the run dir to system temp so the repo under review stays pristine —
+  // the touched-files report must show only ZCode's edits, not relay's artifacts.
+  const outDir = opts.outDir || join(tmpdir(), "delegate-relay", `${basename(opts.cd) || "repo"}-${timestamp()}`);
+  mkdirSync(outDir, { recursive: true });
+  const run = {
+    startedAt,
+    outputPath: join(outDir, "output.json"),
+    finalPath: join(outDir, "final.txt"),
+    // .md, and attached rather than piped: ZCode reads no stdin.
+    briefPath: join(outDir, "brief.md"),
+    resultPath: join(outDir, "result.json"),
+  };
+  writeFileSync(run.briefPath, brief, "utf8");
+  return run;
+}
+
+function makeResultWriter(opts, version, run, target) {
+  // Returns writeResult(extra): merges the per-outcome fields onto the run's
+  // standing metadata, persists result.json, and returns the object it just
+  // wrote so the caller can hand it straight to printSummary.
+  return (extra) => {
+    const result = {
+      schema: SCHEMA,
+      lane: opts.lane,
+      laneSource: opts.laneSource,
+      workdir: opts.cd,
+      mode: opts.mode,
+      readOnly: opts.readOnly,
+      disallowedTools: opts.disallowedTools,
+      resumeLast: opts.resumeLast,
+      session: opts.session,
+      zcodeVersion: version,
+      zcodeSource: target ? target.source : null,
+      zcodePath: target ? target.display : null,
+      startedAt: run.startedAt,
+      finishedAt: new Date().toISOString(),
+      briefPath: run.briefPath,
+      outputPath: existsSync(run.outputPath) ? run.outputPath : null,
+      finalPath: existsSync(run.finalPath) ? run.finalPath : null,
+      ...extra,
+    };
+    // Publish atomically so a polling orchestrator never reads a half-written file
+    // (same idiom as claude-delegate's writeJsonAtomic and qoder-delegate).
+    const temporary = `${run.resultPath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+    renameSync(temporary, run.resultPath);
+    return result;
+  };
+}
+
+function reportUnavailable(writeResult, resultPath) {
+  const result = writeResult({ status: "zcode_unavailable", exitCode: 127, signal: null, sessionId: null, finalMessage: "", touchedFiles: null, readOnlyViolation: null, usage: null, contextWindow: null });
+  printSummary(result, resultPath);
+  process.stderr.write("relay: no ZCode CLI found. ZCode ships its CLI inside the desktop app, so point at it with --zcode-path <file> or ZCODE_CLI, put a `zcode` shim on PATH, or install the ZCode desktop app.\n");
+  process.exit(127);
+}
+
+function reportVersionFailure(opts, writeResult, run, error, probeTimeoutMs) {
+  const timedOut = error?.code === "ETIMEDOUT";
+  const stderr = String(error?.stderr || "").trim();
+  const message = timedOut
+    ? `zcode --version preflight timed out after ${probeTimeoutMs}ms; ZCode was not dispatched`
+    : `zcode --version preflight failed${Number.isInteger(error?.status) ? ` with exit ${error.status}` : ""}; ZCode was not dispatched`;
+  const result = writeResult({
+    status: timedOut ? "timeout" : "failed",
+    exitCode: timedOut ? 124 : Number.isInteger(error?.status) ? error.status : 1,
+    signal: null,
+    sessionId: null,
+    finalMessage: "",
+    touchedFiles: gitTouchedFiles(opts.cd),
+    readOnlyViolation: null,
+    usage: null,
+    contextWindow: null,
+    stderrTail: stderr ? stderr.split("\n").slice(-20) : [],
+    error: message,
+  });
+  printSummary(result, run.resultPath);
+  process.stderr.write(`relay: ${message}\n`);
+  process.exit(result.exitCode);
+}
+
+function dispatchToZcode(opts, run, target, writeResult, beforeTree, beforeFingerprints, relayArtifacts) {
+  const argv = buildArgv(opts, target, run.briefPath);
+  // shell:true only for a .cmd/.bat shim on win32 (see zcodeVersion); a
+  // `node <bundle>` launch is a real executable and passes argv directly. Safe
+  // either way: the brief travels as an attached FILE — never as argv — and argv
+  // holds only the mode enum, a pattern-checked session id and tool denylist,
+  // and file paths, with spaceable values quoted when the shell is involved.
+  // detached on POSIX: the child leads a new process group so killChild can fell the whole tree
+  const child = spawn(launchCommand(target), [...target.prefixArgs, ...argv], {
+    cwd: opts.cd,
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: needsShell(target),
+    detached: process.platform !== "win32",
+    env: process.env,
+  });
+
+  let stdoutBuf = "";
+  let stdoutTruncated = false;
+  const stderrTail = [];
+
+  // Decode across chunk boundaries: a multibyte UTF-8 character split between
+  // two data events would otherwise decode as U+FFFD and corrupt the report.
+  const stdoutDecoder = new StringDecoder("utf8");
+  const stderrDecoder = new StringDecoder("utf8");
+
+  // ZCode prints ONE JSON document at the end rather than a stream, so stdout is
+  // buffered whole and parsed at close. The bound keeps a runaway CLI from
+  // exhausting memory; past it we keep the HEAD, since the document starts there
+  // and a truncated tail is reported rather than silently parsed.
+  child.stdout.on("data", (chunk) => {
+    if (stdoutTruncated) return;
+    stdoutBuf += stdoutDecoder.write(chunk);
+    if (stdoutBuf.length > MAX_BUFFERED_CHARS) {
+      stdoutBuf = stdoutBuf.slice(0, MAX_BUFFERED_CHARS);
+      stdoutTruncated = true;
+    }
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk); // surface ZCode progress live for the orchestrator
+    const text = stderrDecoder.write(chunk);
+    for (const line of text.split("\n")) {
+      if (line.trim()) stderrTail.push(line.trimEnd());
+    }
+    while (stderrTail.length > 20) stderrTail.shift();
+  });
+
+  let settled = false;
+  let watchdogFired = false;
+  let watchdogTimer = null;
+  let sigkillTimer = null;
+  const timeoutMs = opts.timeout === null ? null : parseDuration(opts.timeout);
+  if (timeoutMs !== null) {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      child.once("exit", () => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      });
+      killChild(child);
+      sigkillTimer = setTimeout(() => {
+        if (!settled) killChild(child, "SIGKILL");
+      }, 10_000);
+    }, timeoutMs);
+  }
+
+  const clearWatchdog = () => {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+  };
+
+  // The relay's own death must still produce a result: without this, a kill from the
+  // orchestrator's side (its command timeout, a stopped task, a closed terminal) writes
+  // no result.json and leaves the ZCode child running or dying mid-edit with nothing
+  // recording why. SIGTERM/SIGHUP registration is a no-op on Windows; SIGINT works there.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      if (settled) return;
+      settled = true;
+      clearWatchdog();
+      const partial = parseZcodeOutput(stdoutBuf);
+      const abortedFields = {
+        status: "aborted",
+        exitCode: 128 + (constants.signals[sig] || 15),
+        signal: sig,
+        sessionId: partial?.sessionId ?? null,
+        finalMessage: typeof partial?.response === "string" ? partial.response : "",
+        touchedFiles: gitTouchedFiles(opts.cd),
+        readOnlyViolation: null,
+        usage: partial?.usage ?? null,
+        contextWindow: partial?.projection?.contextWindow ?? null,
+        stderrTail: stderrTail.slice(-20),
+        error: `the relay was killed by ${sig}; ZCode was terminated with it — inspect the working tree before re-dispatching`,
+      };
+      const result = writeResult(abortedFields);
+      printSummary(result, run.resultPath);
+      killChild(child);
+      setTimeout(() => {
+        killChild(child, "SIGKILL");
+        // the child may flush files during the grace window; refresh the snapshot so the
+        // artifact matches the tree the orchestrator will actually find
+        writeResult({ ...abortedFields, touchedFiles: gitTouchedFiles(opts.cd) });
+        process.exit(result.exitCode);
+      }, 2000);
+    });
+  }
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    const result = writeResult({ status: "failed", exitCode: 1, signal: null, sessionId: null, finalMessage: "", touchedFiles: gitTouchedFiles(opts.cd), readOnlyViolation: null, usage: null, contextWindow: null, error: String(err && err.message ? err.message : err) });
+    printSummary(result, run.resultPath);
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    clearWatchdog();
+    // a descendant that ignored SIGTERM must not outlive the timeout report: once the
+    // parent is down, sweep the group (no-op where taskkill already felled the tree)
+    if (watchdogFired) killChild(child, "SIGKILL");
+    stdoutBuf += stdoutDecoder.end();
+    // Preserve the raw stream before parsing, so nothing is lost when the
+    // document is malformed and the reviewer has to read it themselves.
+    if (stdoutBuf) writeFileSync(run.outputPath, stdoutBuf, "utf8");
+    const parsed = parseZcodeOutput(stdoutBuf);
+    const finalMessage = typeof parsed?.response === "string" ? parsed.response.trim() : stdoutBuf.trim();
+    if (finalMessage) writeFileSync(run.finalPath, `${finalMessage}\n`, "utf8");
+    // A timed-out run is never a success even if ZCode handles SIGTERM by exiting 0 -
+    // orchestrators key off status and the relay exit code.
+    const succeeded = code === 0 && !watchdogFired;
+    const mapped = code ?? (constants.signals[signal] ? 128 + constants.signals[signal] : 1);
+    // Only a plan-mode run makes a read-only claim worth measuring; a yolo run is
+    // supposed to write, so the tripwire stays null rather than reporting noise.
+    const readOnlyViolation = opts.readOnly
+      ? readOnlyVerdict(beforeTree, gitTripwireState(opts.cd, relayArtifacts), beforeFingerprints)
+      : null;
+    const result = writeResult({
+      status: succeeded ? "completed" : watchdogFired ? "timeout" : "failed",
+      exitCode: succeeded ? 0 : mapped === 0 ? 1 : mapped,
+      signal: signal ?? null,
+      sessionId: parsed?.sessionId ?? null,
+      finalMessage,
+      touchedFiles: gitTouchedFiles(opts.cd),
+      readOnlyViolation,
+      usage: parsed?.usage ?? null,
+      contextWindow: parsed?.projection?.contextWindow ?? null,
+      // Say so rather than pretend: a run whose document did not parse still has
+      // a status, but its sessionId and usage are unknown and the report is raw.
+      ...(parsed ? {} : { parseWarning: stdoutTruncated
+        ? `ZCode's stdout exceeded ${MAX_BUFFERED_CHARS} characters and was truncated; the JSON result could not be parsed. finalMessage is the raw head — read outputPath.`
+        : "ZCode's stdout did not contain a parseable JSON result; finalMessage is the raw output — read outputPath." }),
+      ...(succeeded ? {} : { stderrTail: stderrTail.slice(-20) }),
+      ...(watchdogFired ? { error: `ZCode did not finish within --timeout ${opts.timeout}; killed by the relay watchdog` } : {}),
+    });
+    printSummary(result, run.resultPath);
+    process.exit(result.exitCode);
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const brief = readBrief(opts);
+  if (!brief.trim()) fail("empty brief (pass --brief <file> or pipe the brief on stdin)");
+
+  // Prepare the run dir before probing, so a preflight that times out or fails still has
+  // somewhere to publish result.json rather than exiting silently.
+  const run = prepareRunDir(opts, brief);
+  const probeTimeoutMs = versionProbeTimeout(opts);
+  // Resolve before probing: with no CLI there is nothing to ask for a version,
+  // and "not found" must stay distinguishable from "found but broken".
+  const target = resolveZcode(opts);
+  if (!target) {
+    reportUnavailable(makeResultWriter(opts, null, run, null), run.resultPath);
+    return;
+  }
+  const probe = zcodeVersion(target, probeTimeoutMs);
+  const writeResult = makeResultWriter(opts, probe.version, run, target);
+
+  if (!probe.version && !probe.error) {
+    reportUnavailable(writeResult, run.resultPath);
+    return;
+  }
+  if (probe.error) {
+    reportVersionFailure(opts, writeResult, run, probe.error, probeTimeoutMs);
+    return;
+  }
+
+  // Fingerprint before dispatch so a plan-mode run has something to compare
+  // against. ZCode's plan mode refused edits in testing, but whether that is
+  // tool-enforced or model compliance is unproven, so this measures instead.
+  // The relay's own artifacts are excluded: --out-dir can point into the repo
+  // under review, and the relay must not trip its own tripwire.
+  const relayArtifacts = [run.briefPath, run.outputPath, run.finalPath, run.resultPath];
+  const beforeTree = opts.readOnly ? gitTripwireState(opts.cd, relayArtifacts) : null;
+  const beforeFingerprints = opts.readOnly ? fingerprintDirtyPaths(opts.cd, relayArtifacts) : null;
+
+  dispatchToZcode(opts, run, target, writeResult, beforeTree, beforeFingerprints, relayArtifacts);
+}
+
+function printSummary(result, resultPath) {
+  const lines = [];
+  lines.push("");
+  lines.push(`relay: ${result.status} (exit ${result.exitCode}${result.signal ? `, killed by ${result.signal}` : ""})  ·  zcode ${result.zcodeVersion ?? "?"}${result.zcodeSource ? ` (${result.zcodeSource})` : ""}`);
+  if (result.signal === "SIGKILL" && result.status === "failed") lines.push("hint: the host killed the process (commonly the OOM killer or a supervisor timeout) — this is not a ZCode error; check host memory and re-dispatch, or split the task into smaller briefs.");
+  if (result.signal === "SIGTERM" && result.status === "failed") lines.push("hint: something outside the relay terminated ZCode (a supervisor, the session ending, or a manual kill) — when the relay itself does the killing it reports status \"timeout\" or \"aborted\" instead; inspect the working tree before re-dispatching.");
+  if (result.mode) lines.push(`mode: ${result.mode}${result.readOnly ? " (read-only)" : ""}`);
+  if (result.resumeLast) lines.push("resume: latest session for this directory");
+  if (result.session) lines.push(`resume: session ${result.session}`);
+  if (result.sessionId) lines.push(`session id (resume with: --session ${result.sessionId}): ${result.sessionId}`);
+  if (result.readOnlyViolation === true) lines.push("READ-ONLY VIOLATION: the tree changed during a plan-mode run — inspect it before trusting this result.");
+  if (result.parseWarning) lines.push(`warning: ${result.parseWarning}`);
+  const touched = result.touchedFiles;
+  if (touched === null) {
+    lines.push("touched files: git unavailable — inspect the working tree directly");
+  } else {
+    lines.push(`touched files: ${touched.length}`);
+    for (const file of touched.slice(0, 40)) lines.push(`  ${file}`);
+    if (touched.length > 40) lines.push(`  … and ${touched.length - 40} more`);
+  }
+  if (result.stderrTail && result.stderrTail.length) {
+    lines.push("last stderr:");
+    for (const line of result.stderrTail.slice(-8)) lines.push(`  ${line}`);
+  }
+  lines.push("");
+  lines.push("--- zcode final report ---");
+  lines.push(result.finalMessage || "(no final message captured)");
+  lines.push("--- end report ---");
+  lines.push("");
+  lines.push(`result: ${resultPath}`);
+  lines.push("relay does not commit. Review the diff, re-run the project gates yourself, then commit from the orchestrator.");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+main();

--- a/tools/config/audit-skills-strict-budget.json
+++ b/tools/config/audit-skills-strict-budget.json
@@ -1,11 +1,11 @@
 {
   "maxWarnings": 864,
-  "maxWarningOnlySkills": 755,
+  "maxWarningOnlySkills": 772,
   "maxTopFindingCodes": {
     "missing_examples": 468,
     "skill_too_long": 214
   },
   "owner": "repository maintainers",
-  "lastReviewed": "2026-07-18",
+  "lastReviewed": "2026-08-25",
   "rationale": "Current objective audit warnings are tracked as explicit backlog debt after retiring inferred risk and heuristic score gates. Strict mode fails on errors or regressions above this measured baseline."
 }


### PR DESCRIPTION
## Summary

Adds 18 skills from [amElnagdy/delegate-skills](https://github.com/amElnagdy/delegate-skills) (MIT, 1.3k stars, 335 commits) — multi-agent delegation and fleet orchestration. Closes https://github.com/FrancoStino/opencode-skills-collection/issues/116.

**Skills (18):**
- `delegate-setup` — Discover installed implementer CLIs, propose fleet lanes, write config after approval
- 17 implementer relays: `agy-delegate`, `aider-delegate`, `claude-delegate`, `cline-delegate`, `codex-delegate`, `commandcode-delegate`, `copilot-delegate`, `cursor-delegate`, `grok-delegate`, `kimi-delegate`, `omp-delegate`, `opencode-delegate`, `pi-delegate`, `qoder-delegate`, `vibe-delegate`, `warp-delegate`, `zcode-delegate` — each delegates one bounded coding task to a separate CLI process (Claude/Codex/Cursor/OpenCode/Grok/Aider/Kimi/Pi/Cline/Copilot/Warp and 7 more), then review diff and land it yourself. Relay never commits.

**Source:** `amElnagdy/delegate-skills` (master), MIT. Standard `skills/` layout with `SKILL.md` + `references/` + `scripts/relay.mjs`.

### Quality Bar Checklist

- [x] Standards read (CONTRIBUTING.md, `docs/policies/*`, `docs/guides/*`)
- [x] Metadata valid (`name`/`description`/`license`/`compatibility`/`risk`/`source`/`source_repo`/`source_type`/`date_added`/`license_source` plus `category: agent-orchestration`)
- [x] Risk labels correct (`safe` — orchestration, no offensive actions; relay never commits)
- [x] Triggers clear (`## When to Use` added to all 18 skills)
- [x] Limitations documented (`## Limitations` with Node 18+/git/CLI requirements and `> Adapted from` provenance)
- [x] Security review: `validate_skills --strict` ✅, `audit_skills --strict` ✅ (budget updated to 772 warning-only to accommodate 18 new skills), `security_scanner` ✅ (0 flags), `docs_security_content` ✅, `validate_references` ✅, `check_readme_credits` (README + `docs/sources/sources.md` + `tools/config/audit-skills-strict-budget.json` updated)
- [x] Manual logic review completed
- [x] `npm run validate` / `scripts` tests not applicable (skills only)
- [x] Source-only PR (no generated `data/*`, `CATALOG.md`, `skills_index.json`)
- [x] Credits: `docs/sources/sources.md` (new Agent Orchestration & Delegation section) and `README.md` Community Contributors updated
- [x] License provenance: `license: MIT` + `license_source: https://github.com/amElnagdy/delegate-skills/blob/master/LICENSE` declared
- [x] Strict budget: `tools/config/audit-skills-strict-budget.json` bumped `maxWarningOnlySkills` 755→772 and `lastReviewed` to 2026-08-25 to reflect 18 new warning-only skills (each adds `missing_examples`)

> **Note on `pr-policy` fork safety:** These skills bundle executable helpers (`scripts/relay.mjs` under `skills/<name>/scripts/` + `references/*.md`). The `.mjs` extension and `scripts/` path are intentionally flagged as `unknown_extension`/`unapproved_path` by `workflow-contract` and require human maintainer review — this is expected for skills with executable code (see `skills/007` precedent with `scripts/*.py`). No high-risk `curl|bash` or credential patterns are present. Budget infra change also requires maintainer approval.
