### PR TITLE
feat: add html-docs skill

### DIFF
--- a/skills/html-docs/SKILL.md
+++ b/skills/html-docs/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: html-docs
+description: "Create source-grounded HTML documents, narrated videos, or courses, then publish and review them through HTML Docs. Use for visual explanations, artifact publishing, comments, and iterative updates."
+category: content
+risk: critical
+source: https://github.com/raunaqbn/html-docs-skill/tree/main/html-docs
+source_repo: raunaqbn/html-docs-skill
+source_type: community
+date_added: "2026-08-25"
+author: Raunaq Naidu
+tags: [documentation, html, publishing, video, courses, mcp]
+tools: [claude, codex, cursor, gemini]
+license: MIT
+license_source: https://github.com/raunaqbn/html-docs-skill/blob/main/LICENSE
+---
+
+# HTML Docs
+
+Create the clearest useful explanation of the user’s source. Use the active
+Codex or Claude session to research, write, design, and author the artifacts.
+Use the local CLI only to normalize sources, compile, validate, render,
+synchronize, and publish. Never invoke a hidden authoring model.
+
+## When to Use
+
+- Use when a user wants source material turned into a polished visual document,
+  narrated explainer, combined document and video, or structured course.
+- Use when an existing HTML Docs page must be read, edited, reviewed, commented
+  on, versioned, or updated without overwriting newer human work.
+- Use when a coding agent needs to publish HTML at a stable URL for collaborative
+  review or expose the workflow through CLI, API, or MCP tools.
+- Do not use for a quick factual answer, a throwaway note, or publication that
+  the user has not explicitly authorized.
+
+## Examples
+
+- `Use HTML Docs to turn this repository into a private onboarding course for new engineers.`
+- `Create a cited visual document and narrated explainer for this research paper.`
+- `Read the comments on this html-docs.com page, apply the requested edits, and verify the new version.`
+
+## Choose the output
+
+Resolve an explicit user request first. Otherwise use `auto`:
+
+| Mode | Choose when | Deliver |
+|---|---|---|
+| `document` | Detail, scanning, reference, data, or collaboration matters | Designed responsive HTML document |
+| `video` | Motion, sequence, mechanism, or narration is the main value | Captioned deterministic HTML video |
+| `document-video` | A focused subject benefits from both explanation and reference | Rich document with embedded live video |
+| `course` | The source has several learning outcomes or the user asks for training | Learning site with modules, lesson pages, videos, checks, and progress |
+| `auto` | The user leaves the format open | `document-video` for one focused outcome; `course` for several cumulative outcomes |
+
+State the chosen mode in one short working update, then continue. Do not stop
+for storyboard or voice approval unless the user requests an approval gate.
+Finish automatic work as a private preview. Publish publicly or unlisted only
+after explicit instruction.
+
+## Start from any source
+
+Classify the input before authoring:
+
+- HTML Docs document or folder: read it through the API.
+- Local document, PDF, HTML, Markdown, or text: recover its structure and facts.
+- Directory or Git repository: respect ignore rules; exclude credentials,
+  dependencies, build output, binaries, and VCS internals.
+- URL: capture the requested page. For a site-level request, crawl same-origin
+  links to depth two and at most 100 pages unless the user sets another bound.
+- Research topic: perform deep research with primary and authoritative sources.
+  Freeze a source manifest before writing.
+- Pasted material: preserve it as a source record rather than treating it as
+  unsupported background knowledge.
+
+Read [references/source-grounding.md](references/source-grounding.md) for source
+normalization, research, privacy, evidence IDs, and refresh rules.
+
+## Universal production loop
+
+1. **Define mastery.** Identify the audience, prerequisites, confusion gap,
+   desired capability, thesis, mechanism, evidence, and limits.
+2. **Ground claims.** Create stable source/evidence records. Every substantive
+   claim and knowledge-check answer must cite evidence.
+3. **Design the explanation.** Build a cumulative teaching spine. Do not follow
+   source order when another sequence teaches better.
+4. **Specify the learning experience.** For a course, define the learner
+   contract, demonstrated mastery states, assessment seams, dependencies, and
+   vertical production slices before authoring.
+5. **Choose a visual language.** Set typography, dominant color, contrast,
+   diagram grammar, layout rhythm, and one memorable visual signature.
+6. **Author the selected outputs.** Derive the page and video from the same
+   lesson/evidence model without duplicating them: the page is the reference;
+   the video teaches the mental model.
+7. **Audit.** Check facts, citations, readability, responsive behavior,
+   accessibility, visual quality, narration coverage, cue ownership, captions,
+   deterministic seeking, and contact sheets.
+8. **Refine until clean.** Fix every failing audit and every visibly weak scene.
+9. **Publish privately.** Return the private document/course link and the stable
+   video player link. Mention raw MP4 only as a fallback or requested download.
+
+## Document workflow
+
+Read [references/design-system.md](references/design-system.md) before any
+substantial document. Use [references/anti-slop.md](references/anti-slop.md) as
+the final visual linter. Use inline CSS and inline SVG; freeze assets locally.
+
+Publish:
+
+```bash
+npx @html-docs/cli publish page.html
+npx @html-docs/cli publish ./site --slug my-site
+```
+
+Authenticate owned work once:
+
+```bash
+npx @html-docs/cli auth
+```
+
+Read [references/api.md](references/api.md) when editing regions, commenting,
+versioning, or using document APIs. Read [references/pdf.md](references/pdf.md)
+for PDF import or export.
+
+For documents that will be reviewed or updated later, give each meaningful
+HTML block a stable `data-hd-block-id`. Use targeted block/region PATCH calls
+for local changes. Before a whole-document PUT, GET the document and send its
+ETag in `If-Match`; never overwrite a newer human review revision blindly.
+
+### Agent editing loop
+
+For an existing HTML Docs document, treat `GET /api/v1/docs/:id/editor` as the
+live semantic source of truth. Apply the smallest precise batch through
+`POST /api/v1/docs/:id/editor/commands`, then read the editor state again to
+verify it. Use visible UTF-16 offsets and `expectedText` for region selections;
+round-trip `node_checks` as `target_checks` for structured documents. A `409`
+is a request to reread and replan, never permission to overwrite.
+
+Use `set_marks` to format only the selected phrase, semantic block/node types
+for hierarchy, bounded block styles for alignment and spacing, and comments for
+review feedback. Prefer one title, consistent heading levels, predictable
+labels, short paragraphs or lists, and a final Notes section. Every agent
+command batch creates a recovery version and publishes through the
+collaboration backend, so do not replace the whole document for a local
+formatting change.
+
+For a flow, timeline, callout, metric strip, comparison, or decision matrix,
+send a semantic visual specification to
+`POST /api/v1/docs/:id/editor/visuals`; do not improvise a large HTML/SVG block.
+The endpoint uses the same deterministic renderer as Docsmith in both editor
+engines and creates a recovery version first.
+
+When the user explicitly asks for a complete transformation, read the entire
+editor payload before writing. For structured documents, send one isolated
+`replace_document` command with the complete semantic `doc` JSON. For region
+documents, use a conditional whole-document `PUT` with the latest ETag. Both
+paths must preserve the pre-change version; a `409` or `412` means reread and
+replan, not force overwrite.
+
+## Video workflow
+
+Read both:
+
+- [references/html-video.md](references/html-video.md) for project format,
+  narration, timing, captions, compilation, rendering, and publication.
+- [references/video-scene-craft.md](references/video-scene-craft.md) for
+  explanatory scene grammar, layout rhythm, cue choreography, and visual review.
+
+For narrated work, render captions in the composition itself as a karaoke rail:
+keep the phrase readable while the exact word currently spoken receives the
+design-matched highlight. WebVTT/SRT metadata alone is not a finished caption
+system.
+
+For a narrated explainer:
+
+```bash
+<skill-root>/scripts/video.sh build ./video-project
+<skill-root>/scripts/video.sh check ./video-project
+<skill-root>/scripts/video.sh audit ./video-project
+<skill-root>/scripts/video.sh render ./video-project --output ./final.mp4
+```
+
+For a document-linked video:
+
+```bash
+<skill-root>/scripts/video.sh publish ./video-project \
+  --document <document-id> \
+  --prompt "Teach the central mechanism clearly" \
+  --provider codex
+```
+
+For a standalone video, omit `--document` after the standalone video API is
+available in the installed CLI release. Always prefer the stable `/v/<code>`
+player link over the raw storage URL.
+
+## Course workflow
+
+Read all three:
+
+- [references/html-course.md](references/html-course.md) for portable course
+  artifacts, paired pages/videos, checks, publication, and refresh.
+- [references/learning-design.md](references/learning-design.md) for the learner
+  contract, mastery evidence, retrieval, feedback, adaptation, and reusable
+  teaching components.
+- [references/course-specification.md](references/course-specification.md) for
+  decision-rich course specs, vertical production slices, dependencies,
+  validation seams, and large-project uncertainty.
+
+Then:
+
+```bash
+<skill-root>/scripts/video.sh course init <source> \
+  --output ./course-project --title "Course title"
+<skill-root>/scripts/video.sh course build ./course-project
+<skill-root>/scripts/video.sh course audit ./course-project
+<skill-root>/scripts/video.sh course preview ./course-project
+<skill-root>/scripts/video.sh course publish ./course-project
+```
+
+The scaffold is not the course. Replace it with a real evidence graph, course
+specification, learner model, course map, vertical lesson slices, lesson pages,
+locked narration, cue-directed storyboards, semantic scene modules, diagnostic
+checks, captions, and source dependencies before building.
+
+For changed sources:
+
+```bash
+<skill-root>/scripts/video.sh course diff ./course-project
+<skill-root>/scripts/video.sh course refresh ./course-project
+```
+
+Regenerate only affected lessons, preserve surviving semantic overrides, audit
+again, and create a new private version. Never replace the published version
+automatically.
+
+## Guided Studio
+
+Use Studio after a private version exists:
+
+```bash
+<skill-root>/scripts/video.sh studio context <video-id>
+<skill-root>/scripts/video.sh studio requests <video-id>
+```
+
+Treat a Studio selection as precise source context: composition version, scene,
+timestamp, semantic element ID, bounds, text, evidence, and surrounding cue.
+Apply direct layout/text/color changes as structured overrides. Apply narration,
+voice, evidence, or generative scene changes in the local project, audit, then
+push a new immutable version.
+
+## Publication and authentication
+
+- Anonymous documents can be published with `curl` or the CLI.
+- Owned videos, courses, edits, and durable publication require
+  `HTMLDOCS_API_KEY` or credentials saved by `npx @html-docs/cli auth`.
+- Keep provider keys local. Never upload TTS keys or put them in a project
+  bundle.
+- Keep source projects and diagnostics private. Only published runtime bundles,
+  posters, and media should be public.
+
+Machine-readable API:
+
+```bash
+curl https://www.html-docs.com/api/v1
+```
+
+Human documentation:
+
+- https://www.html-docs.com/agents
+- https://www.html-docs.com/developers
+- https://www.html-docs.com/showcase
+
+## Limitations
+
+- Hosted editing, video, course, and durable publication operations require the
+  relevant HTML Docs service capability and authorization.
+- Source quality bounds output quality; ambiguous, inaccessible, or unsupported
+  inputs must be surfaced rather than filled with invented claims.
+- A successful local build does not replace factual, accessibility, responsive,
+  visual, and publication review.
+
+## Security & Safety Notes
+
+- Keep provider keys and HTML Docs credentials local. Never place them in source
+  bundles, published pages, shell history, logs, or examples.
+- Treat `publish_result.token` values and anonymous edit URLs as credentials;
+  redact them from shared terminals, logs, screenshots, and reports.
+- Treat public or unlisted publication as an external side effect that requires
+  explicit user instruction. Automatic production finishes as a private preview.
+- Preserve concurrent human work with targeted edits, current editor state,
+  ETags, and `If-Match`; a `409` or `412` requires rereading and replanning.
+- Exclude credentials, ignored files, dependency trees, build output, binaries,
+  and VCS internals when a directory or repository is used as source material.

--- a/skills/html-docs/agents/openai.yaml
+++ b/skills/html-docs/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "HTML Docs"
+  short_description: "Create HTML, video, and adaptive learning courses"
+  default_prompt: "Use $html-docs to turn this source into a polished private course with an observable learner finish line, evidence-state mastery, rich lesson pages, cue-synced explanatory videos, diagnostic practice, captions, and feedback."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/html-docs/references/NOTICE
+++ b/skills/html-docs/references/NOTICE
@@ -1,0 +1,95 @@
+HTML Docs — Agent Design System
+================================
+
+The agent design-system reference library under public/agents/references/
+incorporates ideas and guidance adapted from the following open-source
+projects. The material has been substantially rewritten and recast for
+HTML Docs' self-contained (inline CSS / inline SVG, no external dependencies)
+publishing model; no source code was copied.
+
+--------------------------------------------------------------------------------
+
+impeccable
+  Author:  Paul Bakaus (https://github.com/pbakaus)
+  Source:  https://github.com/pbakaus/impeccable
+  License: Apache License, Version 2.0
+
+  The reading-surface contract in references/design-system.md, the anti-pattern
+  catalog in references/anti-slop.md, and the steering vocabulary in
+  references/design-commands.md draw on impeccable's design principles,
+  catalog of anti-patterns ("slop") in AI-generated UI, and design commands.
+  Concepts were adapted and rewritten for documents; detector rules were
+  reframed as authoring heuristics.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this material except in compliance with the License. You may obtain a
+  copy of the License at:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+--------------------------------------------------------------------------------
+
+design-dna
+  Author:  zanwei (https://github.com/zanwei)
+  Source:  https://github.com/zanwei/design-dna
+  License: MIT License
+
+  The reference-to-spec approach in references/design-dna.md and the
+  visual-effects taxonomy in references/effects.md draw on design-dna's
+  concept of extracting design tokens, qualitative style, and visual effects
+  from a reference and regenerating matching UI. Concepts were adapted and
+  rewritten for self-contained documents.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files, to deal in the Software
+  without restriction, including the rights to use, copy, modify, merge,
+  publish, distribute, sublicense, and/or sell copies of the Software, subject
+  to the inclusion of the above copyright notice and this permission notice.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+
+--------------------------------------------------------------------------------
+
+mattpocock/skills
+  Author:  Matt Pocock (https://github.com/mattpocock)
+  Source:  https://github.com/mattpocock/skills
+  License: MIT License
+
+  The adaptive learner-state guidance in references/learning-design.md and the
+  decision/slicing guidance in references/course-specification.md were informed
+  by the repository's teach, to-spec, to-tickets, research, and wayfinder
+  workflows. The material was independently rewritten for source-grounded HTML
+  documents, narrated video, and learning-site production; no source code was
+  copied.
+
+  MIT License
+
+  Copyright (c) 2026 Matt Pocock
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+Adaptation © HTML Docs. The adapted reference files are part of the HTML Docs
+project and are distributed under the HTML Docs project terms.

--- a/skills/html-docs/references/anti-slop.md
+++ b/skills/html-docs/references/anti-slop.md
@@ -1,0 +1,219 @@
+# Anti-Slop — the tells of AI-generated design, and how to avoid them
+
+"Slop" is the generic, default-looking output that screams *an AI made this in
+one pass*. It's not that any single choice is wrong — it's that the same dozen
+defaults show up in every page, so everything looks the same and nothing looks
+*designed*. This file is a catalog of the most common tells, each with a way to
+**detect** it (a heuristic you can check against your own draft) and a **fix**.
+
+Read [design-system.md](design-system.md) first for the positive vision. This
+file is the negative space: what to stop doing. Run through it like a linter
+before you publish anything non-trivial.
+
+> How to use this: after you draft a doc, scan this list and honestly ask "did
+> I do that?" for each entry. Every "yes" is a place the doc looks like every
+> other AI doc. Fix the worst three before shipping.
+
+---
+
+## Typography tells
+
+### 1. The default font stack nobody chose
+- **Detect:** Body text is in Inter, Roboto, Arial, Helvetica, or unstyled
+  `sans-serif`, and you never made a deliberate type decision.
+- **Why it's slop:** These are the fonts that appear when no one picked a font.
+  They carry no mood, so the page reads as "untouched template."
+- **Fix:** Choose a stack that fits the doc's character (see the mood stacks in
+  design-system.md). A serif display face for the headline alone transforms a
+  page. System stacks are fine — `ui-serif, Georgia, serif` for an editorial
+  feel, `ui-monospace, "SF Mono", monospace` for something technical — but
+  *choose* one.
+
+### 2. One size fits all
+- **Detect:** The biggest text on the page is less than ~2.5× the body size.
+  Headings are `1.25rem`, body is `1rem`, everything is muddy and flat.
+- **Why it's slop:** No dramatic scale means no hierarchy means no focal point.
+- **Fix:** Make the hero/headline genuinely large (`clamp(2.5rem, 6vw, 4.5rem)`
+  for a title). Let the jump between levels be obvious. Contrast in size is the
+  cheapest, strongest hierarchy tool you have.
+
+### 3. Gradient text on everything
+- **Detect:** `background: linear-gradient(...); -webkit-background-clip: text;`
+  applied to headings as the default "make it pop" move.
+- **Why it's slop:** It was novel in 2021. Now it's the single most overused
+  AI-design flourish, and it usually hurts legibility.
+- **Fix:** Use a solid, confident color. If you want emphasis, use weight, size,
+  or a single accent color on one word — not a rainbow on the whole heading.
+
+### 4. Everything is centered
+- **Detect:** Most text blocks, headings, and cards are center-aligned.
+- **Why it's slop:** Center-alignment is the default when no one thought about
+  rhythm. Long centered paragraphs are hard to read; centered everything has no
+  edge to anchor the eye.
+- **Fix:** Left-align body copy and most content. Reserve centering for short
+  hero statements, single CTAs, or genuinely symmetric layouts.
+
+---
+
+## Color tells
+
+### 5. Five balanced colors instead of one
+- **Detect:** The palette has 4–5 roughly equal-weight colors, none clearly
+  dominant. Often a primary, secondary, success, warning, info — all loud.
+- **Why it's slop:** Balanced palettes have no point of view. Designed pages
+  almost always have ONE dominant hue carrying ~70% of the color, plus a single
+  accent.
+- **Fix:** Pick one dominant hue and commit. Add exactly one accent for the
+  things that must stand out. Everything else is neutral.
+
+### 6. Pure black on pure white
+- **Detect:** `color: #000` on `background: #fff`, or the reverse.
+- **Why it's slop:** Real designs almost never use `#000`/`#fff`. Pure black on
+  pure white vibrates and feels cheap.
+- **Fix:** Use a near-black (`#1a1a1a`, `#16161a`, a very dark version of your
+  hue) on an off-white or tinted background (`#fafaf8`, `#f7f6f3`, a 2–4%
+  tint of your hue). The page instantly feels considered.
+
+### 7. Flat stark-white background
+- **Detect:** `background: #fff` with no texture, tint, or gradient anywhere.
+- **Why it's slop:** Default canvas = no canvas decision.
+- **Fix:** Give the background character: a soft tint of the dominant hue, a
+  barely-there radial or linear gradient, or a subtle section banding. Keep it
+  quiet — this is atmosphere, not decoration.
+
+### 8. Gray text on a colored background
+- **Detect:** Muted gray body text (`#6b7280` and friends) sitting on a colored
+  or tinted panel.
+- **Why it's slop:** Gray was chosen for white backgrounds; on color it looks
+  muddy and the contrast is often poor.
+- **Fix:** Derive the "muted" text from the background's own hue — a darker or
+  lighter shade of the panel color, not a neutral gray. Check contrast.
+
+---
+
+## Layout & spacing tells
+
+### 9. Nested cards (cards inside cards inside cards)
+- **Detect:** A bordered/shadowed card contains another bordered/shadowed card,
+  sometimes three deep.
+- **Why it's slop:** It's the default way an AI "groups" things. The result is
+  busy, boxy, and depthless.
+- **Fix:** Flatten. Use whitespace and typography to group, not nested
+  containers. One level of card is plenty; inside it, use spacing and headings.
+
+### 10. Cramped padding
+- **Detect:** Content touches the edges of its container; padding is `0.5rem`
+  or less; sections butt against each other with no breathing room.
+- **Why it's slop:** Generous space is a deliberate choice; cramped space is
+  what you get by default.
+- **Fix:** Be generous. `1.5–2rem` inside cards, large gaps between sections
+  (`4–6rem`), a comfortable max-width on text (`60–72ch`). Whitespace is the
+  cheapest way to look expensive.
+
+### 11. The three-equal-columns reflex
+- **Detect:** Content is jammed into a 3-up grid of equal cards regardless of
+  whether the content wants it.
+- **Why it's slop:** It's the default "features section" shape. Real layouts
+  vary block size to match content importance.
+- **Fix:** Let importance drive size. A hero metric can span full width; a
+  detail can be a narrow aside. Asymmetry reads as intent.
+
+### 12. Wall of text, no visual lead
+- **Detect:** The page opens with paragraphs. The first visual element (diagram,
+  metric, image, pull quote) is far down or absent.
+- **Why it's slop:** AI defaults to prose. Designed docs lead with something to
+  look at.
+- **Fix:** Open with a visual anchor — a big number, a diagram, a striking
+  headline treatment, a chart. Earn the reader's attention before the prose.
+
+---
+
+## Motion & effect tells
+
+### 13. Bounce / overshoot easing
+- **Detect:** `cubic-bezier(...)` with overshoot, `animation: bounce`, springy
+  entrances on everything.
+- **Why it's slop:** Playful bounce is rarely appropriate and always reads as
+  "default fun animation."
+- **Fix:** Use calm, purposeful easing (`ease-out`, `cubic-bezier(0.16,1,0.3,1)`)
+  and at most ONE entrance animation for the whole page. Motion should feel like
+  the page settling, not performing.
+
+### 14. Everything animates in
+- **Detect:** Multiple staggered fade/slide-in animations on load; elements
+  appear one after another across the whole page.
+- **Why it's slop:** It's the default "make it feel alive" move and it delays
+  the content the reader came for.
+- **Fix:** One restrained entrance, or none. Never animate body text into view.
+  If you stagger, keep it to a single hero region and keep it fast (<400ms).
+
+### 15. Hover-lift on every card
+- **Detect:** Every card has `transform: translateY(-4px)` + bigger shadow on
+  hover, including non-interactive cards.
+- **Why it's slop:** Default interactivity theater. Lifting things that aren't
+  clickable is misleading.
+- **Fix:** Only animate genuine affordances (links, buttons, clickable cards).
+  Make the hover state subtle and meaningful.
+
+---
+
+## Decoration tells
+
+### 16. The left side-stripe border
+- **Detect:** Callouts/quotes with a thick colored `border-left`, the same on
+  every block.
+- **Why it's slop:** It's the default "this is a callout" shape, repeated until
+  it's wallpaper.
+- **Fix:** Vary how you signal emphasis: a tinted background, an icon, a change
+  in type, a full-bleed band. Use the side-stripe sparingly if at all.
+
+### 17. Emoji as iconography
+- **Detect:** 🚀 ✨ 💡 🎯 used as section bullets or feature icons.
+- **Why it's slop:** It's the laziest visual shorthand and it dates instantly.
+- **Fix:** Use inline SVG icons (simple, consistent stroke width) or no icons.
+  If you must use a symbol, make it part of a deliberate system.
+
+### 18. Drop shadows on everything
+- **Detect:** Every element has a `box-shadow`, often a harsh default
+  (`0 4px 6px rgba(0,0,0,0.1)`).
+- **Why it's slop:** Uniform shadows flatten hierarchy — if everything floats,
+  nothing does.
+- **Fix:** Use shadow to signal genuine elevation, sparingly. Prefer soft,
+  large-radius, low-opacity shadows tinted with the hue. Often a hairline
+  border reads better than a shadow.
+
+### 19. Rounded-corner sameness
+- **Detect:** `border-radius: 8px` on literally everything.
+- **Why it's slop:** One radius everywhere is the default; designed systems use
+  a deliberate radius scale (or sharp corners by choice).
+- **Fix:** Choose a radius personality — soft (`16–24px`) for friendly, small
+  (`4–6px`) for precise, zero for editorial/brutalist — and apply it
+  consistently as a system, not a reflex.
+
+---
+
+## The meta-tell
+
+### 20. This page looks like the last page
+- **Detect:** Your doc could be swapped with the previous doc you made and no
+  one would notice. Same fonts, same hero, same card grid, same accent.
+- **Why it's slop:** The biggest tell of all. Real design responds to *this*
+  content; AI defaults produce one house style for everything.
+- **Fix:** Start every doc from the creative brief (design-system.md): what is
+  this *about*, who is it *for*, what's the *metaphor*, what's the *one*
+  memorable thing? Let the answers make this doc look unlike the last. If two
+  docs look the same, at least one of them isn't designed.
+
+---
+
+## Quick pre-publish checklist
+
+- [ ] Did I choose the typeface, or accept the default?
+- [ ] Is there ONE dominant hue, not five balanced colors?
+- [ ] Is the background tinted/textured, not flat `#fff`?
+- [ ] Is the largest text genuinely large (dramatic scale)?
+- [ ] Does the page lead with a visual, not a wall of text?
+- [ ] Is there at most one entrance animation, calm easing?
+- [ ] Are cards flat (not nested), with generous padding?
+- [ ] No gradient text, no emoji icons, no uniform shadows?
+- [ ] Does this doc look *different* from the last one I made?

--- a/skills/html-docs/references/api.md
+++ b/skills/html-docs/references/api.md
@@ -1,0 +1,398 @@
+# html-docs.com API Reference
+
+Base URL: `https://www.html-docs.com/api/v1`
+
+## Authentication
+
+- **Agent key**: `Authorization: Bearer hdk_…` — account-level, permanent docs
+- **Doc token**: `x-doc-token: <token>` — per-document, returned on create
+- **Agent name**: `x-agent-name: <name>` — optional, labels comments/versions
+
+## Endpoints
+
+### POST /api/v1/docs — Create and publish
+
+Publish HTML or Markdown to a live URL at `/site/<slug>`.
+
+**Headers:**
+- `Content-Type: text/html` or `text/markdown` (required)
+- `Authorization: Bearer hdk_…` (optional — makes it permanent)
+- `X-Slug: custom-slug` (optional — choose your URL)
+- `x-agent-name: Claude Code` (optional — attribution)
+
+**Query params:**
+- `?slug=custom-slug` — alternative to X-Slug header
+- `?title=My Page` — alternative to inferring from HTML
+
+**Response (201):**
+```json
+{
+  "id": "uuid",
+  "url": "https://www.html-docs.com/site/<slug>",
+  "slug": "<slug>",
+  "editUrl": "https://www.html-docs.com/s/<code>?present=1",
+  "token": "<token>",
+  "revision": 42,
+  "region_sync_engine": "yjs"
+}
+```
+
+The response also carries `ETag: "42"`. Static HTML documents use the
+compatibility-safe Yjs region transport when available. Script-rendered apps,
+rich HTML regions, tables, embeds, and custom visuals remain on the canonical
+HTML-region persistence path automatically.
+
+### GET /api/v1/docs/:id — Read a document
+
+Returns title, html_content (with region placeholders), regions array,
+`editor_engine`, `revision`, and `region_sync_engine`. The numeric revision is
+also returned as an `ETag` response header. Use the editor endpoint below for
+agent edits; it exposes the live state of both document engines in one shape.
+
+### GET /api/v1/docs/:id/editor — Read live semantic editor state
+
+For a Notion/imported-HTML (`regions`) document:
+
+```json
+{
+  "editor_engine": "regions",
+  "blocks": [
+    {
+      "position": 0,
+      "region_key": "region-a1",
+      "type": "text",
+      "tag": "p",
+      "content": "Vibe: <em>relaxed</em>",
+      "atomic": false,
+      "style": {
+        "textAlign": null,
+        "indentPx": 0,
+        "lineHeight": null,
+        "color": null,
+        "backgroundColor": null
+      }
+    }
+  ],
+  "offset_unit": "visible UTF-16 characters inside block.content"
+}
+```
+
+Character ranges address the decoded visible text, not HTML source bytes.
+`<em>Maui</em>` therefore occupies four characters. Exclude text inside
+`script`, `style`, and `template`; count `<br>` as one newline.
+
+For a Google Docs-style (`structured`) document:
+
+```json
+{
+  "editor_engine": "structured",
+  "content": { "type": "doc", "content": [] },
+  "theme": { "pageMode": "paged" },
+  "node_checks": [
+    {
+      "nodeId": "node-a1",
+      "type": "paragraph",
+      "text": "Vibe: relaxed",
+      "expectedTextHash": "sha256…",
+      "expectedAttributes": { "id": "node-a1", "textAlign": null }
+    }
+  ]
+}
+```
+
+The objects in `node_checks` can be sent unchanged in `target_checks`.
+
+### POST /api/v1/docs/:id/editor/commands — Precise agent editing
+
+Applies 1–50 commands through the same persistence and collaboration paths as
+the human editor. Every accepted batch first creates a forced recovery version.
+Open editors receive changes without a page refresh. A stale target returns
+`409` with conflicts; read `/editor` again and replan.
+
+Format one exact range in a region document:
+
+```json
+{
+  "commands": [
+    {
+      "type": "set_marks",
+      "regionKey": "region-a1",
+      "from": 6,
+      "to": 13,
+      "expectedText": "relaxed",
+      "add": [{ "type": "bold" }]
+    }
+  ]
+}
+```
+
+Region commands are:
+
+- `set_marks`: exact `regionKey`, `from`, `to`, optional `expectedText`,
+  optional `add`, and optional `remove`.
+- `replace_text`: exact range plus `text`; use `from == to` for insertion.
+- `set_block_type`: `text`, `h1`, `h2`, `h3`, `bullet`, `numbered`, `quote`,
+  `callout`, `todo`, or `code`.
+- `set_block_style`: bounded wrapper formatting using `textAlign`
+  (`left|center|right|justify|null`), `indentPx` (`0–400|null`), `lineHeight`
+  (`1|1.15|1.5|2|null`), and six-digit hex `color` or `backgroundColor`.
+  Null removes a property. This is the same persisted path used by the human
+  alignment, indentation, and line-spacing toolbar controls.
+
+Both engines support `bold`, `italic`, `underline`, `strike`, `code`, `link`,
+`highlight`, and `textStyle`. A link uses `attrs.href`; highlight uses
+`attrs.color`; `textStyle` accepts bounded `color`, `backgroundColor`,
+`fontFamily`, and `fontSize`. Structured text style also accepts `lineHeight`
+and links may use `target: "_blank"`. Unsafe protocols and invalid styles are
+rejected.
+
+Format one exact node-relative range in a structured document:
+
+```json
+{
+  "target_checks": [
+    {
+      "nodeId": "node-a1",
+      "expectedTextHash": "sha256…",
+      "expectedAttributes": { "id": "node-a1", "textAlign": null }
+    }
+  ],
+  "commands": [
+    {
+      "type": "set_marks",
+      "nodeId": "node-a1",
+      "from": 6,
+      "to": 13,
+      "add": [
+        { "type": "highlight", "attrs": { "color": "#fef08a" } }
+      ]
+    }
+  ]
+}
+```
+
+Structured commands also include `replace_text`, `insert_nodes`,
+`delete_nodes`, `move_node`, `set_node_type`, `set_node_attributes`, and
+`set_document_theme`. They also support an explicit `replace_document` command
+whose `content` is a complete structured `doc` JSON object and whose optional
+`theme` is applied with it. `replace_document` must be the only command in its
+batch. Use it only for an explicit whole-document request; acceptance creates a
+forced recovery version and the complete replacement is one collaborative undo
+event.
+
+Use block/node types for hierarchy and marks only for
+character-level formatting. Prefer one title, consistent heading levels,
+predictable labels, short paragraphs or lists, and a brief final Notes section.
+Do not simulate layout with spaces, tabs, or empty paragraphs.
+
+### POST /api/v1/docs/:id/editor/visuals — Design-system visual
+
+Insert one deterministic visual after a real region key or structured node ID.
+The same schema renders in both editors, all supplied strings are escaped, and
+the server creates a recovery version before committing through the active
+collaboration backend.
+
+```json
+{
+  "anchor_id": "region-a1",
+  "spec": {
+    "kind": "flow",
+    "title": "Review path",
+    "eyebrow": "Decision workflow",
+    "summary": "Every change has a visible owner and recovery path.",
+    "tone": "forest",
+    "items": [
+      { "title": "Draft", "detail": "Create semantic blocks." },
+      { "title": "Review", "detail": "Comment on exact passages." },
+      { "title": "Decide", "detail": "Accept or restore." }
+    ],
+    "note": "Arrows indicate sequence, not system boundaries."
+  }
+}
+```
+
+`kind` is `callout`, `metrics`, `flow`, `timeline`, `comparison`, or
+`matrix`. Tones are `ink`, `ocean`, `forest`, `amber`, `plum`, and `rose`.
+Metrics use `items[].label/value/detail`; comparison additionally supports
+`left` (strength) and `right` (trade-off). A matrix uses `columns` plus
+`rows: [{ "label": "...", "values": ["..."] }]`.
+
+### POST /api/v1/docs/:id/videos — Generate and embed video
+
+Requires an account agent key and document ownership; doc tokens are not
+accepted because generation consumes model and rendering resources.
+
+Body:
+
+```json
+{
+  "prompt": "Animate the three key ideas",
+  "title": "Optional title",
+  "after_region_key": "region-optional",
+  "aspect_ratio": "landscape",
+  "duration_seconds": 8,
+  "quality": "standard"
+}
+```
+
+`aspect_ratio` is `landscape`, `portrait`, or `square`; duration is 3–15
+seconds; quality is `draft`, `standard`, or `high`. Returns the MP4 and poster
+URLs, composition/render IDs, inserted region key, and validation report.
+
+### PUT /api/v1/docs/:id — Replace content
+
+Full content replacement. Prior state is snapshotted to version history.
+
+Send the ETag from the latest GET as `If-Match`; a concurrent human or agent
+edit returns `412 revision_conflict` instead of being overwritten:
+
+```bash
+curl -X PUT https://www.html-docs.com/api/v1/docs/<id> \
+  -H 'Authorization: Bearer hdk_…' \
+  -H 'Content-Type: text/html' \
+  -H 'If-Match: "42"' \
+  --data-binary @page.html
+```
+
+Give important authored blocks stable IDs so comments stay attached through
+whole-document updates:
+
+```html
+<h2 data-hd-block-id="overview">Overview</h2>
+<p data-hd-block-id="overview-summary">...</p>
+```
+
+`data-editable-region="region-…"` values returned by GET are also preserved.
+Prefer region/block PATCH endpoints when changing only part of a reviewed doc.
+
+### GET /api/v1/docs/:id/blocks — List ordered blocks
+
+Returns every editable block in document order:
+
+```json
+{
+  "blocks": [
+    {
+      "position": 0,
+      "region_key": "region-abc123",
+      "type": "h2",
+      "tag": "h2",
+      "content": "Overview",
+      "atomic": false
+    }
+  ],
+  "updated_at": "2026-07-26T03:00:00.000Z"
+}
+```
+
+### POST /api/v1/docs/:id/blocks — Insert a block
+
+Uses the same structural mutation engine as the human editor. Insert an
+atomic HTML/SVG visual after an existing block:
+
+```json
+{
+  "after_region_key": "region-abc123",
+  "type": "html",
+  "content": "<svg viewBox=\"0 0 100 100\"><circle cx=\"50\" cy=\"50\" r=\"40\" /></svg>"
+}
+```
+
+Other supported types are `text`, `h1`, `h2`, `h3`, `bullet`, `numbered`,
+`quote`, `divider`, `callout`, `todo`, `code`, `image`, `video`, `embed`, and
+`table`. Use `media_url` for image, video, and embed blocks. HTML/SVG blocks
+preserve nested markup, SVG definitions, and inline styling while removing
+scripts, event handlers, unsafe URLs, frames, and nested editor markers.
+
+### GET /api/v1/docs/:id/blocks/:key — Read one block
+
+### PATCH /api/v1/docs/:id/blocks/:key — Edit, convert, or move
+
+Send exactly one operation:
+
+```json
+{ "content": "Replace this block's content" }
+{ "type": "callout", "content": "<strong>Important</strong>" }
+{ "move": "up" }
+{ "target_region_key": "region-def456", "position": "after" }
+```
+
+For an existing HTML/SVG block, `{ "content": "<svg>…</svg>" }` runs through
+the HTML-block sanitizer and updates the live document atomically.
+
+### DELETE /api/v1/docs/:id/blocks/:key — Delete one block
+
+Every block write snapshots the prior document version and is attributed
+using the API key/device identity and optional `x-agent-name`. Region content
+and structural shell changes publish through the collaboration backend, so
+open editors see agent edits without manually refreshing.
+
+### PATCH /api/v1/docs/:id/regions/:key — Edit one region
+
+Precise content edit that preserves comment anchors. HTML/SVG block content
+is sanitized automatically. Prefer the `/blocks` endpoints when adding,
+moving, converting, or deleting structure.
+
+### GET /api/v1/docs/:id/comments — List comments
+
+Query: `?resolved=true|false|all`, `?region_key=<key>`
+
+### POST /api/v1/docs/:id/comments — Add a comment
+
+Region body:
+
+```json
+{ "content": "...", "region_key": "region-a1", "selected_text": "relaxed" }
+```
+
+Structured body:
+
+```json
+{
+  "content": "Can we make this more specific?",
+  "structured_node_id": "node-a1",
+  "selected_text": "relaxed",
+  "from": 6,
+  "to": 13
+}
+```
+
+Structured `from`/`to` are node-relative UTF-16 offsets. Replies use
+`parent_id`. Agent comments remain durable, attributed, and visible in the
+normal comment panel.
+
+### POST /api/v1/docs/:id/comments/:id/resolve — Resolve thread
+
+Body: `{ "resolved": true }` (or omit body to resolve)
+
+### GET /api/v1/docs/:id/versions — List versions
+
+### POST /api/v1/docs/:id/versions — Capture a version
+
+Body: `{ "name": "Draft v2" }` (optional)
+
+### POST /api/v1/docs/:id/versions/:id/restore — Restore a version
+
+### GET /api/v1/docs/:id/activity — Activity feed
+
+Query: `?since=<ISO>`, `?type=comment.created,version.created`, `?limit=50`
+
+### POST /api/v1/webhooks — Register a webhook
+
+Body: `{ "url": "https://...", "event_types": ["comment.created"], "document_id": "..." }`
+
+## Rate Limits
+
+- 600 reads / 60 writes per 60-second window per credential
+- Max body: 2 MB
+- 429 responses include `Retry-After` header
+
+## Error Format
+
+```json
+{ "error": "Description of what went wrong." }
+```
+
+Status codes: 200/201/204 (success), 400, 401, 403, 404, 409, 412, 413, 429,
+500. `409` means an editor command target changed; `412` means a whole-document
+ETag changed.

--- a/skills/html-docs/references/course-specification.md
+++ b/skills/html-docs/references/course-specification.md
@@ -1,0 +1,141 @@
+# Course specification and production map
+
+Use this reference before authoring a multi-lesson course or a large
+document-video project. The specification captures decisions; the production
+map turns them into independently verifiable teaching slices.
+
+## Write the course specification
+
+Create `COURSE-SPEC.md` from the conversation, source snapshot, learner contract,
+and codebase or site context. Do not repeat questions the user has already
+answered.
+
+```markdown
+# Course specification: <title>
+
+## Learning problem
+<What the learner cannot reliably do today and why it matters.>
+
+## Learner and finish line
+<Audience, starting point, purpose, and observable final capabilities.>
+
+## Learner journeys
+1. As a <learner>, I want to <practice or understand>, so I can <real outcome>.
+
+## Teaching decisions
+- <Sequence, mental models, examples, terminology, remediation, pacing>
+
+## Artifact decisions
+- <What belongs in pages, videos, interactives, references, and assessments>
+
+## Evidence and uncertainty
+- <Source boundaries, disputed claims, assumptions, and evidence gaps>
+
+## Assessment decisions
+- <How each final capability will be demonstrated through external behavior>
+
+## Accessibility and delivery
+- <Captions, keyboard, contrast, reduced motion, language, device constraints>
+
+## Exclusions
+- <Explicitly deferred topics or editor capabilities>
+
+## Open decisions
+- <Only questions whose answers can change the design>
+```
+
+Keep implementation details at the level of stable interfaces and behavior.
+Avoid volatile file paths and speculative code. When a prototype resolves a
+decision more precisely than prose, preserve only the decision-bearing part and
+link the prototype.
+
+## Choose the highest useful validation seams
+
+Define a small set of observable seams:
+
+- Source evidence becomes a correctly qualified claim.
+- A lesson objective becomes an explanatory page/video and a diagnostic check.
+- Final audio becomes the shared word, cue, caption, scene, and chapter clock.
+- A learner response becomes specific feedback and a justified mastery update.
+- A changed source marks only dependent lessons stale.
+- A private project becomes a playable course preview.
+
+Prefer these end-to-end seams over tests of internal prompt phrasing or
+implementation details.
+
+## Slice production vertically
+
+Create one file per slice in `production/`, numbered in dependency order:
+
+```markdown
+# 01 — <slice title>
+
+## Learner-visible result
+<A complete behavior or lesson the learner can use and the producer can review.>
+
+## Depends on
+<Earlier slice titles, or “Nothing”.>
+
+## Acceptance
+- [ ] <Evidence-grounded, externally verifiable criterion>
+- [ ] <Page/video/check/player criterion>
+
+## Source scope
+<Evidence IDs and source dependencies used by this slice.>
+```
+
+A normal slice cuts through the full production path: evidence, lesson model,
+page, visual explanation, narration, synchronization, checks, and audit. It
+must be demoable on its own and small enough for one focused agent session.
+Avoid horizontal tickets such as “write every script” or “render every video.”
+
+Use an expand–migrate–contract sequence only for a wide mechanical format
+change that cannot remain valid one vertical slice at a time.
+
+## Represent dependencies explicitly
+
+Every slice and lesson lists what blocks it. The ready frontier is the set whose
+dependencies have passed. Build from the frontier rather than following a
+large unchecked list.
+
+Use names in human-facing reports; IDs remain machine references. A dependency
+exists only when its result is genuinely required.
+
+## Map uncertainty without pretending it is resolved
+
+For a course too large or uncertain to specify in one pass, add a decision map
+to `COURSE-SPEC.md`:
+
+- **Destination:** the observable state that ends planning.
+- **Decisions made:** one-line conclusions linked to their evidence or
+  prototype.
+- **Open decisions:** precise questions that can be answered now.
+- **Unresolved territory:** in-scope areas that are still too vague to phrase
+  as decisions.
+- **Exclusions:** work outside the destination.
+
+Resolve research questions with primary sources. Resolve behavior or visual
+questions with the cheapest useful prototype. Promote unresolved territory to
+a decision only when the question becomes precise. Stop planning when the
+remaining work is execution.
+
+## Course-production gate
+
+Before building:
+
+- The learner contract has an observable finish line.
+- The course specification resolves artifact and assessment roles.
+- Every lesson is a vertical teaching slice with explicit dependencies.
+- Every planned claim has evidence or is marked as an unresolved gap.
+- Each final capability has an external demonstration.
+- The first frontier lesson is independently buildable and reviewable.
+
+After building, compare the implementation with both axes:
+
+1. **Craft:** source accuracy, teaching clarity, visual explanation, narration,
+   synchronization, accessibility, and deterministic playback.
+2. **Specification:** learner journeys, finish line, exclusions, artifact
+   decisions, and acceptance criteria.
+
+Passing craft checks does not excuse building the wrong course. Matching the
+specification does not excuse a weak learning experience.

--- a/skills/html-docs/references/design-commands.md
+++ b/skills/html-docs/references/design-commands.md
@@ -1,0 +1,134 @@
+# Design Commands — a shared vocabulary for steering a doc
+
+When you (or the user) want to change how a doc looks, it helps to have precise
+verbs. "Make it better" is unactionable; "make it bolder" or "quiet the color"
+points to a specific set of moves. This file defines a small command vocabulary
+— each one is a *named transformation* you can apply to a draft and that the
+user can ask for by name.
+
+Use these two ways:
+1. **Self-direction:** after a first draft, run `audit` then apply the fixes.
+2. **User shorthand:** when the user says "bolder" or "polish it," apply the
+   corresponding move below rather than guessing.
+
+All moves preserve the self-contained constraint (inline CSS/SVG, no external
+deps) and respect [anti-slop.md](anti-slop.md). Read
+[design-system.md](design-system.md) for the underlying system.
+
+---
+
+## Diagnostic commands (look, don't change)
+
+### `audit`
+Run the doc through [anti-slop.md](anti-slop.md)'s checklist and report every
+tell you find, worst first. Output: a short list of concrete problems with the
+specific element/line each refers to. No changes yet.
+
+### `critique`
+Give an honest design critique as a sharp art director would: what's working,
+what's generic, what the doc is *trying* to be vs. what it *is*. Focus on
+hierarchy, focal point, and whether it looks designed for *this* content.
+
+### `distill`
+State the doc's design DNA as it currently stands (see
+[design-dna.md](design-dna.md)) — dominant hue, type, mood, signature. Useful
+to check whether the doc has a point of view at all. If you can't distill it,
+it doesn't have one yet.
+
+---
+
+## Transformation commands (change the doc)
+
+### `polish`
+The all-purpose cleanup. Tighten spacing rhythm, fix contrast, align the type
+scale, remove stray slop, smooth the details. Doesn't change the concept —
+makes the existing concept land cleanly. This is the default "make it better."
+
+### `harden`
+Make it production-ready and robust: check mobile/narrow widths, ensure
+contrast passes, verify the page works in the shadow-DOM viewer, confirm no
+external dependencies leaked in, validate that diagrams scale. The
+"ship-readiness" pass.
+
+### `bolder`
+Increase drama and confidence: bigger hero type, stronger focal point, more
+decisive accent use, more generous whitespace, a more pronounced signature.
+Turns a timid page assertive. Don't add noise — add *commitment*.
+
+### `quieter`
+The opposite: dial back. Reduce the number of accents, calm the motion, soften
+contrast, remove decoration, let whitespace and restraint carry it. Turns a
+busy or shouty page composed and calm.
+
+### `typeset`
+Focus only on typography: choose a deliberate display/body pairing, fix the
+size scale and line-heights, sort out tracking on headings, improve measure
+(line length), handle widows/orphans, set a real reading rhythm. The single
+highest-leverage move on a text-heavy doc.
+
+### `colorize`
+Focus only on color: establish ONE dominant hue + one accent, derive a coherent
+neutral/muted set from that hue, fix gray-on-color and pure-black/white, tint
+the background. Replaces a default palette with a designed one.
+
+### `animate`
+Add motion *carefully*: at most one restrained entrance, calm easing, motion
+only on genuine affordances. If the doc already has motion, this often means
+*removing* most of it and keeping one purposeful moment. CSS-only (see
+[effects.md](effects.md)).
+
+### `restructure`
+Change the layout DNA: pick a better archetype (report, dashboard, comparison,
+timeline, etc. from design-system.md), reorder for a stronger visual lead,
+break the three-equal-columns reflex, let importance drive block size.
+
+### `illustrate`
+Add or improve visual explanation: convert a wall of text into an inline-SVG
+diagram, a hand-authored chart, a comparison table, or a timeline. Lead with
+the visual. Color-code consistently and label everything.
+
+### `match <reference>`
+Capture the design DNA of a reference (screenshot, named site, brand, or a
+sibling doc) per [design-dna.md](design-dna.md) and re-author the doc to those
+tokens and style. Use when consistency or a specific look is the goal.
+
+### `theme <mood>`
+Re-skin the doc to a named mood (e.g. `theme editorial`, `theme terminal`,
+`theme luxe`, `theme clinical`) by swapping the DNA — type, hue, effects,
+signature — while keeping the content and structure. Useful for trying
+directions fast.
+
+---
+
+## Composing commands
+
+These chain. A typical authoring flow:
+
+```
+draft → audit → polish → typeset → colorize → harden → (publish)
+```
+
+A "make it pop" request usually means:
+
+```
+critique → bolder → illustrate → harden
+```
+
+A "tone it down" request:
+
+```
+critique → quieter → colorize(fewer accents) → harden
+```
+
+When the user asks for something vague, map it to commands out loud ("I'll
+*bolder* the hero and *illustrate* the comparison") so the change is legible
+and they can redirect with the same vocabulary.
+
+---
+
+## The one rule behind all of them
+
+Every command answers to the doc's design DNA (design-dna.md) and avoids the
+tells in anti-slop.md. A command never adds a default; it makes a *decision*.
+If applying a command would make this doc look more like every other doc,
+you've applied it wrong.

--- a/skills/html-docs/references/design-dna.md
+++ b/skills/html-docs/references/design-dna.md
@@ -1,0 +1,145 @@
+# Design DNA — extract a look you love, then author to match
+
+Sometimes the user already knows the look they want: "make it feel like Stripe's
+docs," "match this dashboard screenshot," "I want it to look like the New York
+Times." Don't eyeball it and hope. **Extract the design DNA** — quantify what
+makes that reference look the way it does — then author your doc to those
+specs. The result matches on purpose instead of by accident.
+
+This is the same idea as a design audit: turn a vibe into measurable parameters
+so you can reproduce it deliberately. Read [design-system.md](design-system.md)
+for the authoring fundamentals; this file is the *capture* step that feeds them.
+
+---
+
+## The three dimensions of design DNA
+
+A look is never one thing. Decompose any reference into three layers, capture
+each, and you can rebuild it.
+
+### 1. Design system — the measurable tokens
+The quantitative skeleton. These are numbers and discrete values you can read
+off a reference and reproduce exactly.
+
+- **Color:** dominant hue (HSL), accent hue, surface/background, text colors,
+  borders. Note the *ratio* — which color dominates, which is the rare accent.
+- **Typography:** display face + body face (or closest system equivalents),
+  the size scale (e.g. 14 / 16 / 20 / 32 / 56), weights used, line-heights,
+  letter-spacing on headings.
+- **Spacing:** the base unit (4px? 8px?) and the rhythm built on it; section
+  gaps; padding inside containers.
+- **Radius:** the corner-radius scale (0 / 4 / 8 / 16?).
+- **Borders & lines:** hairline color and weight; do they use borders or
+  shadows to separate?
+- **Shadows:** elevation steps — blur, spread, opacity, and whether tinted.
+
+### 2. Design style — the qualitative character
+The adjectives. These don't have units but they govern every choice.
+
+- **Mood:** editorial / technical / playful / luxe / brutalist / warm / clinical.
+- **Density:** airy and spacious, or dense and information-rich?
+- **Contrast:** high-drama (big jumps, bold hits) or subtle and even?
+- **Formality:** buttoned-up corporate or loose and human?
+- **Era / influence:** Swiss/International, 90s web, editorial print,
+  terminal/CLI, modern SaaS, etc.
+- **Personality in one line:** "calm precise instrument," "loud confident
+  pitch," "quiet literary essay."
+
+### 3. Visual effects — the finishing layer
+The treatments that sit on top. Keep these self-contained (CSS-only) — see
+[effects.md](effects.md) for the constrained palette.
+
+- **Backgrounds:** flat tint, gradient, grain/noise, banding, subtle pattern.
+- **Depth:** layering, soft shadows, glassy panels, borders-only flatness.
+- **Texture:** grain overlays, hairline grids, dotted rules.
+- **Motion:** entrance style and easing (usually one, restrained).
+- **Accents:** underlines, highlight marks, tags, dividers, signature flourish.
+
+---
+
+## The DNA spec — capture it as JSON
+
+When you study a reference (a screenshot the user shared, a site they named, or
+a look you're committing to), write down the DNA as a compact spec before you
+author. This keeps you honest and consistent across a multi-page doc or a set
+of docs that should match.
+
+```json
+{
+  "name": "Editorial Brief",
+  "system": {
+    "color": {
+      "dominant": "hsl(28 40% 96%)",
+      "accent": "hsl(348 72% 47%)",
+      "ink": "hsl(20 14% 12%)",
+      "muted": "hsl(20 8% 38%)",
+      "surface": "hsl(28 30% 99%)",
+      "border": "hsl(28 16% 86%)",
+      "ratio": "warm-neutral dominant ~80%, crimson accent rare"
+    },
+    "type": {
+      "display": "ui-serif, Georgia, 'Times New Roman', serif",
+      "body": "ui-serif, Georgia, serif",
+      "scale": [15, 17, 21, 32, 56],
+      "weights": [400, 600, 700],
+      "leading": { "body": 1.65, "display": 1.05 },
+      "tracking": { "display": "-0.02em" }
+    },
+    "space": { "unit": 8, "section_gap": 72, "container_pad": 32 },
+    "radius": [0, 4],
+    "shadow": "hairline borders, no shadows"
+  },
+  "style": {
+    "mood": "editorial",
+    "density": "airy",
+    "contrast": "high-drama headline, calm body",
+    "formality": "literary, considered",
+    "influence": "print magazine feature",
+    "personality": "a quiet literary essay with one bold opening"
+  },
+  "effects": {
+    "background": "2% warm tint, no gradient",
+    "depth": "flat, hairline rules between sections",
+    "texture": "thin top-rule above each section",
+    "motion": "single fade-up on the title only, ease-out 320ms",
+    "signature": "oversized serif drop-cap on the opening paragraph"
+  }
+}
+```
+
+You don't need every field every time — but the act of writing the spec forces
+the decisions that separate "designed" from "default."
+
+---
+
+## Workflow: reference → DNA → doc
+
+1. **Identify the reference.** A screenshot, a named site, or a target mood. If
+   the user gave a URL or image, study it specifically; if they gave a vibe
+   word, pick a concrete exemplar and commit.
+2. **Extract the DNA.** Fill in the three dimensions. Read real values off the
+   reference where you can (hues, scale, spacing rhythm); infer the qualitative
+   layer; choose self-contained effects.
+3. **Map to system equivalents.** Match brand fonts to the closest system /
+   web-safe stack (you're authoring self-contained HTML — no external font CDNs
+   unless the user explicitly wants them and accepts the dependency). Round
+   tokens to a clean scale.
+4. **Author to the spec.** Build the doc using *only* the captured tokens and
+   style rules. When you reach for a color or size, take it from the DNA, not
+   from instinct. This is what makes the result match.
+5. **Audit against the DNA.** Before publishing, compare the draft to the spec
+   and to the reference. Does the dominant-hue ratio match? Is the type scale
+   right? Did slop creep in? (Run [anti-slop.md](anti-slop.md).)
+
+---
+
+## When to use this vs. the creative brief
+
+- **No reference, fresh look:** start from the **creative brief** in
+  design-system.md — invent the DNA from the content's purpose and metaphor.
+- **A reference exists** (screenshot, named site, "match my brand", a series of
+  docs that must look consistent): use **Design DNA** to capture it, then
+  author to it.
+
+Either way you end up with the same thing: a small, explicit set of decisions
+that every line of CSS answers to. That's what designed looks like.

--- a/skills/html-docs/references/design-system.md
+++ b/skills/html-docs/references/design-system.md
@@ -1,0 +1,332 @@
+# Document Design System (portable, full depth)
+
+> **Portable by design.** Surface-agnostic guidance for authoring a beautiful,
+> **self-contained** HTML document. Works for **html-docs**, **Meta Docs**, or any
+> surface that stores/renders standalone HTML. Adapted from the `/visualize`
+> skill's design system (its `_principles`, `components`, `animations`, and
+> archetype briefs), with one hard constraint added for embedded doc surfaces:
+> **self-contained, no network calls** (see below). Where `/visualize` reaches for
+> Google Fonts, Chart.js, Mermaid, D3, or Motion One, this file substitutes
+> system/serif font stacks, hand-authored inline SVG, and CSS-only motion —
+> because html-docs renders each document inside a sandboxed shadow-DOM viewer
+> and on mobile, where remote assets and heavy JS get stripped.
+
+---
+
+## The one hard constraint: self-contained
+
+Everything must render from a single HTML payload with **no network calls**.
+
+| `/visualize` uses | In a self-contained doc, instead use |
+|---|---|
+| Google Fonts (`@import`, `<link>`) | A named **system/serif/mono stack** (see Typography). Never *depend* on a remote font. |
+| Chart.js, charts via CDN | **Hand-authored inline `<svg>`** — `<rect>` bars, `<polyline>`/`<path>` lines, `<line>`+`<text>` axes. |
+| Mermaid / D3 diagrams & graphs | **Inline `<svg>`** boxes-and-arrows, or styled HTML/CSS boxes. Force-directed graphs become a hand-placed node/link SVG. |
+| Motion One / WAAPI counters / IntersectionObserver reveals | **CSS-only** keyframes + `animation-delay`. Assume JS may be disabled; the doc must read perfectly static. |
+| `infra.html` hamburger menu, feedback UI, save-as-image, Pixelcloud upload | **Nothing** — comments, sharing, theme, export, feedback are the doc surface's chrome. Do not build them into the HTML. |
+| Footer linking back to the skill | **No templated footer.** |
+
+Rules of thumb: inline CSS and inline `<svg>` only; no external stylesheets,
+no render-blocking web-font `<link>`s, no external CDN `<script>`s, no `<img>` to
+remote hosts for core content. Keep any interactivity to tiny inline `<script>` /
+CSS `:target` / `<details>` — and assume it may be stripped.
+
+---
+
+## The Prime Directive
+
+Every document must feel **intentionally designed for its specific content**. If
+you swapped the content out, the design choices should feel wrong. Typography,
+color, layout, and structure all serve THIS content, THIS audience, THIS moment.
+Never ship plain HTML.
+
+---
+
+## Reading-surface contract
+
+Documents are reading surfaces before they are compositions. Apply these
+constraints before choosing decorative treatments:
+
+1. Preserve a clear linear reading path. A reader should understand what comes
+   first, what belongs together, and what matters most without decoding the
+   layout.
+2. Assign stable content roles: one title; consistent section-heading ranks;
+   body; labels; evidence; actions; notes. One role gets one treatment.
+3. Create hierarchy with type, weight, and spacing first. Borders, surfaces,
+   shadows, and cards must communicate grouping, status, or comparison.
+4. Keep long-form text near 45–75 characters per line. Use tighter line height
+   for large display type and more open leading for sustained reading.
+5. Keep items within a group close and put visibly more space between groups.
+   Flatten wrappers that do not add meaning. Never make every group a card or
+   nest decorative cards.
+6. Define color by role—ink, muted ink, surface, border, accent, positive,
+   warning, critical—and reuse roles consistently. State cannot rely on color
+   alone.
+7. A visualization must prove a relationship: sequence, causality,
+   comparison, distribution, dependency, or decision. Label that relationship,
+   not just the boxes.
+8. Preserve reading order at narrower widths. Grids should collapse naturally;
+   tables and diagrams cannot depend on hover.
+
+For agent insertion, prefer the deterministic Docsmith visual grammar:
+`callout`, `metrics`, `flow`, `timeline`, `comparison`, and `matrix`. Supply
+meaning and labels; let the server own rendering. Hand-author SVG only when the
+relationship cannot be expressed by those patterns.
+
+---
+
+## Anti-slop rules (non-negotiable — all must hold)
+
+| Rule | Why |
+|------|-----|
+| **Don't use default/system-default fonts as the design.** Pick a distinctive, *named* stack matched to the content's tone (serif vs geometric-sans vs mono). Don't reuse the same pairing twice in a row. (Remote fonts are forbidden here, so distinctiveness comes from stack choice, weight, scale, letter-spacing, and pairing — not from a Google Font.) | Undifferentiated type is the #1 signal of generic AI output. |
+| **Commit to ONE dominant hue** with supporting accents — not a balanced 5-color palette. Drive it with CSS custom properties. | Even color distribution is visual noise; dominance creates identity. |
+| **Backgrounds have character.** Warm off-white, subtle tint, soft gradient, faint texture — never flat stark white with no atmosphere. | Flat backgrounds read as unfinished wireframes. |
+| **Hierarchy through dramatic scale.** The most important element is much larger than the rest. | If everything is the same size, nothing is important. |
+| **Lead with visuals, not walls of text.** Any system, flow, comparison, timeline, or set of relationships gets a diagram/illustration. | A precise diagram is the difference between a doc people skim and one they understand. |
+| **One orchestrated entrance, at most.** If you animate, stagger a single CSS page-load reveal. Skip scattered micro-animations. Assume motion may be disabled. | Choreography feels designed; random motion feels noisy. |
+| **Every document looks different.** Vary fonts, palette, layout, and signature across docs. If it looks like the last one, start over. | Repetition kills the value. |
+
+---
+
+## The Creative Brief — answer before writing any HTML
+
+Do not skip a question. Your design should flow from these answers.
+
+1. **PURPOSE** — What is this communicating? Who is the audience? What should
+   they understand or feel afterward?
+2. **METAPHOR** — What visual world does this content belong to? Name a PLACE or
+   OBJECT, not the format. Not "a dashboard" but "a mission-control room"; not "a
+   report" but "a field journal from an expedition." The metaphor guides every
+   downstream choice — color, type, spacing, structure.
+3. **TYPOGRAPHY** — Name a display stack and a body stack and WHY they fit the
+   emotional register (authoritative → serif; modern → geometric sans; technical
+   → mono; warm → humanist; elegant → high-contrast serif). Must stay legible at
+   16px with safe fallbacks. (See the Typography system below for stacks.)
+4. **PALETTE** — Name ONE dominant hue and why it matches the mood (urgent → warm
+   reds; analytical → cool blues; growth → greens; creative → purples; warm →
+   ambers/terracotta; technical → cool grays + one vivid accent). Then pick an
+   accent that complements or creates tension.
+5. **SIGNATURE** — The ONE thing someone will remember (a striking diagram, an
+   unusual layout, a distinctive color pairing, a memorable CSS treatment).
+   Describe it in one sentence.
+6. **COMPOSITION** — Dense or spacious? Scrolling or single-screen? Centered
+   reading column (900–1100px) or full-bleed? Grid or organic? Commit — no mushy
+   middle ground.
+
+---
+
+## Typography system
+
+Type is the highest-leverage creative decision. Remote fonts are forbidden, so
+pick a **named, self-contained stack** whose personality matches the metaphor,
+then create distinctiveness through weight, scale, tracking, and pairing.
+
+| Mood | Display stack | Body stack |
+|------|---------------|-----------|
+| Editorial / magazine | `"Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif` | `system-ui, -apple-system, "Segoe UI", sans-serif` |
+| Technical / precise | `ui-monospace, "SF Mono", Menlo, Consolas, monospace` | `"IBM Plex Sans", system-ui, sans-serif` (fallback to system sans) |
+| Bold / modern | `system-ui, "Segoe UI", Roboto, sans-serif` (heavy weights, tight tracking) | `system-ui, -apple-system, sans-serif` |
+| Warm / humanist | `"Hoefler Text", Georgia, "Times New Roman", serif` | `"Segoe UI", system-ui, sans-serif` |
+| Elegant / refined | `Georgia, "Times New Roman", "Liberation Serif", serif` (high contrast, large) | `system-ui, -apple-system, sans-serif` |
+| Data / scientific | `ui-monospace, "SF Mono", Menlo, monospace` | `system-ui, sans-serif`, tabular numerals |
+
+Guidance: establish **at least five type sizes** (e.g. hero, h1, h2, body,
+caption). Body 15–17px, line-height 1.55–1.7. Use small-caps + letter-spacing
+for section labels. Reserve mono for code, identifiers, and tabular numbers.
+
+---
+
+## Color system
+
+Don't reuse the same palette across docs. Pick a **territory**, commit to one
+dominant hue, choose surfaces and an accent from within it.
+
+- **Warm earth** — terracotta, sand, olive, warm brown, burnt sienna
+- **Cool ocean** — navy, teal, seafoam, pearl gray, deep blue
+- **Monochromatic + pop** — shades of one hue with a single contrasting accent
+- **High contrast** — near-black surfaces with one vivid accent (electric blue, hot pink, lime)
+- **Muted / desaturated** — soft pastels, dusty rose, sage, lavender
+- **Bold / saturated** — primary colors at intensity, playful energy
+- **Jewel tones** — deep emerald, sapphire, amethyst, ruby
+- **Industrial** — concrete gray, steel blue, caution yellow, rust orange
+- **Nordic** — ice white, pale blue, soft gray, silver, pine green
+
+Surface baseline for a light reading doc: near-white tinted background
+(`#fafaf8`–`#f6f1e8`), deep-ink body text (`#1f1b16`–`#1a1a1a`), hairline borders
+in softened ink, one accent used sparingly. **Data values stay dark** — put color
+on the *container* (background tint, left-border, badge), and scale saturation
+with magnitude (a +15% lift gets a more saturated tint than +3%).
+
+---
+
+## Motion (CSS-only)
+
+JS may be stripped, so motion is CSS keyframes + `animation-delay`. The doc must
+be perfect with motion off. Pick **one** energy preset and use it consistently.
+
+| Preset | Duration | Easing | When |
+|--------|----------|--------|------|
+| Subtle | 0.5s | `cubic-bezier(0.25,0.1,0.25,1)` | reports, dashboards — content speaks |
+| Energetic | 0.4s | `cubic-bezier(0.22,1,0.36,1)` | launches, showcases — momentum |
+| Cinematic | 0.8s | `cubic-bezier(0.16,1,0.3,1)` | presentations, heroes — drama |
+| Data-driven | 0.6s | `cubic-bezier(0.34,1.56,0.64,1)` | counters, bars — slight overshoot |
+
+```css
+@keyframes fadeInUp { from { opacity:0; transform:translateY(20px);} to { opacity:1; transform:translateY(0);} }
+@keyframes fadeInScale { from { opacity:0; transform:scale(.96);} to { opacity:1; transform:scale(1);} }
+@keyframes blurIn { from { opacity:0; filter:blur(8px);} to { opacity:1; filter:blur(0);} }
+/* Stagger an above-the-fold reveal: */
+.reveal { animation: fadeInUp .6s both; }
+.reveal:nth-child(2){ animation-delay:.1s } .reveal:nth-child(3){ animation-delay:.2s }
+@media (prefers-reduced-motion: reduce){ * { animation:none !important; transition:none !important } }
+```
+
+Restraint: max 3 animation types per page; no delay > 0.8s; animate `transform`
+and `opacity` only (plus a one-shot `width` for progress fills). Don't animate the
+same element both on load and "on scroll." Always honor `prefers-reduced-motion`.
+
+---
+
+## Composition principles
+
+- **Generous negative space OR controlled density** — never a mushy middle. Decide and commit.
+- **Asymmetry creates energy.** Off-center hero, broken grid, overlap. Centered is safe; safe is forgettable.
+- **Hierarchy through scale.** The most important element is dramatically larger than everything else.
+- **Max width matters:** 900–1100px reading column for prose; full-bleed for dashboards/graphs; 600–800px for a single diagram.
+
+---
+
+## Archetype catalog
+
+Match the content to the closest archetype for layout DNA — inspiration, not a
+constraint. Adapt or freestyle when nothing fits. Each entry gives when to use,
+the communication goal, layout DNA, "flavor seeds" (metaphors to spark a look),
+and the traps to avoid.
+
+### Report / proposal (technical proposal, RFC, design doc)
+- **When:** a problem + proposed solution with trade-offs; RFC, design doc, architecture, technical plan, findings writeup.
+- **Goal:** persuade through structured reasoning — establish *why it matters* before *how to solve it*, and build credibility by honestly evaluating alternatives.
+- **Layout DNA:** single scrollable doc with a sticky/anchored TOC. Status header (Draft/In Review/Approved badge + date + author) → 3-sentence TL;DR → problem → goals/non-goals → proposed solution with inline diagram → alternatives with a trade-off matrix → detailed design (data models, API shapes as code) → phased plan with milestones → risks & mitigations → open questions. Diagrams dominate their sections; show concrete code, not abstract prose. Medium density with breathing room.
+- **Flavor seeds:** the Architect's Blueprint (faint grid, blue dimension lines); the War-Room Whiteboard (hand-drawn connectors, yellow "ASK?" cards, red RISK boxes); the Patent Filing (numbered sections, "Fig. 1" captions, institutional serif); the Expedition Map (problem = terrain, solution = charted route, milestones = camps).
+- **Avoid:** jumping straight to the solution; presenting only one option; hand-waving the implementation; hiding risks; prose where a diagram is clearer; > ~20 sections.
+
+### Dashboard (metrics, health, KPIs)
+- **When:** primarily numeric — health scores, counts, percentages, trends; answers "how are we doing?" in under 3 seconds.
+- **Goal:** assess overall status at a glance, surface what needs attention, drill in only when something looks wrong.
+- **Layout DNA:** header bar (title · "last updated" · overall status badge) → row of 4–6 KPI cards with trend indicators (▲▼ deltas, inline-SVG sparklines) → 2–3 column grid of trend charts (inline SVG) → component-level breakdown tables/cards by category → alerts section at the bottom. Z-shaped reading order.
+- **Flavor seeds:** Mission Control (dark, cyan/amber readouts, mono numerals); Weather Station (multi-panel, soft blues); Cockpit Instrument Panel (green/yellow/red arcs); Trading Floor Terminal (dense grid, sharp gain/loss colors); Greenhouse Monitor (warm greens, organic shapes).
+- **Avoid:** > 6–8 top-level KPIs; numbers without trend direction; decorative use of status colors (green/yellow/red must mean good/warn/critical); paragraphs of prose; missing "last updated"; unlabeled charts.
+
+### Comparison / matrix (A vs B, evaluation, tradeoffs)
+- **When:** evaluating 2–4 options against multiple criteria; a "which should we use?" decision.
+- **Goal:** make the right choice feel inevitable — show the recommendation, the criteria that drove it, and honest strengths/weaknesses of every option. The structure *is* the argument.
+- **Layout DNA:** header stating what's compared + a recommendation summary with confidence up top. Core is the matrix: criteria as rows, options as columns, **visual scoring** in each cell (filled dots, color ratings, CSS bars). The recommended option gets a subtle but unmistakable distinction. 2 options → side-by-side "versus"; 3–4 → full matrix. Detailed per-option breakdowns below. **Keep each option on the same side/column throughout.**
+- **Flavor seeds:** Boxing Tale of the Tape; Wine Tasting Scorecard (spider charts as inline SVG); Car Spec Sheet (gold "editor's pick" badge); Peer-Review Rubric (weighted scores); Restaurant Health-Inspection Card (letter grade first, evidence second).
+- **Avoid:** options without defined criteria; giving the favored option more real estate; > 8–10 ungrouped criteria; text-only scoring ("Good"/"Fair") instead of visual scales; omitting the recommendation; hiding the winner's trade-offs.
+
+### Architecture / flow / visual (diagrams, infographics, one-pagers)
+- **When:** a system, pipeline, state machine, hierarchy, or relationship that's best understood spatially; embeddable infographic or "fancy diagram."
+- **Goal:** communicate through spatial relationships — nesting = containment, adjacency = association, arrows = flow, color = taxonomy. Grasp the structure in a single glance.
+- **Layout DNA:** fixed width (600–800px), no scroll. Nested boxes + connectors + grouping. Each category gets a distinct color (border tint + light fill). Connectors: solid = containment, dashed = optional; small edge labels say what flows. **Legend at the bottom** maps color → meaning. Clean edges, screenshot-ready. Build with inline SVG or styled HTML/CSS boxes — no diagram libraries.
+- **Flavor seeds:** Circuit Board (chips + copper traces, faint grid); Botanical Illustration (specimen labels on parchment); Transit Map (stations + colored lines, schematic not literal); Stained Glass (jewel tones, black leading); Mission Patch (circular badge, functional zones).
+- **Avoid:** paragraphs inside boxes (1–2 lines max); > 5–6 colors; scrolling (simplify instead); requiring JS; inconsistent styling for same-type boxes; omitting the legend.
+
+### Timeline / roadmap (history, milestones, phases)
+- **When:** a multi-phase project with deliverables and deadlines; "where are we on X?"
+- **Goal:** communicate **current position** in 2 seconds and the full journey (done / in-progress / next / blockers) in 60. Forward-looking by design.
+- **Layout DNA:** header (project · status badge On Track/At Risk/Blocked · date range · owner) → 3 overview cards (Goal · Current Status · Next Milestone) → the signature **horizontal timeline strip**: phase segments colored by state (done = green, current pulses with a "You Are Here" marker, upcoming = gray, blocked = red), widths ∝ duration → milestone diamonds with dates → one card per phase (status, dates, deliverables checklist) → dependencies grid → risks & open questions → a "What's Next" card (Immediate / Decisions / Blockers).
+- **Flavor seeds:** Subway Map (phases = stations, pulsing "you are here"); Mountain Expedition (elevation profile, camps = milestones); Film Production Schedule (slate board); Periodic Table (phase = element); Garden Almanac (planting seasons).
+- **Avoid:** > 7 phases; skipping the "You Are Here" marker; listing individual tasks (show deliverables, right altitude); vague names like "Phase 3"; omitting dates; skipping "What's Next"; ignoring risks/dependencies.
+
+### Graph / map (entities + relationships, ecosystems)
+- **When:** entities with relationships (skills, people, systems, concepts) best seen as clusters and connections, not lists.
+- **Goal:** reveal hidden structure — which nodes are hubs, which clusters are isolated, which categories bridge. A tool for discovery.
+- **Layout DNA (self-contained adaptation):** since there's no D3 force simulation, **hand-place nodes** in an inline `<svg>` with deliberate clustering. Node size encodes importance (e.g. connection count); node color encodes category; labels sit below nodes; links are semi-transparent lines. Include a **legend** mapping color → category. For interactivity, use only CSS `:hover` to brighten a node's neighborhood; never depend on it.
+- **Flavor seeds:** Star Chart (dark sky, stars by brightness, constellation lines); Mycelium Network (organic branching); City Transit Map (stations + colored lines); Molecular Structure (atoms + bonds); Party Social Network (conversation clusters).
+- **Avoid:** text inside small nodes (label below + on-hover detail); > 8–9 categories; uniform node size; missing legend; overlap (space nodes out).
+
+### Guide / reference / FAQ (how-to, runbook, Q&A)
+- **When:** question-answer pairs or step-by-step instructions organized by topic; onboarding, troubleshooting, self-service; referenced repeatedly, not read linearly.
+- **Goal:** answers optimized for *retrieval*, not reading — find the answer in seconds via browse (or a tiny optional filter). Trust from consistent formatting and visible "last updated" dates.
+- **Layout DNA:** optional filter input at the top ("start here") → category sections (sidebar on wide, stacked on narrow) → `<details>`/`<summary>` Q&A pairs (question always visible, answer expands) → answers under ~150 words with code/steps/short bullets → an "escalation / still stuck?" section at the bottom → small maintenance metadata. Numbered steps or accordions; copy-ready commands.
+- **Flavor seeds:** Library Card Catalog (warm wood, typewritten labels); Medical Symptom Checker (clinical, high-contrast, actionable); Jukebox Selector (genre codes); Recipe Index (categories + prep time); Switchboard Directory (mono, tight, uniform).
+- **Avoid:** no way to filter on a long list; inconsistent answer formats; answers > 150 words inline (link out); a flat ungrouped list; missing "last updated"; unexplained jargon; no escalation path.
+
+### Session summary / debrief (recap, worklog, weekly update)
+- **When:** what happened over a period — session, day, week; decisions, action items, progress; or a structured work digest of someone's accomplishments.
+- **Goal:** absorb *what happened, what was decided, what's next* in under 30 seconds. Decisions and action items are the highest-value content and must never be buried. A debrief is a **narrative report, not a changelog** — synthesize raw items into themed highlights.
+- **Layout DNA:** editorial header (name/title · period · dateline — no gradient banner) → **TL;DR block** (accent left-border, one bullet per workstream with a bolded name + impact sentence) → a small stats ribbon → **always-visible** project/workstream cards, each with a What/Why/How block and ~3 highlight cards (category-tag pills: Shipped/Impact/Community/Planning/Infra), raw artifacts tucked in a collapsed `<details>` → timeline spine for chronological recaps, with decisions in distinct callouts and action items as an owner+date checklist at the bottom. Single 900px editorial column.
+- **Flavor seeds:** Long-form Journalism (Atlantic feature); Annual Report (dignified, theme-organized); Research Lab Notebook; Architecture Portfolio; Curated Exhibition Catalog. (For session recaps: Field Notebook, Mission Debrief, Sprint Board Snapshot.)
+- **Avoid:** an artifact list as the primary content; collapsing the workstream sections; a gradient/dark hero (the content is the hero); charts for tiny counts ("23 diffs" as text is more honest); red/green value-judgment coloring of counts; skipping the TL;DR; action items without owners.
+
+### Presentation deck (slides, pitch)
+- **When:** content to be *presented* — sequential/narrative, paced; "slides", "deck", "talk", "pitch".
+- **Goal:** one idea per slide, minimal text, maximum clarity; build ideas across slides; end with a clear ask.
+- **Layout DNA:** each slide exactly `100vw × 100vh`, `overflow:hidden`, centered. Title → context → one-idea content slides (each with a visual anchor) → summary (≤3 bullets) → call to action. Large type (headlines 2.5rem+, body 1.25rem+, ≤6 lines/slide). Scroll-snap (`scroll-snap-type:y mandatory`, each slide `scroll-snap-align:start`) is the self-contained, JS-free navigation; a visible slide counter as static text. (Arrow-key nav is the one acceptable tiny inline `<script>`, but the deck must work by scrolling alone.)
+- **Flavor seeds:** Editorial/Magazine; Luxury/Refined (serif, muted, gold accents); Bold/Geometric (oversized numbers); Dark/Cinematic; Minimal/Swiss.
+- **Avoid:** walls of text (then it's a doc); 5+ column data tables (use a chart); fonts < 1rem; no focal point per slide; a 15-item agenda; decoration without meaning.
+
+### Experiment / data report (A/B test, analysis, findings)
+- **When:** a hypothesis tested with data; metrics, stat results, before/after; "experiment", "results", "analysis", "deep dive".
+- **Goal:** lead with the verdict; layer depth (executive summary → key metrics → detailed breakdowns → root cause) so each layer adds detail without requiring the rest.
+- **Layout DNA:** header (title · ID · date range · platform) → **verdict callout** (severity-colored) + 4–6 metric cards → tabbed/multi-scope tables → the "smoking gun" breakdown → daily-trend chart (inline SVG line) → historical comparison → root-cause hypothesis cards (Primary/Secondary/Tertiary with evidence + verification) → numbered recommendations → linked data sources. **Readable numbers, colored containers:** values stay dark; tint the container, scale saturation with magnitude; always show confidence interval + significance (SS/NSS) badges.
+- **Flavor seeds:** Scientific/Academic; Data Dashboard; Corporate Clean; Notebook/Lab; Editorial Data (NYT/Economist chart typography).
+- **Avoid:** burying the conclusion; colored *text* for data values (color the container); numbers without CIs or SS/NSS; uniform color intensity; one scope only; cherry-picking segments; pie charts for small deltas; skipping historical context; hypotheses without evidence; prose where a table fits.
+
+---
+
+## Diagrams & illustrations (inline SVG)
+
+- **When:** architecture/data-flow, pipelines/state machines, comparisons, concepts, metrics, relationships.
+- **How:** inline `<svg viewBox=… width="100%">` for crisp scalable graphics, or styled HTML/CSS boxes for simple flows. Always self-contained — no libraries.
+- **Color-code consistently:** one color per component/layer/persona, reused throughout, with a small **legend**. **Label every box and arrow**; annotate edges with what flows across them.
+- **Charts:** bars are `<rect>`s, lines are `<polyline>`/`<path>`, axes are `<line>`+`<text>`, sparklines are a single `<polyline>`. Keep them small and labeled.
+- **Clean & explanatory:** generous whitespace, the single accent hue, soft borders, legible type. Every line/color must aid understanding — if a visual doesn't make something clearer, drop it. A few precise diagrams beat one busy one.
+
+Tiny inline-SVG flow (3 stages with arrows):
+
+```html
+<svg viewBox="0 0 520 90" width="100%" role="img" aria-label="Capture → Author → Publish"
+     font-family="system-ui" font-size="12">
+  <defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+    <path d="M0,0 L6,3 L0,6 Z" fill="#8A8A8A"/></marker></defs>
+  <rect x="8"   y="28" width="140" height="34" rx="6" fill="#fff" stroke="#E5E0D3"/>
+  <rect x="190" y="28" width="140" height="34" rx="6" fill="#fff" stroke="#E5E0D3"/>
+  <rect x="372" y="28" width="140" height="34" rx="6" fill="#fff" stroke="#E5E0D3"/>
+  <text x="78"  y="49" text-anchor="middle">Capture</text>
+  <text x="260" y="49" text-anchor="middle">Author</text>
+  <text x="442" y="49" text-anchor="middle">Publish</text>
+  <line x1="148" y1="45" x2="190" y2="45" stroke="#8A8A8A" marker-end="url(#arrow)"/>
+  <line x1="330" y1="45" x2="372" y2="45" stroke="#8A8A8A" marker-end="url(#arrow)"/>
+</svg>
+```
+
+---
+
+## Component patterns (style to match your brief — don't force-include)
+
+Starting points, not finished designs. Style each to your palette and type.
+Items marked **(needs JS)** require a tiny inline script and must degrade
+gracefully — never required for the content to be usable.
+
+- **Metric card** — large dark value, small muted label, optional ▲▼ trend; grid `repeat(auto-fit, minmax(200px,1fr))`; rounded surface. Color the card, not the number; scale tint with magnitude.
+- **Callout / alert** — icon + bold title + body, 4px left-border accent; info/success/warning/error tints (use `color-mix()` for backgrounds). Icons: ℹ ✓ ⚠ ✕.
+- **Collapsible** — `<details><summary>` with a rotating chevron; for deep dives / optional detail. Pure HTML, no JS.
+- **Table** — `table-layout:fixed; width:100%` for even columns; `overflow-wrap:anywhere` so long cells wrap; uppercase tinted header row; subtle row separators. For data: colored cell backgrounds by direction/magnitude, dark text.
+- **Timeline** — vertical line (gradient accent→border) + circular markers; date/title/body stacked; stagger the entrance.
+- **Progress / proportion** — label row (name + %) over an 8px rounded track; accent fill via CSS `width` (the one allowed width transition).
+- **Tag / badge** — pill `<span>`, tinted by status (primary/success/warning/error/neutral); 0.7–0.75rem, tight tracking.
+- **Code block** — dark surface (`#0f172a`), monospace, ~0.85rem; language label in a header bar. Copy button only **(needs JS)** — never required.
+- **Tabs** — button row + panels, active state via class. **(needs JS)** — prefer `<details>` or anchored sections when JS can't be assumed.
+- **Anchored Table of Contents** — sticky `<nav>` of `<h2>`/`<h3>` links; on links to in-page anchors use `html{scroll-behavior:smooth; scroll-padding-top:2rem}`. Hide under ~1400px and in print.
+
+---
+
+## Theming (optional)
+
+Only if the surface supports a light/dark toggle you've been told to target,
+follow the contract: `:root` = **light** (light backgrounds, dark text; the page
+loads light by default) and `body.dark-mode` = **dark**. Make dark a *redesign*
+(adjust hue/saturation/surfaces), not a black/white inversion. Otherwise author a
+single light, surface-harmonious palette and stop there.

--- a/skills/html-docs/references/effects.md
+++ b/skills/html-docs/references/effects.md
@@ -1,0 +1,169 @@
+# Visual Effects — the finishing layer, self-contained only
+
+Effects are the treatments that sit on top of a solid layout: the background
+that has character, the depth that makes panels feel placed, the one motion
+that makes the page feel alive, the signature flourish that makes it memorable.
+
+**Hard constraint:** every effect here is CSS-only (plus inline SVG). No
+external JS, no CDNs, no libraries, no web-font fetches unless the user
+explicitly opts in. Docs render in a shadow-DOM viewer and on mobile, so
+effects must be self-contained and degrade gracefully. Read
+[design-system.md](design-system.md) for the system and
+[anti-slop.md](anti-slop.md) for what *not* to do — many "effects" are slop.
+
+Use effects sparingly. One or two deliberate treatments make a page feel
+crafted; a pile of them makes it feel like a demo.
+
+---
+
+## Backgrounds with character
+
+The default flat `#fff` is the #1 "untouched" tell. Give the canvas a quiet
+personality:
+
+```css
+/* Soft tint of the dominant hue — almost subliminal */
+background: hsl(28 30% 98%);
+
+/* Gentle top-down gradient */
+background: linear-gradient(180deg, hsl(220 40% 99%), hsl(220 30% 96%));
+
+/* Atmospheric radial glow behind the hero */
+background:
+  radial-gradient(60% 50% at 50% 0%, hsl(264 60% 96%), transparent 70%),
+  hsl(264 20% 99%);
+
+/* Section banding — alternate subtle tints to separate zones */
+.section--alt { background: hsl(28 24% 97%); }
+```
+
+Keep it quiet: this is atmosphere, not decoration. If you notice the
+background, it's too strong.
+
+---
+
+## Texture (CSS-only)
+
+Texture adds tactility without images. All of these are pure CSS:
+
+```css
+/* Hairline grid — great for technical/blueprint docs */
+background-image:
+  linear-gradient(hsl(220 20% 90% / .5) 1px, transparent 1px),
+  linear-gradient(90deg, hsl(220 20% 90% / .5) 1px, transparent 1px);
+background-size: 24px 24px;
+
+/* Dotted field */
+background-image: radial-gradient(hsl(220 14% 80%) 1px, transparent 1px);
+background-size: 16px 16px;
+
+/* Grain via SVG turbulence (inline data URI, no network) */
+background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E");
+```
+
+Use one texture at most, at low opacity. Texture is seasoning.
+
+---
+
+## Depth & elevation
+
+Prefer hairline borders over shadows; when you do use shadow, make it soft,
+large, low-opacity, and tinted with the hue (never a harsh default gray):
+
+```css
+/* Tinted soft elevation */
+box-shadow: 0 12px 40px -12px hsl(264 40% 30% / .18);
+
+/* Hairline separation (often better than a shadow) */
+border: 1px solid hsl(264 20% 88%);
+
+/* Glassy panel — use sparingly, ensure a fallback bg */
+background: hsl(0 0% 100% / .65);
+backdrop-filter: blur(12px);
+-webkit-backdrop-filter: blur(12px);
+```
+
+Reserve elevation for things that are genuinely "above" the page. If everything
+floats, nothing does (anti-slop #18).
+
+---
+
+## Accents & signature marks
+
+The small, distinctive touches that make a doc memorable — pick ONE as the
+doc's signature, don't stack them:
+
+```css
+/* Marker highlight on a key phrase */
+.mark {
+  background: linear-gradient(transparent 60%, hsl(48 95% 70% / .6) 0);
+}
+
+/* Editorial drop-cap */
+.lead::first-letter {
+  float: left; font-size: 3.4em; line-height: .8;
+  padding: .05em .08em 0 0; font-weight: 700;
+}
+
+/* Hairline section rule with a hue tint */
+.rule { height: 1px; background: hsl(264 30% 86%); }
+
+/* Accent underline that doesn't touch the text */
+.link { border-bottom: 2px solid hsl(348 72% 55%); padding-bottom: 1px; }
+
+/* Numbered step badge */
+.badge {
+  display: grid; place-items: center; width: 2rem; height: 2rem;
+  border-radius: 999px; background: hsl(264 60% 50%); color: #fff;
+  font-weight: 700;
+}
+```
+
+---
+
+## Motion — one moment, calm easing
+
+The rule from design-system.md holds: **at most one entrance** for the whole
+page, calm easing, never on body text, and always behind a reduced-motion
+guard.
+
+```css
+@media (prefers-reduced-motion: no-preference) {
+  .hero { animation: rise .5s cubic-bezier(0.16, 1, 0.3, 1) both; }
+  @keyframes rise {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: none; }
+  }
+}
+```
+
+Good easings: `ease-out`, `cubic-bezier(0.16, 1, 0.3, 1)` (gentle settle).
+Avoid bounce/overshoot and staggered cascades across the whole page
+(anti-slop #13, #14).
+
+Subtle, *continuous* ambient motion can work for a single hero element if it's
+slow and ignorable (e.g. a 20s drifting gradient) — but when in doubt, don't.
+
+---
+
+## Effect recipes by mood
+
+- **Editorial:** 2% warm tint background, hairline top-rules, drop-cap
+  signature, no shadows, no motion (or one fade on the title).
+- **Technical / blueprint:** hairline grid texture, monospace accents,
+  hue-tinted borders, color-coded SVG diagrams, zero decoration.
+- **Dashboard:** flat tinted surface, soft tinted elevation on metric cards,
+  one accent hue for the key number, no entrance animation (data should be
+  instant).
+- **Luxe:** deep dark surface, generous space, a single gold/accent hairline,
+  one slow ambient gradient, serif display.
+- **Playful (rare, earn it):** warm gradient background, rounded radius system,
+  one springy-but-quick entrance on the hero only, marker highlights.
+
+---
+
+## The effects rule
+
+An effect must serve the content or the mood. If you can't say which, cut it.
+The goal is a page that feels *crafted* — and craft reads as restraint plus one
+or two confident, intentional touches, never as a checklist of every trick.

--- a/skills/html-docs/references/html-course.md
+++ b/skills/html-docs/references/html-course.md
@@ -1,0 +1,183 @@
+# Source-grounded HTML Docs courses
+
+Use this reference for curricula, training, onboarding, multi-lesson
+explanations, and learning sites.
+
+## Required outcome
+
+Produce:
+
+- Portable `CourseProject v1`.
+- Versioned source snapshot and evidence graph.
+- Learner contract, canonical glossary, trusted-resource ledger, and
+  evidence-backed learning records.
+- Decision-rich course specification and dependency-aware production slices.
+- Course homepage and cumulative module map.
+- Rich lesson pages.
+- One explanatory `VideoProject v2` for each lesson that benefits from motion.
+- Narration, word timings, captions, transcript, and chapters.
+- Two to four grounded checks per lesson.
+- Progress state and source citations.
+- Quality reports and contact sheets.
+- Private HTML Docs learning-site preview.
+- Short course trailer after lessons pass.
+
+Target four-to-ten-minute lesson videos. Split narration above roughly 1,500
+spoken words at a conceptual boundary. Do not impose a course-wide duration
+limit.
+
+## Portable project
+
+```text
+course-project/
+  course.project.json
+  COURSE-SPEC.md
+  COURSE.md
+  design.md
+  learning/
+    LEARNER.md
+    GLOSSARY.md
+    RESOURCES.md
+    records/
+  production/
+    01-foundations.md
+  source/
+    manifest.json
+    evidence.jsonl
+    fingerprints.json
+  lessons/
+    01-foundations/
+      lesson.json
+      page.html
+      BRIEF.md
+      SCRIPT.md
+      STORYBOARD.md
+      video.project.json
+      audio/
+      assets/
+      scenes/
+      quality/
+      renders/
+  publish-manifest.json
+```
+
+## Design the curriculum
+
+Read [learning-design.md](learning-design.md) and
+[course-specification.md](course-specification.md), then:
+
+1. Define the learner’s purpose, starting point, constraints, exclusions, and
+   observable finish line.
+2. Extract candidate concepts and dependencies from evidence.
+3. Write the course specification, including learner journeys, teaching and
+   artifact decisions, assessment seams, uncertainties, and exclusions.
+4. Reorganize the concepts into a teaching sequence.
+5. Give each module one cumulative capability.
+6. Give each lesson two to four observable objectives and one useful win.
+7. Slice production vertically so each lesson is independently reviewable from
+   evidence through page, video, practice, feedback, and audit.
+8. Record prerequisites, blocking slices, evidence IDs, and source
+   dependencies.
+9. End modules with application or synthesis rather than repetition.
+
+Do not mirror file order, page order, or paper sections unless that is also the
+best learning order.
+
+## Pair page and video
+
+Derive both from one lesson model:
+
+- The page is detailed, searchable, citeable, and collaborative.
+- The video establishes the core mental model through voice, motion, examples,
+  and visual causality.
+- The transcript connects them.
+- Diagrams may share a design language, but prose and narration should not be
+  duplicates.
+
+Embed the stable live player in the lesson page and keep MP4 fallback.
+
+## Ground checks
+
+Create two to four checks per lesson. Each check includes:
+
+- Stable ID.
+- Prompt.
+- Choices or expected response.
+- Correct answer.
+- Expected reasoning and targeted feedback.
+- Check kind: recall, application, discrimination, or transfer.
+- Objective ID and justified mastery-state transition.
+- Evidence IDs.
+
+Test the objective, not trivia about wording. Never invent an answer that is not
+supported by the evidence graph. Treat viewing and completion as exposure, not
+proof of mastery.
+
+## Shared design system
+
+Write one `design.md` for:
+
+- Type roles and scale.
+- Dominant color and semantic colors.
+- Diagram shapes and connectors.
+- Caption skin.
+- Motion tempo.
+- Layout families.
+- Course-page components.
+- Accessibility and responsive rules.
+
+Vary framing between lessons while keeping entities and semantic colors stable.
+
+## Build workflow
+
+```bash
+<skill-root>/scripts/video.sh course init <source> \
+  --output ./course-project --title "Course title"
+```
+
+Replace the scaffold completely. Then:
+
+```bash
+<skill-root>/scripts/video.sh course build ./course-project
+<skill-root>/scripts/video.sh course audit ./course-project
+<skill-root>/scripts/video.sh course preview ./course-project
+<skill-root>/scripts/video.sh course publish ./course-project
+```
+
+`publish` creates a private preview unless an explicit visibility is provided.
+Do not use `--visibility unlisted` or `public` without user authorization.
+
+## Course audit
+
+Require:
+
+- Every substantive claim and answer has evidence.
+- The learner contract has a concrete purpose and observable finish line.
+- Every objective declares how mastery can be demonstrated.
+- Learning records reflect evidence, not content completion.
+- The course implementation matches the decisions and exclusions in
+  `COURSE-SPEC.md`.
+- Production slices are vertical, dependency-valid, and independently
+  reviewable.
+- Every lesson has a clear teaching job.
+- Objectives match lesson content and checks.
+- Each narrated video passes word/cue/scene ownership.
+- Caption and visual safe areas remain clear.
+- Pages work on mobile and keyboard.
+- Navigation reflects dependencies and progress.
+- No missing lesson assets or broken player embeds.
+- Full sound-on video review and contact-sheet inspection.
+
+Generate the trailer only after all lesson audits pass.
+
+## Source refresh
+
+```bash
+<skill-root>/scripts/video.sh course diff ./course-project
+<skill-root>/scripts/video.sh course refresh ./course-project
+```
+
+Use stored dependencies to mark lessons unchanged, stale, or conflicted.
+Regenerate only stale pages, narration segments, scenes, and checks. Preserve
+overrides with surviving semantic IDs. Resolve removed-target conflicts in
+Studio. Produce a new private version and require explicit publication.

--- a/skills/html-docs/references/html-video.md
+++ b/skills/html-docs/references/html-video.md
@@ -1,0 +1,226 @@
+# Deterministic HTML explainer video
+
+Use this reference for narrated or multi-scene HTML video. The active agent
+writes the brief, narration, storyboard, HTML/CSS/JavaScript scenes, and review.
+The local renderer turns time-addressable HTML into pixels and media.
+
+## Final-output contract
+
+A final must provide:
+
+- One teaching job per scene.
+- A cumulative idea sequence, not a list of facts.
+- A substantive explanatory visual in each body scene.
+- Locked narration generated before final timing.
+- Exact word timings from the final audio.
+- One cue and one scene owner for every spoken word.
+- One or more same-scene semantic targets for every cue.
+- Semantic caption groups and a visible karaoke-style active-word treatment
+  derived from the same word track. A caption manifest without the rendered
+  highlight is not a finished caption system.
+- Deterministic seeking and a passing sound-on visual audit.
+- A live HTML player plus MP4 fallback.
+
+## Project layout
+
+```text
+video-project/
+  BRIEF.md
+  SCRIPT.md
+  STORYBOARD.md
+  design.md
+  video.project.json
+  audio/
+    request.json
+    manifest.json
+    pronunciations.json
+    segments/
+    master.wav
+    words.json
+    captions.json
+  assets/
+  scenes/
+    01-hook.html
+    01-hook.css
+    01-hook.js
+  quality/
+  composition.json
+```
+
+`composition.json` is generated. Edit the project and scene modules instead.
+
+## VideoProject v2
+
+Each scene declares:
+
+- Stable scene ID and label.
+- Teaching job.
+- Evidence IDs.
+- Layout family.
+- Source files.
+- Spoken text.
+- Ordered cues.
+- Transition meaning.
+
+Each cue declares:
+
+- Stable cue ID.
+- Exact contiguous spoken text.
+- Optional shorter display text.
+- One or more semantic target IDs.
+- Visual verb.
+- Settled read.
+- Seek-driven effect.
+
+Give selectable elements a globally unique `data-html-video-id`. Use descriptive
+IDs such as `request-enters-queue`, not positions such as `left-box`.
+
+## Write narration for explanation
+
+Write speech, not page prose:
+
+1. Name the learner’s problem.
+2. Give one orienting model.
+3. Explain the mechanism in causal order.
+4. Demonstrate it with a concrete example.
+5. State the practical consequence.
+6. Recap the model in changed language.
+
+Prefer short phrase-shaped sentences. Put difficult identifiers in
+`pronunciations.json`. Keep `spokenText` separate from display labels. Add
+delivery direction to the provider request rather than speaking it aloud.
+
+## Voice pipeline
+
+Choose a provider-neutral profile:
+
+- `warm-teacher`: default educational narration.
+- `gentle-guide`: personal, medical, or sensitive material.
+- `precise-engineer`: technical and code-heavy material.
+- `energetic-coach`: short, action-oriented instruction.
+
+Use ElevenLabs with timestamps when available. Use a local Kokoro implementation
+for offline work. When the provider does not return timings, forced-align the
+locked transcript against the final audio. Do not use unconstrained
+transcription as timing truth.
+
+Generate scene-sized audio segments. Pass neighboring narration as context when
+the provider supports it. Concatenate with click-free boundaries, normalize
+narration near −16 LUFS with a −1 dBTP ceiling, and preserve segment sources for
+selective regeneration.
+
+Use the measured final audio duration as authority. Never time-stretch speech to
+match an estimated storyboard.
+
+## Timing and cue ownership
+
+For each scene:
+
+1. Split narration into ordered cue phrases.
+2. Require concatenated cue text to equal scene narration after punctuation
+   normalization.
+3. Map timed words to cues exactly.
+4. Map every cue to semantic targets in the same scene.
+5. Begin target motion at or immediately around the owned phrase.
+6. Settle the target after the phrase rather than revealing its conclusion
+   early.
+7. Compute scene boundaries from word timings plus pre/post-roll holds.
+
+Use roughly 200 ms pre-roll and 600 ms settled post-roll unless the scene has a
+reason to differ. Shift timestamps mechanically when adding holds.
+
+## Captions
+
+Build semantic caption groups from punctuation, pauses, and phrase structure:
+
+- Usually two to six words.
+- One active group at a time. Keep the full phrase readable.
+- Give the exact word currently spoken an accent pill and restrained scale pop
+  driven by its canonical `startMs` and `endMs`.
+- Bottom 17% reserved across all scenes.
+- Default on in the live player and captioned MP4.
+- Also export WebVTT and SRT.
+
+Match the compiler's baseline treatment to `design.md` in `global.css`:
+
+```css
+:root {
+  --hv-caption-bg: rgba(247, 242, 225, 0.94);
+  --hv-caption-border: #d989a8;
+  --hv-caption-text: #25251f;
+  --hv-caption-inactive-opacity: 0.82;
+  --hv-caption-accent: #d989a8;
+  --hv-caption-active-text: #25251f;
+}
+```
+
+Do not remove `.hv-caption-word[data-active="true"]` or replace the in-frame
+rail with WebVTT/SRT-only output. Sample word starts, midpoints, ends, and short
+pauses during audit. Exactly one word should carry the highlight while spoken,
+without leading, lagging, or covering scene content.
+
+Do not independently retime captions. Cues, captions, scenes, and transcript all
+derive from one normalized word track.
+
+## Deterministic scene code
+
+Register one seek function:
+
+```js
+window.__HTML_VIDEO__ = {
+  renderFrame({ root, timeMs, progress, variables }) {
+    const target = root.querySelector(
+      '[data-html-video-id="central-mechanism"]',
+    )
+    target.style.opacity = String(Math.min(1, progress * 1.4))
+  },
+}
+```
+
+Derive every pixel from the supplied time and variables. Do not use wall clocks,
+timers, unseeded randomness, requestAnimationFrame, self-running CSS animation,
+network requests, storage, workers, dynamic imports, or external runtime media.
+
+## Build and audit
+
+```bash
+<skill-root>/scripts/video.sh build ./video-project
+<skill-root>/scripts/video.sh check ./video-project
+<skill-root>/scripts/video.sh audit ./video-project
+<skill-root>/scripts/video.sh render ./video-project --output ./final.mp4
+```
+
+Inspect:
+
+- Scene opening, development, and settled frames.
+- Cue midpoint frames.
+- Caption clearance.
+- Repeated layouts.
+- Text clipping and contrast.
+- Missing or premature targets.
+- Same-time deterministic captures.
+- Full playback with sound.
+
+Do not publish a final that passes numerically but fails visually.
+
+## Publish
+
+Document-linked:
+
+```bash
+<skill-root>/scripts/video.sh publish ./video-project \
+  --document <document-id> \
+  --prompt "Teach the mechanism" \
+  --provider codex
+```
+
+Standalone:
+
+```bash
+<skill-root>/scripts/video.sh publish ./video-project \
+  --prompt "Teach the mechanism" \
+  --provider codex
+```
+
+Use the returned `/v/<code>` URL for sharing. Keep the MP4 as fallback or
+download. Keep provider keys, raw source bundles, and diagnostics private.

--- a/skills/html-docs/references/learning-design.md
+++ b/skills/html-docs/references/learning-design.md
@@ -1,0 +1,138 @@
+# Adaptive learning design
+
+Use this reference for a course, onboarding path, curriculum, or any explanation
+the learner will revisit across sessions. A course is not a playlist. It is a
+stateful teaching system that changes what comes next based on demonstrated
+understanding.
+
+## Start with the learner contract
+
+Write `learning/LEARNER.md` before outlining lessons:
+
+```markdown
+# Learner contract: <topic>
+
+## Purpose
+<The concrete work, decision, or life outcome this learning should enable.>
+
+## Finish line
+- <An observable capability the learner can demonstrate>
+- <Another observable capability>
+
+## Starting point
+- <Relevant prior knowledge, with whether it is claimed or demonstrated>
+
+## Constraints
+- <Time, accessibility, tools, budget, language, or delivery constraints>
+
+## Exclusions
+- <Adjacent material intentionally deferred>
+```
+
+Keep this shorter than a page. Prefer an observable capability over “understand
+X.” If the user already supplied enough context, synthesize it without adding
+an approval gate. Ask only when a missing answer would materially change the
+course.
+
+## Maintain four kinds of learning state
+
+Store the state under `learning/`:
+
+- `LEARNER.md`: purpose, finish line, starting point, constraints, exclusions,
+  and teaching preferences.
+- `GLOSSARY.md`: the course’s canonical terms and short definitions.
+- `RESOURCES.md`: a curated, annotated ledger of primary and authoritative
+  sources, including known evidence gaps.
+- `records/NNNN-<slug>.md`: durable changes in the learner model.
+
+A learning record is not a session log. Write one only when evidence changes
+what should be taught next:
+
+- The learner demonstrated a non-trivial capability.
+- A claimed prerequisite was confirmed or disproved.
+- A misconception was identified and corrected.
+- The purpose or finish line changed.
+
+Each record contains the observation, the evidence, and the consequence for
+future lessons. Supersede a stale record rather than deleting history.
+
+Do not treat content exposure, video completion, or a correct guess as mastery.
+
+## Track mastery as evidence, not a percentage
+
+For each objective, use one of these states:
+
+| State | Meaning | Suitable evidence |
+|---|---|---|
+| `unseen` | Not introduced | None |
+| `introduced` | Learner encountered the model | Viewing or reading only |
+| `practiced` | Learner used it with support | Guided task with feedback |
+| `demonstrated` | Learner applied it independently | Transfer task or explanation |
+| `needs-review` | Retrieval weakened or a misconception resurfaced | Failed delayed check |
+
+Progress percentages may be shown for navigation, but lesson selection must use
+objective state, prerequisites, misconceptions, and the learner’s purpose.
+
+## Design one lesson around one useful win
+
+Keep the core lesson within working-memory limits. A lesson may contain several
+scenes, but it should make one capability measurably stronger.
+
+Use this sequence when it fits:
+
+1. **Retrieve.** Ask for a brief recall or prediction before revealing the
+   answer.
+2. **Orient.** Tie the lesson to the learner’s purpose and prior model.
+3. **Explain.** Build one causal or procedural mental model.
+4. **Demonstrate.** Work through a concrete example while narrating decisions.
+5. **Practice.** Give the learner a small task with immediate, specific
+   feedback.
+6. **Transfer.** Change the surface details and require independent use.
+7. **Consolidate.** Compress the model, name the next dependency, and schedule
+   retrieval.
+
+Knowledge acquisition should be clear and low-friction. Practice should be
+effortful enough to reveal understanding. Do not manufacture difficulty through
+trick wording, decorative interaction, or ambiguous choices.
+
+## Use checks diagnostically
+
+Every check declares:
+
+- The objective it measures.
+- The expected reasoning, not only the answer.
+- Evidence IDs supporting the answer.
+- Feedback for the correct answer and each plausible misconception.
+- Whether it measures recall, application, discrimination, or transfer.
+- The mastery-state transition it can justify.
+
+Keep multiple-choice options parallel in grammar, length, and visual treatment.
+Avoid clues caused by one answer being more detailed than the others.
+
+End each module with application or synthesis. Revisit important objectives
+after a delay and interleave related skills when that improves discrimination.
+
+## Reuse teaching components
+
+Store reusable lesson components under `assets/`: course typography, diagram
+tokens, quiz widgets, simulators, code walkers, equation builders, and feedback
+patterns. Read the existing asset ledger before creating a new component.
+
+Reuse should create a coherent learning environment, not identical lessons.
+Keep entity colors and interaction meanings stable while varying the visual
+framing needed by each concept.
+
+## Adapt the next lesson
+
+Before generating or refreshing a lesson:
+
+1. Read the learner contract and active learning records.
+2. Identify prerequisite objectives and their current evidence state.
+3. Choose the smallest next capability that advances the finish line.
+4. Prefer a retrieval activity when prior learning is due for review.
+5. Record newly demonstrated capabilities only after the learner provides
+   evidence.
+
+For a static public course with no individual learner history, ship an explicit
+default path plus optional prerequisite checks and remediation branches. Do not
+pretend that anonymous completion data proves mastery.

--- a/skills/html-docs/references/pdf.md
+++ b/skills/html-docs/references/pdf.md
@@ -1,0 +1,199 @@
+# PDF — turn a PDF into a beautiful doc, and export a clean PDF back
+
+Two directions, one skill:
+
+1. **PDF in → designed doc.** Take a source PDF and re-author it as a genuinely
+   *designed* HTML doc (then publish it, and optionally export a clean PDF).
+2. **Doc → PDF out.** Export any hosted doc to a well-laid-out PDF that paginates
+   properly — not a screenshot, a real document.
+
+This is **not** a "print to PDF" button. The goal is a doc that looks
+*intentionally typeset*, on screen and on the page. Read
+[design-system.md](design-system.md) and [anti-slop.md](anti-slop.md) first —
+everything here sits on top of them.
+
+---
+
+## Part 1 — PDF in → a designed doc
+
+### The wrong way (don't do this)
+Dumping the PDF's text into `<p>` tags, or OCR-flattening each page into an
+image, gives you a *reflow*, not a *design*. It carries over the source's bad
+typography and none of its meaning-structure. Skip it.
+
+### The right way: read → understand → re-author
+You (Claude Code) can read a PDF directly. Use that. The job is to understand
+the document's **structure and intent**, then rebuild it as a designed doc.
+
+1. **Read the source.** Pull the full text, the heading hierarchy, tables,
+   figures, and the reading order. Note what *kind* of document it is — report,
+   contract, paper, deck, invoice, résumé, manual. That choice picks an
+   archetype (design-system.md).
+
+2. **Recover the structure, not just the words.** A heading that was big-bold in
+   the PDF is an `<h2>`, not a fat `<p>`. A two-column comparison is a real
+   table or grid. A boxed aside is a callout. Reconstruct the *semantics* the
+   PDF only expressed visually.
+
+3. **Extract real assets.** Diagrams and charts that were bitmap images in the
+   PDF should be re-authored as inline SVG / styled HTML where feasible (sharp
+   at any zoom, recolorable, accessible). Keep genuine photos as images. Never
+   leave a wall of low-res page screenshots.
+
+4. **Author from the creative brief.** Don't mirror the source's look — design
+   *for the content*. Pick the archetype, one dominant hue, a real type scale,
+   a signature. Preserve every fact, number, link, and table from the source;
+   invent nothing.
+
+5. **Run the linter.** Before publishing, pass the draft through
+   [anti-slop.md](anti-slop.md). A re-authored PDF should look better than the
+   original, not like a default template.
+
+6. **Publish** (see the main skill): `POST /api/v1/docs` or
+   `npx @html-docs/cli publish doc.html`.
+
+### When the source is faithful-reproduction territory
+Some PDFs (signed contracts, regulatory filings, anything where exact layout is
+legally meaningful) should be reproduced faithfully rather than redesigned. In
+that case preserve structure and content precisely and keep styling minimal and
+neutral — fidelity over flair. Use judgment: redesign explainers and reports;
+reproduce documents of record.
+
+---
+
+## Part 2 — Doc → PDF out
+
+### The key idea: author a *print edition*, don't just print the screen doc
+
+The single biggest lever on PDF quality is this: **a great PDF is a second
+rendition of the document, authored for the page — not the on-screen HTML run
+through a printer.** The screen edition and the print edition want different
+things, and forcing one to be both gives you a mediocre version of each.
+
+| | Screen edition | Print edition |
+|---|---|---|
+| Hero | full-bleed, scrolls | cover/title block ≈ one page |
+| Type | screen scale, tints | print scale, ink-on-paper contrast |
+| Flow | one continuous column | paginated; chapters start fresh |
+| Motion | entrances, hover | none |
+| Width | viewport-driven | fitted to the page box |
+| Chrome | nav, scroll-spy | dropped |
+
+So the quality workflow is: take the doc's content and **transform it into a
+print-oriented HTML rendition**, then export *that*. Concretely:
+
+1. **Cover/title block** sized to roughly one page — not a giant scroll hero
+   that wastes the first printed sheet.
+2. **Print type scale** — slightly smaller body, tighter leading, contrast
+   tuned for paper (deep ink on near-white) rather than screen tints/glows.
+3. **Deliberate pagination** — major sections / chapters begin on a fresh page
+   via the break hooks below; a short TOC up front if the doc is long.
+4. **Figures & tables fitted to the page box** — `max-width: 100%`, repeating
+   table headers, no element wider than the printable area.
+5. **Strip screen-only behavior** — motion, hover states, sticky nav, anything
+   that only makes sense while scrolling.
+
+Keep both renditions from one source of truth: the screen edition stays live and
+interactive; the print edition is what you hand to the `/pdf` endpoint. This is
+also exactly the HTML you'd feed a Paged Media engine (Paged.js, WeasyPrint,
+Prince) if you want running headers and TOC leaders later.
+
+### The export endpoint
+
+Every hosted doc exports to PDF via one endpoint, rendered with headless
+Chromium for full visual fidelity (fonts, colors, gradients, inline SVG,
+backgrounds all preserved exactly as on screen):
+
+    GET /api/v1/docs/:id/pdf
+
+Authenticated like every v1 endpoint (doc token or API key). Options:
+
+| Param | Values | Effect |
+|---|---|---|
+| `format` | `letter` (default), `a4`, `legal` | page size |
+| `landscape` | `1` | landscape orientation |
+| `html` | `1` | return **print-ready HTML** instead of PDF bytes |
+
+Examples:
+
+    # Letter PDF
+    curl 'https://www.html-docs.com/api/v1/docs/<id>/pdf' \
+      -H 'x-doc-token: <token>' -o report.pdf
+
+    # A4, landscape
+    curl 'https://www.html-docs.com/api/v1/docs/<id>/pdf?format=a4&landscape=1' \
+      -H 'Authorization: Bearer <key>' -o report.pdf
+
+### Run your own PDF engine (`?html=1`)
+Chromium has excellent fidelity but only partial CSS Paged Media support (no
+running headers from content, no TOC leaders, limited named pages). If you want
+book-grade output, fetch the **print-ready HTML** and run a dedicated engine:
+
+    curl 'https://www.html-docs.com/api/v1/docs/<id>/pdf?html=1' \
+      -H 'x-doc-token: <token>' -o print.html
+    # then, with a Paged Media engine you control:
+    weasyprint print.html out.pdf      # open-source, strong paged media, no JS
+    prince print.html -o out.pdf       # commercial, best-in-class paged media
+
+The returned HTML already has the print stylesheet injected (see below), so
+these engines pick up the same break discipline.
+
+---
+
+## What "well laid out" means — and what the export already does for you
+
+The export injects a print stylesheet so the PDF paginates like a document, not
+a long screenshot. You get these **for free** on export:
+
+- **No stranded lines** — `orphans`/`widows` keep at least 3 lines together.
+- **Headings stay with their content** — a heading never sits alone at the foot
+  of a page (`break-after: avoid-page`).
+- **Atomic blocks don't split** — figures, images, tables, `pre`, blockquotes,
+  cards, callouts, and timeline items use `break-inside: avoid`.
+- **Tables repeat their header** on each page (`thead { display:
+  table-header-group }`) and rows stay whole.
+- **Code wraps** instead of clipping or running off the page edge.
+- **Backgrounds and colors print** (`print-color-adjust: exact`).
+- **On-screen-only chrome is hidden** (sidebars, scroll-spy, slide nav).
+- **Entrance animations are neutralized** so nothing renders mid-fade.
+- **Margins come from the engine** (uniform page gutter), not doubled in CSS.
+
+### Authoring hooks you can use
+When you author a doc and want explicit control over pagination, these class /
+data-attribute hooks are honored on export:
+
+| Hook | Effect |
+|---|---|
+| `class="page-break-before"` / `data-page-break="before"` | start a new page before this element |
+| `class="page-break-after"` / `data-page-break="after"` | break the page after this element |
+| `class="page-break-avoid"` / `data-page-break="avoid"` | keep this element whole on one page |
+| `class="no-print"` / `class="screen-only"` / `data-print-hide` | hide this element in the PDF |
+| `data-keep-together` | never split this block across pages |
+
+Use them sparingly and deliberately — let the defaults do most of the work, and
+reach for an explicit break only where the content genuinely demands it (e.g.
+start each chapter or each major section on a fresh page).
+
+### Print-friendly authoring tips
+- Prefer relative widths (`max-width: 100%`) so content fits any page format.
+- Keep hero/cover sections to roughly one page; a giant full-bleed hero wastes
+  the first printed page.
+- Color-code consistently and include legends — color survives to PDF.
+- Test both `letter` and `a4` if the audience is international.
+- For data tables longer than a page, rely on the repeating `thead` rather than
+  forcing breaks.
+
+---
+
+## Quick recipes
+
+**"Make this PDF into a nice web doc":** read the PDF → recover structure →
+pick an archetype → author per design-system.md → `audit` against anti-slop.md →
+publish. Offer the live URL; export a PDF too if they want the file back.
+
+**"Export my doc as a polished PDF":** `GET /api/v1/docs/:id/pdf?format=…`. If
+they need running headers / TOC leaders / book-grade paging, use `?html=1` and
+run WeasyPrint or Prince on the returned HTML.
+
+**"Round-trip a report":** import PDF → redesign → publish → export PDF. The
+output is a designed document in both forms, not a reflow of the original.

--- a/skills/html-docs/references/source-grounding.md
+++ b/skills/html-docs/references/source-grounding.md
@@ -1,0 +1,93 @@
+# Source grounding and research
+
+Use this reference for folders, repositories, websites, documents, PDFs,
+pasted material, and research topics.
+
+## Snapshot contract
+
+Freeze a `SourceSnapshot` before outlining. Record:
+
+- Stable evidence ID.
+- Canonical URI or safe local locator.
+- Title and section heading.
+- Extracted passage or code excerpt.
+- Content checksum.
+- File/page/line locator when safe.
+- Source type, authorship, date, and retrieval time when known.
+- Privacy and publication metadata.
+
+Keep raw sources private. Upload only used excerpts unless the user explicitly
+requests a full-source archive.
+
+## Codebases
+
+Respect `.gitignore` plus these exclusions:
+
+- Environment and credential files.
+- VCS internals.
+- Dependency directories.
+- Build output, caches, generated binaries, media, and archives.
+- Minified or vendored files unless they are the subject.
+
+Record the commit SHA and selected file hashes. Build evidence around concepts,
+architecture, data flow, interfaces, and representative code. Do not turn a
+directory listing into a course.
+
+## Websites
+
+For one-page requests, snapshot only that page and directly required assets.
+For site-level requests:
+
+- Stay on the same origin by default.
+- Crawl to depth two and at most 100 pages.
+- Respect authentication and access restrictions.
+- Canonicalize URLs and remove tracking parameters.
+- Deduplicate content by checksum.
+- Preserve heading anchors and page titles.
+
+## Research topics
+
+Research before outlining:
+
+1. Decompose the topic into the learner’s likely questions.
+2. Prefer primary papers, standards, official documentation, datasets, and
+   first-party technical material.
+3. Use secondary sources to orient, not as the only support for technical
+   claims.
+4. Resolve disagreements and mark uncertainty.
+5. Continue until every planned substantive claim has at least one evidence
+   record.
+6. Freeze the research manifest, then write.
+
+Do not cite search-result pages. Keep claims narrower than their evidence.
+Distinguish source facts from agent inference.
+
+For a course, maintain an annotated `learning/RESOURCES.md` alongside the
+machine-readable evidence graph. Record what each source is authoritative for,
+when to consult it, and any evidence gap still blocking a lesson. Prefer a
+small, sharp source set over a long undifferentiated bibliography.
+
+## Evidence graph
+
+Represent:
+
+- `supports`: evidence supports a claim.
+- `qualifies`: evidence limits a claim.
+- `contradicts`: sources disagree.
+- `depends_on`: one idea requires another.
+- `demonstrates`: an example makes a mechanism concrete.
+
+Every lesson records evidence IDs and source dependencies. The page shows
+human-readable citations; the project retains machine-readable IDs.
+
+## Refresh
+
+Rescan fingerprints and classify each lesson:
+
+- `unchanged`: no dependency changed.
+- `stale`: one or more dependencies changed.
+- `conflicted`: a changed source removed or replaced an edited semantic target.
+
+Regenerate stale lessons only. Reapply overrides whose semantic IDs survive.
+Surface conflicts in Studio. Create a private version and require explicit
+publication.

--- a/skills/html-docs/references/video-scene-craft.md
+++ b/skills/html-docs/references/video-scene-craft.md
@@ -1,0 +1,133 @@
+# Explanatory scene craft
+
+Use this reference to design what the learner sees while each phrase is spoken.
+
+## Start with the teaching spine
+
+Write one sentence for each:
+
+- Learner’s initial misconception or missing model.
+- Central claim.
+- Mechanism.
+- Evidence or example.
+- Consequence.
+- Final usable mental model.
+
+Every scene must advance this sequence. Remove scenes that merely repeat a
+headline or decorate narration.
+
+## Assign one teaching job per scene
+
+Good jobs are observable:
+
+- Orient the parts of a system.
+- Reveal a causal step.
+- Compare two states.
+- Trace one object through a process.
+- Construct an equation.
+- Show why an intuition fails.
+- Apply a model to a case.
+- Reassemble the lesson into one map.
+
+Do not combine orientation, three mechanisms, and a conclusion in one frame.
+
+## Choose an explanatory grammar
+
+Select the grammar that matches the idea:
+
+| Idea | Visual grammar |
+|---|---|
+| Causality | Nodes connected by directional transfer |
+| Architecture | Nested layers and interfaces |
+| State change | Stable states with a highlighted transition |
+| Code execution | Source line, runtime state, and output |
+| Equation | Terms introduced, related, then simplified |
+| Time | Stations, intervals, and changing state |
+| Comparison | Shared baseline with one variable changed |
+| Tradeoff | Axes, constraints, and movement through the space |
+| Data story | Baseline, change, annotation, implication |
+| Feedback | Loop with measured return path |
+
+Invent subject-specific visuals from these grammars. Do not reuse one card grid
+for unrelated ideas.
+
+## Plan the layout rhythm
+
+A normal lesson uses at least three framing families:
+
+- Full-stage hook or orienting image.
+- Asymmetric labeled diagram.
+- Close-up mechanism or code/equation view.
+- Split comparison.
+- Wide synthesis map.
+
+Alternate density and scale. Follow a dense diagram with a focused close-up.
+Use whitespace to direct attention, not to avoid explaining.
+
+## Choreograph each cue
+
+For each spoken phrase:
+
+1. **Prepare:** required context may exist quietly.
+2. **Activate:** motion begins near the owned words.
+3. **Develop:** the relation or state visibly changes.
+4. **Settle:** the phrase’s meaning becomes easy to read.
+5. **Hold:** leave enough time to understand the result.
+
+The final state must not read before the phrase that owns it. Decorative ambient
+motion cannot substitute for conceptual change.
+
+Useful visual verbs:
+
+- enter, connect, split, route, accumulate, compare, swap, constrain, reveal,
+  label, measure, collapse, expand, trace, resolve.
+
+Avoid vague verbs such as “animate” or “make dynamic.”
+
+## Use transitions semantically
+
+- Cut: new chapter or deliberate contrast.
+- Crossfade: same idea seen from another abstraction level.
+- Push: movement through a process or space.
+- Zoom: move between system and component.
+- Shared-object handoff: preserve one concept while context changes.
+
+Do not rotate transition types for novelty.
+
+## Design for narration and captions
+
+Keep critical diagrams above the bottom caption reserve. Place labels near their
+referents. Use consistent colors for the same entities throughout the lesson.
+When narration names a part, highlight that part—not the entire diagram.
+
+Keep each caption phrase readable while the exact spoken word receives a
+design-matched accent pill and restrained scale pop. Audit word starts,
+midpoints, ends, and pauses so the highlight follows the audio without leading,
+lagging, or leaving two words active.
+
+Keep display copy shorter than narration. Use a large label, a concise
+annotation, and the visual relation itself to carry meaning.
+
+## Review at three levels
+
+### Frame review
+
+At sampled timestamps verify hierarchy, contrast, clipping, safe areas, and
+whether the focal idea is obvious without playback.
+
+### Motion review
+
+Compare opening, active-cue, and settled frames. Verify that the scene visibly
+develops and that the target does not land early.
+
+### Lesson review
+
+Watch sound-on without stopping. Verify that:
+
+- Voice and visible idea match.
+- Each scene earns its duration.
+- Layout changes feel intentional.
+- Captions do not compete with diagrams.
+- The ending leaves one usable model.
+
+Fix weak scenes in source modules, rebuild, and review again.

--- a/skills/html-docs/scripts/publish.sh
+++ b/skills/html-docs/scripts/publish.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="https://www.html-docs.com"
+CREDENTIALS_FILE="$HOME/.htmldocs/credentials"
+API_KEY=""
+API_KEY_SOURCE="none"
+SLUG=""
+TITLE=""
+CLIENT=""
+TARGET=""
+DOC_ID=""
+DOC_TOKEN=""
+
+if [[ -n "${HTMLDOCS_API_KEY:-}" ]]; then
+  API_KEY="$HTMLDOCS_API_KEY"
+  API_KEY_SOURCE="env"
+fi
+
+usage() {
+  cat <<'USAGE'
+Usage: publish.sh <file-or-dir> [options]
+
+Publish HTML files and directories to html-docs.com.
+
+Options:
+  --api-key <key>         API key (or set $HTMLDOCS_API_KEY)
+  --slug <slug>           Custom slug for the hosted URL
+  --title <text>          Document title
+  --client <name>         Agent name for attribution (e.g. cursor, claude-code)
+  --doc-id <id>           Update an existing document (requires --doc-token or --api-key)
+  --doc-token <token>     Token for updating an existing anonymous document
+  --base-url <url>        API base (default: https://www.html-docs.com)
+
+Examples:
+  publish.sh page.html                          # anonymous publish
+  publish.sh dashboard.html --slug my-dash      # custom slug
+  publish.sh ./site/ --api-key hdk_xxx          # authenticated, directory
+  publish.sh page.html --doc-id <id> --doc-token <tok>  # update existing
+USAGE
+  exit 1
+}
+
+die() { echo "error: $1" >&2; exit 1; }
+
+for cmd in curl; do
+  command -v "$cmd" >/dev/null 2>&1 || die "requires $cmd"
+done
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --api-key)      API_KEY="$2"; API_KEY_SOURCE="flag"; shift 2 ;;
+    --slug)         SLUG="$2"; shift 2 ;;
+    --title)        TITLE="$2"; shift 2 ;;
+    --client)       CLIENT="$2"; shift 2 ;;
+    --doc-id)       DOC_ID="$2"; shift 2 ;;
+    --doc-token)    DOC_TOKEN="$2"; shift 2 ;;
+    --base-url)     BASE_URL="$2"; shift 2 ;;
+    --help|-h)      usage ;;
+    -*)             die "unknown option: $1" ;;
+    *)              [[ -z "$TARGET" ]] && TARGET="$1" || die "unexpected argument: $1"; shift ;;
+  esac
+done
+
+[[ -n "$TARGET" ]] || usage
+[[ -e "$TARGET" ]] || die "path does not exist: $TARGET"
+
+# Load API key from credentials file if not provided
+if [[ -z "$API_KEY" && -f "$CREDENTIALS_FILE" ]]; then
+  API_KEY=$(cat "$CREDENTIALS_FILE" | tr -d '[:space:]')
+  [[ -n "$API_KEY" ]] && API_KEY_SOURCE="credentials"
+fi
+
+BASE_URL="${BASE_URL%/}"
+
+# ── Determine content to send ──────────────────────────────────────
+
+CONTENT=""
+CONTENT_TYPE="text/html"
+
+if [[ -f "$TARGET" ]]; then
+  CONTENT=$(cat "$TARGET")
+  # Detect markdown
+  case "${TARGET##*.}" in
+    md|markdown)
+      CONTENT_TYPE="text/markdown"
+      ;;
+  esac
+elif [[ -d "$TARGET" ]]; then
+  # For directories, look for index.html
+  if [[ -f "$TARGET/index.html" ]]; then
+    CONTENT=$(cat "$TARGET/index.html")
+  elif [[ -f "$TARGET/index.htm" ]]; then
+    CONTENT=$(cat "$TARGET/index.htm")
+  elif [[ -f "$TARGET/index.md" ]]; then
+    CONTENT=$(cat "$TARGET/index.md")
+    CONTENT_TYPE="text/markdown"
+  else
+    die "no index.html, index.htm, or index.md found in $TARGET"
+  fi
+else
+  die "not a file or directory: $TARGET"
+fi
+
+[[ -n "$CONTENT" ]] || die "empty file"
+
+# ── Build request ──────────────────────────────────────────────────
+
+AUTH_ARGS=()
+if [[ -n "$API_KEY" ]]; then
+  AUTH_ARGS=(-H "authorization: Bearer $API_KEY")
+fi
+
+EXTRA_HEADERS=()
+if [[ -n "$SLUG" ]]; then
+  EXTRA_HEADERS+=(-H "x-slug: $SLUG")
+fi
+if [[ -n "$CLIENT" ]]; then
+  EXTRA_HEADERS+=(-H "x-agent-name: $CLIENT")
+fi
+if [[ -n "$TITLE" ]]; then
+  EXTRA_HEADERS+=(-H "x-doc-title: $TITLE")
+fi
+
+# ── Send request ───────────────────────────────────────────────────
+
+if [[ -n "$DOC_ID" ]]; then
+  # Update existing document
+  URL="$BASE_URL/api/v1/docs/$DOC_ID"
+  METHOD="PUT"
+  TOKEN_ARGS=()
+  if [[ -n "$DOC_TOKEN" && -z "$API_KEY" ]]; then
+    TOKEN_ARGS=(-H "x-doc-token: $DOC_TOKEN")
+  fi
+
+  RESPONSE=$(curl -sS -X "$METHOD" "$URL" \
+    -H "content-type: $CONTENT_TYPE" \
+    "${AUTH_ARGS[@]}" \
+    "${TOKEN_ARGS[@]}" \
+    "${EXTRA_HEADERS[@]}" \
+    --data-binary "$CONTENT" 2>&1) || true
+else
+  # Create new document
+  URL="$BASE_URL/api/v1/docs"
+
+  RESPONSE=$(curl -sS -X POST "$URL" \
+    -H "content-type: $CONTENT_TYPE" \
+    "${AUTH_ARGS[@]}" \
+    "${EXTRA_HEADERS[@]}" \
+    --data-binary "$CONTENT" 2>&1) || true
+fi
+
+# ── Parse response ─────────────────────────────────────────────────
+
+# Check for error
+if echo "$RESPONSE" | grep -q '"error"'; then
+  err=$(echo "$RESPONSE" | grep -o '"error":"[^"]*"' | head -1 | sed 's/"error":"//;s/"$//')
+  die "$err"
+fi
+
+# Extract fields
+SITE_URL=$(echo "$RESPONSE" | grep -o '"url":"[^"]*"' | head -1 | sed 's/"url":"//;s/"$//')
+OUT_SLUG=$(echo "$RESPONSE" | grep -o '"slug":"[^"]*"' | head -1 | sed 's/"slug":"//;s/"$//')
+EDIT_URL=$(echo "$RESPONSE" | grep -o '"editUrl":"[^"]*"' | head -1 | sed 's/"editUrl":"//;s/"$//')
+OUT_TOKEN=$(echo "$RESPONSE" | grep -o '"token":"[^"]*"' | head -1 | sed 's/"token":"//;s/"$//')
+OUT_ID=$(echo "$RESPONSE" | grep -o '"id":"[^"]*"' | head -1 | sed 's/"id":"//;s/"$//')
+
+# Output the hosted URL (primary output on stdout)
+echo "$SITE_URL"
+
+# Structured metadata on stderr
+echo "" >&2
+echo "publish_result.url=$SITE_URL" >&2
+echo "publish_result.slug=$OUT_SLUG" >&2
+echo "publish_result.edit_url=$EDIT_URL" >&2
+echo "publish_result.token=$OUT_TOKEN" >&2
+echo "publish_result.id=$OUT_ID" >&2
+echo "publish_result.api_key_source=$API_KEY_SOURCE" >&2
+
+if [[ -n "$API_KEY" ]]; then
+  echo "publish_result.auth_mode=authenticated" >&2
+  echo "publish_result.persistence=permanent" >&2
+else
+  echo "publish_result.auth_mode=anonymous" >&2
+fi

--- a/skills/html-docs/scripts/video.sh
+++ b/skills/html-docs/scripts/video.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# pnpm runs a filtered package script from that package's directory. Preserve
+# the caller's path semantics before handing arguments to either renderer path.
+caller_dir="$PWD"
+renderer_args=("$@")
+target_index=1
+if (( ${#renderer_args[@]} >= 1 )) && [[ "${renderer_args[0]}" =~ ^(course|project)$ ]]; then
+  target_index=2
+elif (( ${#renderer_args[@]} >= 1 )) && [[ "${renderer_args[0]}" == "studio" ]]; then
+  target_index=-1
+fi
+if (( target_index >= 0 && ${#renderer_args[@]} > target_index )) && [[ "${renderer_args[$target_index]}" != --* ]] && [[ "${renderer_args[$target_index]}" != /* ]] && [[ "${renderer_args[$target_index]}" != *://* ]]; then
+  renderer_args[$target_index]="$caller_dir/${renderer_args[$target_index]}"
+fi
+for ((i = 0; i < ${#renderer_args[@]}; i++)); do
+  if [[ "${renderer_args[$i]}" =~ ^--(output|output-dir|voiceover|source|project)$ ]] && (( i + 1 < ${#renderer_args[@]} )) && [[ "${renderer_args[$((i + 1))]}" != /* ]]; then
+    renderer_args[$((i + 1))]="$caller_dir/${renderer_args[$((i + 1))]}"
+  fi
+done
+
+# Prefer a checked-out HTML Docs workspace so skill development and released
+# renderer builds use the exact same open-source implementation. A custom
+# checkout can be selected without editing this skill.
+video_repo="${HTMLDOCS_VIDEO_REPO:-}"
+if [[ -z "$video_repo" ]]; then
+  current_dir="$PWD"
+  while [[ "$current_dir" != "/" ]]; do
+    if [[ -f "$current_dir/packages/html-video/package.json" ]]; then
+      video_repo="$current_dir"
+      break
+    fi
+    current_dir="$(dirname "$current_dir")"
+  done
+fi
+if [[ -z "$video_repo" && -f "$HOME/projects/html-docs/packages/html-video/package.json" ]]; then
+  video_repo="$HOME/projects/html-docs"
+fi
+
+if [[ -n "$video_repo" ]]; then
+  exec pnpm --dir "$video_repo" --filter @html-docs/html-video cli "${renderer_args[@]}"
+fi
+
+# A scoped package whose executable has a different name must be selected
+# explicitly; `npx @html-docs/html-video` cannot infer `html-docs-video`.
+exec npx -y --package @html-docs/html-video html-docs-video "${renderer_args[@]}"


### PR DESCRIPTION
## Summary

Adds the public `html-docs` skill bundle from [`raunaqbn/html-docs-skill`](https://github.com/raunaqbn/html-docs-skill/tree/main/html-docs). The skill creates source-grounded HTML documents, narrated videos, and courses, then publishes and reviews them through HTML Docs.

This is a source-only, docs-only contribution: `SKILL.md` and 13 Markdown references are included, while executable tooling, agent policy files, notices, and generated catalog artifacts are intentionally excluded.

## Provenance and safety

- Declares the exact upstream repository, community source type, author, MIT license, and license source.
- Uses `risk: critical` because the workflow can authenticate, mutate documents, upload assets, and publish externally.
- Defaults production to a private preview and requires explicit user instruction for public or unlisted publication.
- Keeps credentials local, treats anonymous edit tokens/URLs as credentials, excludes sensitive repository material, and preserves concurrent edits with ETags and `If-Match`.
- Uses the published `@html-docs/html-video` CLI directly in documentation examples; no executable files or local wrappers are included.

## Validation

- `npm run validate` — passed (2,029 skills; only the repository's existing advisories)
- `npm run validate:references` — passed
- `npm run security:docs` — passed
- Manual logic, provenance, risk, bundled-file, credential, network, mutation, and failure-mode review — completed
- `npm test` — all tests reached the final generated-catalog contract; the source-only tree reports the expected 2,029-vs-2,028 generated registry mismatch. Generated artifacts were restored and are not included, per the contributor contract; PR CI owns the generated preview.

## Maintainer review response

Exact head `c4f0396a17f43211b5283ba72e0baccaceb20525` addresses the protected-fork policy feedback by removing both executable shell files, `agents/openai.yaml`, and `references/NOTICE`. All remaining paths are regular-mode canonical skill or Markdown reference files. The removed wrapper invocations were replaced with direct published-package CLI commands, so the docs-only skill remains usable without importing executable tooling.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag.
- [x] **Triggers**: The "When to Use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` section.
- [x] **Security**: Not an offensive skill; critical operational risk is documented.
- [x] **Safety scan**: `npm run security:docs` passed.
- [ ] **Automated Skill Review**: Pending the GitHub Actions result for this PR.
- [x] **Manual Logic Review**: Logic, safety, failure modes, and `risk:` were manually reviewed.
- [x] **Local Test**: Contributor validation, reference validation, security scan, and the source bundle were verified locally.
- [x] **Repo Checks**: `npm run validate:references` passed.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Exact source, author, and license provenance are declared in frontmatter for canonical credit generation.
- [x] **License provenance**: `license: MIT` and `license_source:` are declared.
- [x] **Maintainer Edits**: Allow edits from maintainers is enabled.

## Agent assistance disclosure

Codex assisted with the mechanical bundle import, metadata adaptation, maintainer-requested docs-only reduction, validation, and PR preparation. The contributor reviewed the resulting source-only diff and its safety-critical guidance before submission.
