### PR TITLE
feat: add 2 review skills docs-only from amElnagdy/review-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-<!-- registry-sync: version=16.0.0; skills=2026; stars=45322; updated_at=2026-08-24T05:22:46+00:00 -->
+<!-- registry-sync: version=16.2.0; skills=2074; stars=45467; updated_at=2026-08-26T18:31:49+00:00 -->
 # AAS Core — Agentic Awesome Skills
 
 > **Local, agent-owned skill stacks for coding agents—from complete catalog access to a reproducible, reviewable plan.**
 
-**Current release: V16.0.0.** This release includes AAS Core for complete local catalog search, agent-owned selection, manifest validation, planning, and diagnosis. Apply and recovery remain experimental and outside the supported preview path.
+**Current release: V16.2.0.** This release includes AAS Core for complete local catalog search, agent-owned selection, manifest validation, planning, and diagnosis. Apply and recovery remain experimental and outside the supported preview path.
 
 Codex or Claude inspects your project and chooses exact skills from the complete local AAS catalog. AAS Core does not rank or recommend them: its read-only `compose_stack` tool validates the agent-owned selection in memory, and a client or the `aas` CLI can persist it as `aas-stack.json` and produce an immutable plan before any target change.
 
-**[Read the AAS Core preview guide →](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md)**
+**[Read the AAS Core preview guide →](https://github.com/sickn33/agentic-awesome-skills/blob/v16.2.0/docs/users/aas-core.md)**
 
 ```text
 Project
@@ -67,7 +67,7 @@ AAS Core gives the repository one product model:
 | Apply and recovery | Experimental, explicit opt-in, outside the supported safety claim |
 | Semantic suitability certification | Not provided |
 
-Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md) for the exact trust boundaries, current preview status, Codex/Claude setup model, and CLI lifecycle.
+Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.2.0/docs/users/aas-core.md) for the exact trust boundaries, current preview status, Codex/Claude setup model, and CLI lifecycle.
 
 ## Why This Repo
 
@@ -76,7 +76,7 @@ Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob
 - **Approval before writes**: the durable artifacts are an approved stack and immutable plan, not an opaque one-shot install.
 - **Installable, not just inspirational**: use the compatible legacy installer or plugin distributions when direct delivery is the right path.
 - **Built for major agent workflows**: Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, Kiro, OpenCode, Copilot, and more.
-- **Broad coverage with real utility**: 2,026+ skills across development, testing, security, infrastructure, product, and marketing.
+- **Broad coverage with real utility**: 2,074+ skills across development, testing, security, infrastructure, product, and marketing.
 - **Inspect before installing**: the hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) reviews agent-produced stack manifests and immutable plans without browser-side installation.
 - **Focused delivery remains available**: specialized plugins package proven sets for web, security, data, docs, DevOps, QA, OSS, or agent/MCP workflows.
 - **Useful whether you want breadth or curation**: install the full catalog, choose a specialized plugin, start with bundles, or compare alternatives before installing.
@@ -94,7 +94,7 @@ Direct file search can find candidate prose, but it leaves the result in the con
 - [Choose Your Tool](#choose-your-tool)
 - [Quick FAQ](#quick-faq)
 - [Bundles & Workflows](#bundles--workflows)
-- [Browse 2,026+ Skills](#browse-2026-skills)
+- [Browse 2,074+ Skills](#browse-2074-skills)
 - [Troubleshooting](#troubleshooting)
 - [Stable Skills Manifest v1](#stable-skills-manifest-v1)
 - [Support the Project](#support-the-project)
@@ -107,7 +107,7 @@ Direct file search can find candidate prose, but it leaves the result in the con
 
 ## Installation
 
-For Codex and Claude, start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md): configure the local MCP, ask the agent to inspect the project and choose exact IDs from the full catalog, review the proposed `aas-stack.json`, then run CLI validation and planning. The MCP and validation are read-only. Planning writes only the requested plan artifact; it does not materialize skill payloads or AAS managed state in the target.
+For Codex and Claude, start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.2.0/docs/users/aas-core.md): configure the local MCP, ask the agent to inspect the project and choose exact IDs from the full catalog, review the proposed `aas-stack.json`, then run CLI validation and planning. The MCP and validation are read-only. Planning writes only the requested plan artifact; it does not materialize skill payloads or AAS managed state in the target.
 
 Use direct installation when your host does not yet have a native AAS Core adapter, when you already know the exact skill IDs, or when you deliberately prefer manual selection:
 
@@ -261,7 +261,7 @@ The supported path covers complete local catalog search and inspection, agent-ow
 
 ### How do I install it?
 
-For AAS Core, follow the [preview guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md) and use only a package release whose notes explicitly state that it includes Core. Release 14.6.0 predates Core; Core-capable releases begin with the 15.x line.
+For AAS Core, follow the [preview guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.2.0/docs/users/aas-core.md) and use only a package release whose notes explicitly state that it includes Core. Release 14.6.0 predates Core; Core-capable releases begin with the 15.x line.
 
 For direct skill distribution, use a tool-specific flag such as `--codex`,
 `--cursor`, `--gemini`, or `--claude` to place skills in the directory your
@@ -339,7 +339,7 @@ Remove `--dry-run` only after reviewing the install, update, and removal plan. U
 
 The hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) imports and reviews AAS Core stack manifests and immutable plans in browser memory. It does not access the filesystem, generate an approved plan, or install skills.
 
-## Browse 2,026+ Skills
+## Browse 2,074+ Skills
 
 Use the root repo as a landing page, then jump into the deeper surface that matches your intent.
 
@@ -377,7 +377,7 @@ Use the root repo as a landing page, then jump into the deeper surface that matc
 Keep the root README short; use the dedicated docs for recovery and platform-specific guidance.
 
 - If you are confused after installation, start with the [Usage Guide](docs/users/usage.md).
-- For Core setup, trust boundaries, stack manifests, and preview status, use the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md).
+- For Core setup, trust boundaries, stack manifests, and preview status, use the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.2.0/docs/users/aas-core.md).
 - On native Windows, `AAS_ADAPTER_WINDOWS_ACL_FAILED` refers to the configuration path checked with PowerShell `Get-Acl`, not the cache and not `icacls`; do not approve until preview returns an approval digest.
 - If you integrate agentic-awesome-skills into a host, read the discovery contract first: [Stable Skills Manifest v1](docs/users/discovery-manifest.md).
 - For Windows truncation or context crash loops, use [docs/users/windows-truncation-recovery.md](docs/users/windows-truncation-recovery.md).
@@ -388,7 +388,7 @@ Keep the root README short; use the dedicated docs for recovery and platform-spe
 
 ## Stable Skills Manifest v1
 
-This is the stable **direct-host discovery manifest** for integrations that load individual `SKILL.md` files. It is not `aas-stack.json`, the verified AAS Core catalog, or the Core composition contract. Core users should start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.0.0/docs/users/aas-core.md); custom host integrations can continue using the manifest below.
+This is the stable **direct-host discovery manifest** for integrations that load individual `SKILL.md` files. It is not `aas-stack.json`, the verified AAS Core catalog, or the Core composition contract. Core users should start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/v16.2.0/docs/users/aas-core.md); custom host integrations can continue using the manifest below.
 
 Host integrations should use:
 
@@ -506,11 +506,14 @@ Key source families include:
 - **[OJPalenzuela/agents-generator](https://github.com/OJPalenzuela/agents-generator)**: Source for the `agents-generator` skill - project-specific `AGENTS.md` and companion rule generation with package-manager detection, monorepo handling, dry-run/update modes, backups, and validated commands (MIT).
 - **[agentbody/skills](https://github.com/agentbody/skills)**: Source for the `people-data` skill - LinkedIn and YouTube professional-profile and public business-contact research via the Agent Body MCP server (MIT).
 - **[sudosubin/gh-attach](https://github.com/sudosubin/gh-attach)**: Source for the `gh-attach` skill - GitHub CLI uploads and downloads of `user-attachments` (screenshots, PDFs, zips, videos), producing repo-scoped URLs for PRs, issues, and READMEs, with GitHub Enterprise Server support (MIT).
+- **[amElnagdy/review-skills](https://github.com/amElnagdy/review-skills)**: Source for the `debate-review` and `babysit-pr` skills - two-model debate review of PRs/MRs with inline comments and automated babysitting of review rounds for GitHub, GitLab and Azure DevOps (MIT, docs-only — runtime not bundled).
+- **[zhaoxuya520/reverse-skill](https://github.com/zhaoxuya520/reverse-skill)**: Source for 43 security skills covering reverse engineering, binary analysis, offensive assessment orchestration, and threat-intelligence workflows, adapted with English metadata and upstream safety gates (MIT).
 - **[abhinaykrupa/cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge)**: Source for the `cowork-to-code-bridge` skill - consent-bound execution on the user's own machine with pinned provenance, narrow scopes, and explicit local-agent limitations (MIT).
 - **[maleksaadi0109/hyprfedora](https://github.com/maleksaadi0109/hyprfedora)**: Source for the `fedora-hyprland-installer` skill - GPU-aware Fedora Hyprland installation, configuration, verification, repair, and removal workflows (MIT).
 - **[merc1305/findMate](https://github.com/merc1305/findMate)**: Source for the `find-complementary-founders` skill - private-first own-owner assessment, approved expiring profiles, and evidence-backed human founder matching (MIT).
 - **[provencher/codex-skills](https://github.com/provencher/codex-skills)**: Source for the `orchestrate` skill - focused Codex multi-agent delegation with non-overlapping ownership, coordinator integration, and user-held approval gates (MIT).
 - **[Phelan164/codex-howto](https://github.com/Phelan164/codex-howto)**: Source for the `maintain-codex-wiki` skill - review-first engineering knowledge with provenance, explicit capture and promotion, and deterministic structural checks (MIT).
+- **[kotobuki09/instructree](https://github.com/kotobuki09/instructree)**: Source for the `instructree` skill - local instruction-scope mapping, metadata and link validation, recursive Copilot import audits, and SARIF reports (MIT).
 - **[0xsarwagya/ontoly](https://github.com/0xsarwagya/ontoly)**: Source for the `ontoly-software-graph` skill - deterministic TypeScript software graphs, MCP-backed architecture review, request tracing, impact analysis, and dependency analysis (MIT).
 - [amElnagdy/guard-skills](https://github.com/amElnagdy/guard-skills) — Code Quality & Testing Guard Skills (by amElnagdy)
 
@@ -554,6 +557,7 @@ Key source families include:
 - **[JunsW/feature-track](https://github.com/JunsW/feature-track)**: Source for the `feature-tracking` skill - lightweight repository-native feature memory for current status, source-of-truth documents, decisions, risks, and cross-session handoff (MIT).
 - **[JularDepick/user-thoughts.SKILL](https://github.com/JularDepick/user-thoughts.SKILL)**: Source for the `user-thoughts` skill - persistent project idea repository workflows for capturing decisions, tech stack notes, UI/UX rationale, and MDBASE-backed project memory (MIT).
 - **[TheaDust/lore](https://github.com/TheaDust/lore)**: Source for the `lore` skill - Markdown-only, zero-dependency long-term project memory for AI coding agents, with monorepo scopes, two-section platform mirrors, and stdlib Python helpers (MIT).
+- **[rainmanjam/poka-yoke](https://github.com/rainmanjam/poka-yoke)**: Source for the `poka-yoke` skill - software mistake-proofing through control, warning, detection, and source-inspection guardrails (MIT).
 - **[ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills)**: Source for the `youtube-full` skill - TranscriptAPI-backed YouTube transcripts, search, channel browsing, playlists, and cloud-safe video research workflows (MIT).
 - **[ZeroPointRepo/zillow-skills](https://github.com/ZeroPointRepo/zillow-skills)**: Source for the `us-property-data` skill - U.S. property lookup, valuation, listing, tax, school, photo, and price-history guidance through the independent Zillapi API (MIT-0).
 - **[Antheurus/anywrite](https://github.com/Antheurus/anywrite)**: Source for the `anywrite` skill - low-context CLI access to Anytype's local API for objects, properties, files, search, chat, and other workspace operations (MIT).
@@ -672,7 +676,7 @@ Key source families include:
 - **[sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills)**: Apache-licensed collection of agent skills for AI coding assistants.
 - **[scarletkc/vexor](https://github.com/scarletkc/vexor)**: Semantic search engine for files and code, referenced in release history.
 - **[sstklen/infinite-gratitude](https://github.com/sstklen/infinite-gratitude)**: Multi-agent research skill from the AI Dojo series (MIT).
-- **[TerminallyLazy/Tree-Ring-Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory)**: Source for the `tree-ring-memory` skill — local-first memory lifecycle guidance for recall, evidence, audit, forgetting, consolidation, and privacy-safe agent memory operations (Apache-2.0).
+- **[TerminallyLazy/Tree-Ring-Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory)**: Source for the `tree-ring-memory` skill — local-first memory lifecycle guidance for recall, evidence, audit, forgetting, consolidation, and privacy-safe agent memory operations (MIT).
 - **[wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill)**: Linear issue/project/team management skill with MCP and GraphQL workflows (MIT).
 - **[wrsmith108/varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill)**: Secure environment-variable management skill for Claude Code (MIT).
 - **[xwmxcz/papers-skill](https://github.com/xwmxcz/papers-skill)**: Source for the `papers-skill` skill — academic research workflows over Semantic Scholar (200M+ papers) and arXiv, with citation lookup, arXiv PDF download, and PyMuPDF text extraction via a bundled Python CLI (MIT).

--- a/skills/babysit-pr/SKILL.md
+++ b/skills/babysit-pr/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: babysit-pr
+description: 'Babysit a pull request through its bot review rounds: verify, fix, reply,
+  resolve. Use for any babysit or watch-the-PR ask.'
+risk: safe
+category: code-quality
+source: https://github.com/amElnagdy/review-skills
+source_repo: amElnagdy/review-skills
+source_type: community
+date_added: '2026-08-26'
+license: MIT
+license_source: https://github.com/amElnagdy/review-skills/blob/master/LICENSE
+compatibility: Requires `gh` (GitHub) or `glab` (GitLab) authenticated, plus `jq`
+  and bash for the thread harvester.
+metadata:
+  version: 0.1.0
+---
+# Babysit a PR
+
+## When to Use
+
+- A PR/MR has accumulated bot review threads that need verification, fixes, replies, and resolution.
+- You want to drive a PR from 'just opened' to 'nothing left unanswered' across multiple review rounds.
+
+Goal: carry a pull request (GitHub) or merge request (GitLab) from "just opened" to "nothing left
+unanswered," without the human having to sit and refresh the page. "PR" below means either.
+
+Review bots are diff-anchored samplers. Every push mints a fresh round, and a fix in one place can
+light up commentary somewhere adjacent. Left alone, a PR accumulates half-answered threads that
+nobody resolves, and the real bug in round three gets buried under nitpicks from rounds one and two.
+Your job is to be the person who reads every finding, decides what is actually true, fixes what
+blocks, and closes every loop in writing.
+
+You know how to drive `gh` (GitHub), `glab` (GitLab), and git. What follows is only the judgment this
+loop needs and the few API calls that are easy to get wrong. The harvest script picks the forge from
+the cwd's git origin; everything it returns has the same shape on both, with a `capabilities` block
+naming what that forge cannot tell you.
+
+## The three rules that matter most
+
+Verify before you believe. A bot's severity badge is a guess made without running anything. Treat
+every finding, including the P1s, as a claim to check against the code. Bots are frequently right
+(that is why this loop is worth running), and they are also confidently wrong often enough that
+shipping their suggestions unexamined will introduce bugs. Read the actual code path before you
+agree or disagree.
+
+Every thread gets an answer. A finding you fixed, rejected, or deferred is only closed once you have
+said so in that thread and resolved it. Silence reads as "ignored" to the next human who opens the
+PR, and it is how a real bug gets lost.
+
+Publish before you answer. A "fixed" reply is only true once the remote branch carries the fix.
+Never post a confirmed reply, or resolve its thread, while the fix exists only locally. Rejections
+need no push. Reply with evidence and resolve immediately.
+
+## Harvest the round
+
+Findings arrive on two different surfaces, and a round that reads only one silently misses half of
+them. This is the single most common way a babysit loop goes wrong:
+
+- Inline review threads. This is where debate-review and Codex post their findings (Codex attaches
+  P1/P2-badged inline comments to an otherwise boilerplate review body; an empty-looking body proves
+  nothing). Each thread carries a `thread_id` (to resolve) and a `reply_to` (to reply inside the
+  thread). On GitHub these are GraphQL review threads; on GitLab they are discussions.
+- Top-level review bodies. This is where Greptile summarizes, Codex sometimes posts a numbered list,
+  and debate-review posts its round summary. These have no thread to resolve; answer them with one PR
+  comment per round. On GitHub they are review objects; on GitLab they are plain notes.
+
+The bundled script returns both in one call, already correlated (`<skill-dir>` is the folder that
+holds this SKILL.md):
+
+```bash
+"<skill-dir>/scripts/threads.sh" <N> > /tmp/pr-<N>-round-<k>.json
+```
+
+Never trust a filtered count without its unfiltered twin. Before applying any jq filter to the
+harvest, print the raw totals (`jq '{threads: (.threads|length), reviews: (.reviews|length)}'`) and
+compare. A filter that eliminates 100% of items is presumed broken until the field names are
+verified against the actual schema (`jq '.threads[0] | keys'`). jq selects on a misspelled field
+fail silently-empty, and a "clean round" built on one is how a P1 gets a merge-gate mention posted
+over it. That has happened. GitHub tooling fails by returning less data, not by erroring; pair this with the
+pagination rule.
+
+Never describe an object you did not fetch. If a query for a specific id returns empty, that is a
+stop signal. Say "I can't see it" and fetch it another way (`gh api .../reviews/<id>`), never narrate
+its presumed content. Related trap: every inline thread reply arrives wrapped in a zero-byte
+`COMMENTED` review object, so a watcher's "new review" event may be just a reply wrapper, not a new
+round. threads.sh's `.reviews` does not include these wrappers, so a review id from an event that is
+missing from the harvest means "wrapper", not "gone".
+
+Diff it against the previous round's file to see what is genuinely new. `outdated: true` on a thread
+means the line moved underneath it. The finding may already be fixed, so check it against current
+code before spending the round on it. A `comment_count` bump on a thread you already handled means a
+bot followed up inside it.
+
+Has this reviewer seen the current push? Only trust a field that names a sha. On GitHub each review
+carries `commit_id`; compare it to `head`. For debate-review on either forge, the round body's
+`debate_head` is the sha it reviewed. On GitLab other reviewers' notes carry no sha (`capabilities.
+review_commit_id: false`); a note's timestamp being later than your push does not prove it reviewed
+that push, so say "coverage unknown" rather than guessing.
+
+Two kinds of author count as a reviewer. First, a bot: `author_bot: true` in the harvest. On GitHub
+that comes from the API's own author type and is reliable (`chatgpt-codex-connector` and
+`greptile-apps` are the usual ones; don't hardcode a whitelist). On GitLab the API only sometimes
+says, so `author_bot` can be `null`; treat `null` as unknown, look at the thread, and say in your
+report that you could not confirm it. Second, any thread whose first comment carries a
+`<!-- debate-review:... -->` marker. debate-review posts from the user's own account, so the author
+is the PR author (`author_is_pr_author: true`), but the thread is a reviewer thread. The harvest
+flags these as `debate_review: true` with `debate_id`, `debate_status`, and `debate_severity` parsed
+from the marker; its round body shows up in `.reviews` with `debate_head` (the sha it reviewed) and
+`debate_agreed` / `debate_contested`. Treat them like any other bot thread. Anything else from the PR
+author, and any human's comment without that marker, is never in scope for autonomous fixing.
+Surface it to the user instead.
+
+Bots post 5 to 10 minutes after a push, longer on a big diff. Don't poll tightly; background the wait
+and review the diff yourself meanwhile. A round is "in" once every reviewer you expect has either
+posted against the current head SHA or been marked unavailable after its own wait budget. An
+unavailable reviewer never blocks harvesting or acting on the ones that did post. Disclose the gap
+instead of reporting the PR clean.
+
+## Classify by real impact, not by badge
+
+After verifying a finding, sort it by consequence rather than by the label the bot attached.
+
+Blocking, meaning it would ship a defect or stop the merge:
+- a real bug, wrong behavior, or broken edge case in the changed code
+- security, authorization, data-integrity, or data-loss exposure
+- a violation of the change's own stated contract, acceptance criteria, or spec
+- a migration or schema hazard
+- a failing or newly-flaky check
+
+Non-blocking, meaning real but ships nothing broken: naming, structure, docs, test nitpicks, micro
+performance, "consider extracting this", style preference.
+
+When a finding is genuinely ambiguous, hold it as blocking until you have read enough code to demote
+it. The asymmetry is deliberate. An over-cautious fix costs minutes, a missed P1 costs a production
+bug.
+
+A debate-review thread with `debate_status: contested` means two models looked and disagreed. The
+main reviewer held the finding against a refutation, and the italic last line of the comment says
+what the challenge was. That is a claim with a known counter-argument, not a weaker claim. Verify it
+the same way, and say in your reply which side the code supports and why.
+
+## Fix the blockers, autonomously
+
+Don't stop to ask about blockers. Verify, fix, push, keep watching, report what you did.
+
+- Reproduce first where you can. A probe that fails before the fix and passes after is what separates
+  a real fix from a plausible edit. This matters most on findings you initially disagreed with. Those
+  are the ones where being wrong is expensive.
+- One push per round, not one per finding. Every push mints a new bot round, so per-finding pushes
+  multiply the rounds you have to sit through.
+- Run the repo's own gate before pushing. A fix that breaks the suite costs a whole extra round.
+- If a matching guard skill is installed (clean-code-guard, test-guard, wp-guard, woo-guard from
+  guard-skills), run it on your fix before pushing. The guards catch the failure modes a quick fix
+  under review pressure tends to produce.
+- When you disagree, prove it. Rejecting a finding is legitimate and common, but the reply has to
+  carry the evidence: the code path, the guard that already handles it, or the test that pins the
+  behavior. "This is fine" is not a rejection.
+
+## Publish, then reply, then resolve
+
+Work the round in one pass, not per finding: verify everything, reproduce confirmed blockers where
+practical, fix them all, run the gate, then commit and push once and confirm the remote SHA. Only
+then close the loops:
+
+- Confirmed: reply naming the fix commit, then resolve.
+- Rejected: reply with concrete evidence, then resolve. No push needed; these can close anytime.
+- Deferred: create the agreed issue, reply with its link, then resolve.
+
+Non-blocker fixes the user approves ride the next consolidated push, never a dedicated push of their
+own. There is no re-review-exempt push: every push, including a final docs-only or nit-only one, must
+be covered by a clean round from the merge-gate reviewer before merge (see "Before merge"). If
+publication or verification fails, leave the thread open and report the blocker.
+
+Answer inside the thread the finding came from. A fresh top-level comment leaves the original thread
+open and forces the reader to correlate by hand. Use the harvest's `reply_to` to reply and `thread_id`
+to resolve. On GitHub those are two different identifiers (REST comment id, GraphQL thread id); on
+GitLab both are the discussion id.
+
+GitHub:
+
+```bash
+gh api --method POST "repos/<owner>/<repo>/pulls/<N>/comments/<reply_to>/replies" \
+  -f body="$(cat /tmp/reply.md)"
+
+gh api graphql -f query='mutation($t:ID!){
+  resolveReviewThread(input:{threadId:$t}){ thread{ isResolved } } }' -F t="<thread_id>"
+```
+
+GitLab (`<project>` is the URL-encoded `group/path`, `--hostname` your instance):
+
+```bash
+glab api --hostname <host> --method POST "projects/<project>/merge_requests/<N>/discussions/<reply_to>/notes" \
+  --raw-field "body=$(cat /tmp/reply.md)"
+
+glab api --hostname <host> --method PUT "projects/<project>/merge_requests/<N>/discussions/<thread_id>" \
+  -F resolved=true
+```
+
+The GitLab reply and resolve calls are taken from the GitLab API docs and have not yet been exercised
+against a live instance from this skill. The first time you use them, check the response, and if
+either fails, stop and report rather than retrying variations.
+
+Attribution. Open every reply by naming the model writing it and the person it writes for, so a
+reader never has to guess whether a human weighed in. Sign your own model name; this skill is
+model-neutral. The person is whoever owns the account the reply posts from. Get the name once per
+session, `gh api user -q '.name // .login'` on GitHub or `glab api user --hostname <host> | jq -r
+'.name // .username'` on GitLab, and reuse it:
+
+> I am \<model-slug\> writing on behalf of \<user\>.
+
+Then the verdict, then the evidence, briefly:
+
+```
+I am <model-slug> writing on behalf of <user>.
+
+Confirmed and fixed in `a1b2c3d`. You were right that `occurrence_time` was never
+compared against `evidence.event_time`, so a mapping could bind proof from a
+different occurrence. Reproduced with a failing test first
+(`test_binds_proof_to_mapped_occurrence`), then fixed the composition check.
+```
+
+```
+I am <model-slug> writing on behalf of <user>.
+
+Declining this one. The nil case you describe is already unreachable. `resolve()`
+returns early at `handlers.py:88` whenever the session is unset, which is the only
+path that reaches this line. Leaving the behavior as-is.
+```
+
+Resolve only what is actually closed: fixed and pushed, rejected with evidence, or deferred with an
+issue filed. Never resolve a thread whose question you have not answered. Resolution claims the loop
+is closed, and a false claim is worse than an open thread.
+
+## Non-blockers: one batched ask per round
+
+Don't interrupt per finding, and don't silently decide. Once per round, after the blockers are
+handled, bring the non-blocking findings as one list with a recommendation each (fix now, open an
+issue, or reject) and let the user choose:
+
+> Round 2 on PR #123. 1 blocker fixed and pushed (`a1b2c3d`). Three non-blocking findings left:
+> 1. debate-review: extract the duplicated fixture in `test_foo.py`. Recommend issue, touches
+>    files outside this change
+> 2. Codex: `Counter` comparison could use `==` directly. Recommend fix now, one line
+> 3. Greptile: docstring missing on the new helper. Recommend fix now, trivial
+> Fix 2 and 3 in the next push, issue for 1?
+
+Whatever they decide, close each thread the same way as any other finding. Anything deferred gets a
+real issue with enough context to act on months later: a link back to the thread, the file, and why
+it was deferred. Not just a title.
+
+## Re-trigger within a fixed budget
+
+One invocation gets the initial harvest plus at most two consolidated repair pushes and two
+re-review cycles unless the user explicitly asks to continue. After each push you start the next
+round yourself. How depends on the reviewer, because they are triggered in three different ways:
+
+- debate-review is a local script, not a bot, and it works on both forges. You run it, it does the
+  whole review while you wait, and it exits once the review is posted. Nothing to mention, nothing
+  to poll:
+
+  ```bash
+  node "<debate-review skill-dir>/scripts/review-pr.mjs" <pr-url>
+  ```
+
+  (`<debate-review skill-dir>` is wherever that skill is installed, `~/.agents/skills/debate-review`
+  on a standard install.) Run it in the background, keep working, and harvest the moment the command
+  exits. It prints the review URL; exit code 3 means this head was already reviewed. It reviews
+  exactly one head sha per run, so a run after a push always produces a fresh round. A run takes
+  10 to 20 minutes.
+- Codex is a GitHub app (there is no GitLab equivalent). Mention `@codex review` in a PR comment,
+  then wait. It answers 8 to 15 minutes later, against whatever head was current when it ran. Check
+  `commit_id` on its review before believing it covers your push.
+- Greptile and similar bots re-review every push on their own. Don't summon them; handle their
+  findings when they show up.
+
+For a bot you are waiting on, wait at most 10 minutes past its usual window. If it is silent or
+rate-limited, mark that reviewer unavailable; do not wait out a cooldown. The one exception is the
+merge-gate reviewer at the merge gate, which has no timeout (see "Before merge"). Even a final
+test-only, documentation-only, or nit-only push gets a round. The merge gate below is meaningless if
+the last push went unreviewed.
+
+Run the repository's required gate once per consolidated repair push; never rerun an already-passing
+gate for the same SHA. If the user says "stop", "enough", or "push whatever you have", cancel active
+polls and long gates, run the smallest relevant check that can finish promptly, publish the safe
+work, disclose any incomplete gate, and do not trigger another review round.
+
+Rounds should shrink. If round three is as large as round one, something systematic is wrong. Say
+so rather than grinding. Findings that recur in the same shape usually mean the fix addressed a
+symptom instead of the cause, which is worth surfacing.
+
+At the budget boundary, stop and hand off the exact remaining findings, unresolved threads, last
+reviewed SHA, and unavailable reviewers. Never describe an unreviewed head as clean.
+
+## Before merge
+
+The merge gate is an explicit clean round from the repo's primary reviewer on the exact merge
+candidate, the final head sha. Which reviewer that is depends on the repo.
+
+Where Codex is installed, mention `@codex review` after the final push and wait for its reply. A
+clean round is Codex saying so in plain words ("no findings", "good job") against the final head. No
+reply yet is not a pass. Codex answers 8 to 15 minutes after a push, and merging inside that window
+is how a real finding lands minutes after the merge.
+
+Where debate-review is the reviewer (on GitLab it is usually the only one), run it on the final head.
+A clean round is all three of: its round body present in `.reviews` with `debate_head` equal to the
+final head sha, `debate_agreed` and `debate_contested` both zero, and no unresolved reviewer threads.
+If the body is missing (a run can fail after posting inline comments), the gate has not been met;
+re-run it, don't infer.
+
+Either way, a finding is a new round, not a merge. Silence well past the usual window is something
+to report to the user, not approval.
+
+Re-harvest and re-read the PR's most recent comments before proposing a merge. A watcher settled
+into a quiet interval can miss a late round, and a comment posted after your last check is exactly
+the one that gets merged over.
+
+Then ask the user whether to merge. Never merge on your own initiative. Report: rounds run,
+blockers fixed with their SHAs, findings rejected and why, issues filed, unresolved threads
+remaining (ideally zero), and CI state. The merge decision is theirs; everything leading to it was
+yours.
+
+## When to stop and speak up
+
+Some situations are not yours to grind through:
+
+- A bot finding that is right but demands a change well beyond this PR's scope.
+- Two bots contradicting each other on the same line, when code, tests, and the stated contract
+  cannot settle it.
+- The same finding recurring after a retry. The first recurrence gets a re-verified root cause and
+  one more attempt inside the repair budget; a second means your model of the bug is wrong.
+- A human reviewer's comment, always.
+- CI failing for infrastructure reasons rather than code.
+- The two-repair-cycle budget is exhausted.
+- The user asks to stop, push the current work, or end the babysit loop.
+
+
+## Limitations
+
+- Requires authenticated `gh`/`glab`, `jq` and bash; harvests threads and reviews.
+- Docs-only import — executable helper (`scripts/threads.sh`) not included; see upstream for full runtime. Fixes are to PR branch only, never merges.
+
+> Adapted from [amElnagdy/review-skills](https://github.com/amElnagdy/review-skills) (MIT) — docs-only, runtime not bundled.

--- a/skills/debate-review/SKILL.md
+++ b/skills/debate-review/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: debate-review
+description: Two-model debate review of a GitHub PR, GitLab MR, Azure DevOps PR, or
+  local working tree, posted as inline comments or printed. Use for any PR/MR review
+  request, or a local review before a PR exists.
+risk: safe
+category: code-quality
+source: https://github.com/amElnagdy/review-skills
+source_repo: amElnagdy/review-skills
+source_type: community
+date_added: '2026-08-26'
+license: MIT
+license_source: https://github.com/amElnagdy/review-skills/blob/master/LICENSE
+compatibility: Requires Node 18+, Git 2.31+ for Azure DevOps, `gh` (GitHub), `glab`
+  (GitLab) or `az` (Azure DevOps) authenticated, and delegate-skills installed for
+  the main/debate lanes.
+metadata:
+  version: 0.2.0
+---
+# debate-review
+
+## When to Use
+
+- You have a GitHub PR or GitLab MR that needs a thorough pre-merge review.
+- You want a two-model debate (main reviewer vs. debate reviewer) to catch blind spots before posting inline comments.
+
+Two models argue before anything is posted. A main reviewer finds issues. A debate reviewer tries to
+knock them down and may add its own. The main reviewer then makes the final call, and one review with
+inline comments lands on the PR or MR. It posts from the user's own `gh`, `glab` or `az` account as a
+non-approval review or comment. It never approves and never requests changes.
+
+You are the orchestrator. You run one command and relay the result. You do not review the diff
+yourself, and you do not touch the PR.
+
+## Run it
+
+```bash
+node "<skill-dir>/scripts/review-pr.mjs" --local [--base <ref>]
+node "<skill-dir>/scripts/review-pr.mjs" <pr-url | number> [--dry-run]
+```
+
+- If the user wants a review and there is no PR/MR URL, run `--local` from the repo (or `--repo-dir`). Do not invent a URL. Relay stdout. `--local` never talks to a forge and rejects non-UTF-8 Git paths rather than decoding them lossily.
+- `<pr-url>` is a GitHub `/pull/N`, GitLab `/-/merge_requests/N`, or Azure DevOps
+  `/_git/<repo>/pullrequest/N` URL (`dev.azure.com` or the legacy `*.visualstudio.com`). A bare number
+  resolves against the cwd's `origin`, including Azure DevOps https and `ssh.dev.azure.com:v3/` remotes.
+- `--dry-run` prints a live PR review instead of posting it. It does not combine with `--local`.
+- Azure DevOps needs `az` logged in (`az login`) with access to the project. No extension is required,
+  the script talks to the REST API through `az rest`. A review there is N inline comment threads plus
+  one closed summary thread, since Azure DevOps has no single review object; the alert blockquotes
+  render as plain quotes, which still read.
+- The reviewers are two delegate-skills lanes, `review-main` and `review-debate`. If either is missing
+  the script says so. Add them with `delegate-setup`. Pick two different implementers, since the debate
+  is only worth something when the second model doesn't share the first one's blind spots (main
+  `claude` or `grok`, debate `codex` at high effort is a good pair). For a one-off, pass
+  `--main <implementer>` or `--debate <implementer>`. Only implementers whose relay has `--read-only`
+  are accepted. These two lanes belong to the reviewer. Don't point them at a lane you use for other
+  work, such as a plan-debate lane.
+- Exit code `3` means this head sha already has a debate-review. Re-run with `--force` to post again.
+- A run takes minutes, since it is two or three implementer sessions back to back. Run it in the
+  background and report the printed URL when it finishes. Don't poll tightly.
+
+All flags: `--help`. Contracts: [references/schema.md](references/schema.md). What gets posted:
+[references/comment-format.md](references/comment-format.md). The reviewer briefs live in `assets/prompts/`
+and the script fills them in; you don't need to read them.
+
+## After it posts
+
+Each posted comment carries a `<!-- debate-review:<id> status=... -->` marker. `babysit-pr` handles
+GitHub and GitLab rounds (verify, fix blockers, reply, resolve). It cannot harvest Azure DevOps yet,
+so relay Azure findings directly to the user. Don't act on the findings yourself unless asked.
+
+## Artifacts
+
+`~/.cache/debate-review/<owner>__<repo>/<N>/<head>/` holds `run.json` (all three documents, timings,
+what was posted) plus `main/`, `debate/`, and `final/`, each with the brief sent and the relay's
+`result.json`.
+`--local` writes under `~/.cache/debate-review/local/<repo>/<branch>/<head>/` instead.
+
+
+## Limitations
+
+- Requires `delegate-skills` with `review-main` and `review-debate` lanes and authenticated `gh`/`glab`.
+- Docs-only import — executable helpers (`scripts/`) not included; see upstream for full runtime. Posts a single `COMMENT` review only.
+
+> Adapted from [amElnagdy/review-skills](https://github.com/amElnagdy/review-skills) (MIT) — docs-only, runtime not bundled.

--- a/skills/debate-review/assets/prompts/review-debate.md
+++ b/skills/debate-review/assets/prompts/review-debate.md
@@ -1,0 +1,51 @@
+You are the debate reviewer. A prior review pass produced the findings below. Judge them on the code,
+not on who wrote them. Treat every claim as unattributed. Your job is to break confidence in those
+findings and in the change itself, not to validate either. You review; you never edit. Return exactly
+one fenced ```json block matching `debate-review.debate.v1` and nothing after it.
+
+## Input
+- Repository checked out at the PR head. Base: `{{BASE}}`. Head: `{{HEAD}}`.
+- Diff: `git diff {{BASE}}...{{HEAD}}`.
+- Findings under review:
+{{FINDINGS_JSON}}
+
+## Stance
+Default to skepticism in both directions. The three verdicts are not symmetric. `refute` has the
+highest bar.
+
+- `refute` only when the refutation is constructible from the code. The claim is factually wrong
+  (quote the actual line). It is provably impossible (show the type, constant, or invariant). It is
+  already guarded in this diff (cite the guard). Or it has no observable effect.
+- `downgrade` when the defect is real but severity or confidence is overstated. That includes realistic
+  but unverified state (a race, nil on a rare but reachable path, a cold cache, an absent optional
+  field) when the finding was written as always-on or blocking.
+- `confirm` when you traced the path yourself and it holds. Realistic runtime state you cannot disprove
+  from the code is not grounds to refute.
+
+Do not refute a finding for being speculative or "dependent on runtime state" when that state is
+realistic. Re-read the code. Do not treat the finding's quoted evidence as proof that the line says
+what it claims.
+
+Then attack the change where the first pass did not look. `new_findings` is a gap sweep, not a second
+review. Add one only when it is `blocking`, you can name the trigger and the wrong result, and it is
+one of: auth or trust boundaries, data loss or duplication, idempotency or partial failure, races and
+ordering, schema drift or migrations. Do not relabel a non-blocking issue as blocking to get it
+through. Zero new findings is the expected outcome on most PRs. Do not pad.
+
+## Bar
+- Every verdict and every new finding carries evidence: `file:line` or quoted code. Where a grep or a
+  test settles it, run it and quote the command and output. A refutation without evidence is a
+  downgrade.
+- Do not invent files, lines, or runtime behaviour. If a conclusion rests on an inference, say so and
+  keep the confidence honest.
+- Material only. No style, naming, or cleanup.
+- New finding ids are `D1`, `D2`, and so on. Same shape as the findings under review.
+
+## Before you emit
+Check each verdict and each new finding. Is it adversarial rather than stylistic? Tied to a location
+you actually read? Plausible under a failure scenario you can state? Actionable? Drop anything that
+fails one. Every `F*` id still needs exactly one verdict. A verdict on an `F*` does not suppress a `D*`
+at the same location for a different failure. Record both.
+
+## Schema
+{{SCHEMA_DEBATE}}

--- a/skills/debate-review/assets/prompts/review-main.md
+++ b/skills/debate-review/assets/prompts/review-main.md
@@ -1,0 +1,64 @@
+You are the main reviewer of a pull request. You review; you never edit. Return exactly one fenced
+```json block matching `debate-review.findings.v1` (schema below) and nothing after it.
+
+## Input
+- Repository checked out at the PR head. Base ref: `{{BASE}}`. Head: `{{HEAD}}`.
+- Diff to review: `git diff {{BASE}}...{{HEAD}}`. Commits: `git log {{BASE}}..{{HEAD}} --oneline`.
+- PR title and body: {{PR_TITLE}}. {{PR_BODY}}
+- Spec source (issue or PRD), if any: {{SPEC}}
+- Standards sources found in the repo (CONTRIBUTING, CODING_STANDARDS, CLAUDE.md, AGENTS.md): {{STANDARDS}}
+
+## Review on these axes
+1. Correctness and security. Bugs, broken edge cases, auth, data, and idempotency hazards in the
+   changed code. Run three passes in order, and don't let one pass suppress another:
+   - Every hunk line by line, then its enclosing function. A defect on an unchanged line of a function
+     this PR touches is in scope. For each line ask what input, state, timing, or config makes it wrong.
+   - Every deleted or replaced line. Name the invariant it enforced, then find where the new code
+     re-establishes it. If you cannot find it, that is a finding.
+   - Every changed signature or contract. Grep the callers. Check each for a new precondition, a changed
+     return shape, a new exception, or an ordering dependency.
+2. Spec. Requirements asked for but missing or partial. Behaviour nobody asked for. Implemented but
+   wrong. Quote the spec line. If there is no spec, skip the axis and say so in `summary`.
+3. Standards. Violations of the repo's documented rules. Quote the exact rule text and the exact line
+   that breaks it. No "spirit of the doc". Do not invent a finding because a standards file exists.
+   Skip anything tooling enforces.
+4. Tests and docs, only when the diff touches them. Tests that don't pin behaviour. Docs that drift
+   from code.
+
+## Bar
+You are reviewing for precision. The passes above find candidates. Only candidates that clear this
+bar become findings.
+
+- Report a finding only if all of these hold:
+  1. It materially affects one of the axes above.
+  2. It is one discrete, actionable defect at one location.
+  3. Fixing it does not demand more rigour than the rest of this codebase already shows.
+  4. This diff introduced it, or it sits on an unchanged line of a function this PR touches, or it is
+     an unchanged caller broken by a contract this PR changed. Other pre-existing defects are out of
+     scope even when real.
+  5. If you claim it breaks code elsewhere, you identified that code and can cite it. "May affect" is
+     not a finding.
+  6. It does not rest on an unstated assumption about intent. A behaviour change stated in the PR body
+     is not a bug.
+- Never report what CI already catches (type errors, lint, formatting, missing imports, failing tests).
+  Never report naming, style, or "consider extracting".
+- `evidence` names the trigger (input, state, timing, or config) and the wrong result (output, crash,
+  or violated invariant). Where a grep or a test settles it, run it and quote the command and output.
+  If you cannot name the trigger, you do not have a finding.
+- `confidence`. Findings below the pipeline's `min_confidence` (default 0.5) are dropped before debate.
+  - `0.9` to `1.0`: you traced the trigger through to the wrong result.
+  - `0.7` to `0.9`: mechanism quoted, trigger realistic but unverified (concurrency, cold cache, absent
+    optional field, timeout).
+  - `0.5` to `0.7`: plausible, but a guard elsewhere was not ruled out. Say which guard you looked for.
+  - below `0.5`: do not emit it.
+- Anchor `line_start` and `line_end` to the new side of the diff. Pick the one to three lines that show
+  the defect, never more than ten. If the defect is outside the diff, anchor the nearest changed line
+  and say so in `evidence`.
+- `claim`, `evidence`, and `recommendation` are posted as an inline comment on a colleague's PR. One
+  short paragraph each. At most three lines of quoted code. Matter-of-fact, plain punctuation (no em
+  dashes). No flattery. No severity inflation. Say which inputs the bug depends on.
+- Do not stop at the first qualifying finding, and do not pad. Zero findings with `verdict: approve`
+  is the correct answer for a clean diff. Under 15 findings. `summary` under 300 words.
+
+## Schema
+{{SCHEMA_FINDINGS}}

--- a/skills/debate-review/assets/prompts/review-rebuttal.md
+++ b/skills/debate-review/assets/prompts/review-rebuttal.md
@@ -1,0 +1,42 @@
+You are the main reviewer again, making the final call. Two positions about this pull request are
+below. Treat both as unattributed arguments about the code. Not yours, not a peer's verdict. Decide
+each one from the repository. You review; you never edit. Return exactly one fenced ```json block
+matching `debate-review.final.v1` and nothing after it.
+
+## Input
+- Repository checked out at the PR head. Base: `{{BASE}}`. Head: `{{HEAD}}`.
+- Position A, the original findings (`F*`):
+{{FINDINGS_JSON}}
+- Position B, verdicts on each `F*` plus any additional findings (`D*`):
+{{DEBATE_JSON}}
+
+## Rules
+- Re-read the code for every `refute` and `downgrade` before deciding.
+  - `withdrawn` requires a positive reason of your own. Name the line, guard, type, invariant, or spec
+    clause that makes the original claim wrong, and put it in `debate_note`. "Position B disagreed" is
+    not a reason. Neither is the absence of a counter-argument.
+  - If the challenge is wrong and you can show why, use `contested`, with the why in `debate_note`.
+  - Accept a valid `downgrade` by changing `severity` and marking `agreed`.
+  - If every challenge really does collapse, withdraw them all. Do not keep a finding in order to
+    have kept one.
+- For each `D*`, apply the same bar as any finding. This diff introduced it (or it sits on an unchanged
+  line of a function this PR touches, or an unchanged caller broken by a changed contract). It is
+  discrete. `evidence` names a trigger and a wrong result. CI would not already catch it.
+  - Holds: `agreed`.
+  - Does not hold: `withdrawn`, with your evidence in `debate_note`. A rejected `D*` is never posted.
+    `contested` is reserved for `F*` findings you hold against a refutation.
+  - Restates an `F*` at the same location for the same failure: `withdrawn` with `debate_note`
+    "duplicate of F<n>". Keep the `F*`.
+- Carry every finding through with its final `status`. Drop nothing silently.
+- `claim`, `evidence`, `recommendation`, `debate_note`, and `summary` are posted on the PR for a
+  reader who never saw this exchange. Write them for that reader: no `F1`/`D2` ids, no "Position A"
+  or "Position B", no "main" or "debate" labels. Say "the second pass" or "the challenge" if you must
+  refer to it. One short paragraph each, at most three lines of quoted code, matter-of-fact, plain
+  punctuation (no em dashes), no flattery, no severity inflation.
+- `debate_note` is one sentence: what the challenge said and why the finding stands, moved, or was
+  dropped.
+- `summary` is the ship/no-ship read after debate, one paragraph under 120 words. Name what is still
+  blocking. Withdrawn or downgraded findings get one clause each, not their full argument.
+
+## Schema
+{{SCHEMA_FINAL}}

--- a/skills/debate-review/references/comment-format.md
+++ b/skills/debate-review/references/comment-format.md
@@ -1,0 +1,63 @@
+# What gets posted
+
+One review run per head sha. GitHub uses a `COMMENT` review; GitLab and Azure DevOps use comment
+threads plus a summary. None can approve or request changes on the author's behalf. Inline comments
+anchor to `line_start` through `line_end` on the new side of the diff.
+
+## Levels
+
+Severity is shown on the PR as a level, computed by the script from the contract's fields:
+
+| Level | Meaning | Alert |
+| --- | --- | --- |
+| P0 | blocking on the security axis | `[!CAUTION]` (red) |
+| P1 | any other blocking finding | `[!WARNING]` (yellow) |
+| P2 | non-blocking | `[!NOTE]` (blue) |
+
+GitHub and GitLab (17.10+) render those alert blockquotes with colour; anything else, Azure DevOps
+included, shows a plain quote, which still reads.
+
+## Review body
+
+```
+<!-- debate-review head=<sha> main=<implementer> debate=<implementer> agreed=<n> contested=<m> p0=<a> p1=<b> p2=<c> -->
+| Level | Count |
+| --- | ---: |
+| P0 | <a> |
+| P1 | <b> |
+| P2 | <c> |
+| contested | <m> |
+
+**debate-review** on `<sha7>`, main `<implementer>`, second `<implementer>`.
+
+<final.summary>
+```
+
+## Inline comment
+
+```
+<!-- debate-review:<id> status=<agreed|contested> severity=<blocking|non-blocking> level=<P0|P1|P2> -->
+> [!CAUTION | WARNING | NOTE]
+> **<level>, agreed by both reviewers.** <claim>
+
+<evidence>
+
+Suggested: <recommendation>
+
+_<debate_note>_
+```
+
+Azure DevOps prepends `<!-- debate-review finding=<content-hash> head=<sha> [attempt=<id>] -->` to
+identify threads that landed before a posting failure. A retry without `--force` resumes the exact
+saved payload from `run.json` before checkout; inline and summary threads are reused, and forced runs
+use the attempt id to avoid matching an older completed review. `--force` always starts a fresh review.
+
+A contested finding's first line reads `**<level>, contested. The second reviewer disagreed; the
+main reviewer holds it, reasons below.** <claim>`.
+
+## Why the HTML markers
+
+- `babysit-pr` finds these threads by the `<!-- debate-review` marker, not by a `[bot]` author. The
+  review is posted from the user's own account, so there is no bot author to match on.
+- `head=<sha>` lets a re-run detect that this push already has a review and skip it (or `--force`).
+- Replies inside a thread keep babysit-pr's attribution line: `I am <model-slug> writing on behalf of <user>.`

--- a/skills/debate-review/references/schema.md
+++ b/skills/debate-review/references/schema.md
@@ -1,0 +1,95 @@
+# debate-review JSON contracts
+
+Three documents flow through one run. Each implementer returns its document as the only fenced
+```json block in its final message. The script extracts it and checks it against the contract below.
+Anything that fails the check stops the run. Nothing gets posted.
+
+The script reads sections 1, 2, and 3 below by heading order and pastes them into the briefs. Don't
+reorder them or add a `##` heading above section 3.
+
+## 1. `debate-review.findings.v1`, main reviewer to script
+
+```json
+{
+  "schema": "debate-review.findings.v1",
+  "head": "<head sha reviewed>",
+  "verdict": "approve | needs-attention",
+  "summary": "one-paragraph ship/no-ship read",
+  "findings": [
+    {
+      "id": "F1",
+      "file": "src/foo.py",
+      "line_start": 42,
+      "line_end": 48,
+      "severity": "blocking | non-blocking",
+      "axis": "correctness | security | spec | standards | tests | docs",
+      "claim": "what is wrong, one sentence",
+      "evidence": "why: the code path, the quoted line, the spec line",
+      "recommendation": "concrete change",
+      "confidence": 0.0
+    }
+  ]
+}
+```
+
+- `id` is `F<n>` for the main reviewer and `D<n>` for findings the debate reviewer adds.
+- `line_start` and `line_end` must be lines on the new side of the PR diff, because GitHub and GitLab
+  can only anchor comments there. If the problem is outside the diff, anchor the nearest changed line
+  and say so in `evidence`.
+- `severity` follows babysit-pr. Blocking means it ships a defect, a security or data exposure, a spec
+  violation, a migration hazard, or a failing check. Everything else is non-blocking.
+- `confidence` is 0 to 1. Findings under `min_confidence` (default 0.5) are dropped before debate.
+
+## 2. `debate-review.debate.v1`, debate reviewer to script
+
+```json
+{
+  "schema": "debate-review.debate.v1",
+  "head": "<same sha>",
+  "verdicts": [
+    { "id": "F1", "verdict": "confirm | refute | downgrade", "reason": "one sentence", "evidence": "file:line or quoted code" }
+  ],
+  "new_findings": [ /* same shape as findings[], ids D1, D2, ... */ ]
+}
+```
+
+- Every `F*` id gets exactly one verdict. A missing id counts as `confirm` with reason "no objection".
+- `downgrade` means the defect is real but severity or confidence was overstated.
+- `refute` must carry evidence. A bare "I disagree" is recorded but weighted as `downgrade`.
+- `new_findings` is a gap sweep, not a second review. Blocking only, with a named trigger. Entries
+  below `min_confidence` are dropped the same way the main findings are. Zero new findings is the
+  expected outcome on most PRs.
+
+## 3. `debate-review.final.v1`, main reviewer (rebuttal pass) to script, then to the PR
+
+```json
+{
+  "schema": "debate-review.final.v1",
+  "head": "<same sha>",
+  "summary": "final ship/no-ship read after debate",
+  "findings": [
+    {
+      "id": "F1",
+      "status": "agreed | contested | withdrawn",
+      "severity": "blocking | non-blocking",
+      "file": "...", "line_start": 0, "line_end": 0,
+      "claim": "...", "evidence": "...", "recommendation": "...",
+      "debate_note": "one line: what the challenge said and why the finding was kept, dropped, or changed"
+    }
+  ]
+}
+```
+
+- `agreed`: both models stand behind it. Posted.
+- `contested`: the debate reviewer refuted it and the main reviewer holds, with evidence. Posted with a
+  `contested` tag, or dropped with `--contested drop`.
+- `withdrawn`: the main reviewer accepts the refutation. Never posted, kept in the run log.
+- `D*` findings can only end as `agreed` or `withdrawn`. A `D*` the main reviewer rejects with evidence
+  is `withdrawn` with the objection in `debate_note`. It is never `contested`, so a rejected claim from
+  the second model is never posted. A `D*` that duplicates an `F*` is `withdrawn` with `debate_note`
+  "duplicate of F<n>".
+
+## Run log
+
+`<out-dir>/run.json` keeps all three documents plus timings, implementers, lanes, and the posted
+comment ids, keyed by `owner/repo#N@head`. Re-running on the same head does nothing unless `--force`.


### PR DESCRIPTION
## Summary

Docs-only re-proposal of #1250 after maintainer fork-gate feedback. Closes https://github.com/FrancoStino/opencode-skills-collection/issues/115.

Adds 2 skills from [amElnagdy/review-skills](https://github.com/amElnagdy/review-skills) (MIT, 45 stars → 0.2.0) as **docs-only** (no `scripts/` executables) so the import is `approval-safe` from a fork.

**Skills:**
- `debate-review` — Two-model debate review for GitHub/GitLab/Azure DevOps PRs/MRs + local working tree, posted as inline comments. Requires `delegate-skills` lanes `review-main`/`review-debate`.
- `babysit-pr` — Babysits a PR/MR through bot review rounds: harvests threads, verifies, fixes blockers, replies, resolves.

**What changed vs #1250:** Removed `skills/debate-review/scripts/**` (7× `*.mjs`) and `skills/babysit-pr/scripts/threads.sh` (1× `*.sh`). Kept `SKILL.md` + `assets/prompts/` + `references/` only. Added `> **Docs-only:** executable `scripts/` not included — see https://github.com/amElnagdy/review-skills for full runtime.` note and `## Limitations` docs-only provenance.

### Quality Bar Checklist

- [x] Standards read
- [x] Metadata valid (`risk: safe`, `category: code-quality`, `source`/`source_repo`/`source_type`/`date_added`/`license`/`license_source` + `compatibility`/`metadata`)
- [x] Risk labels correct
- [x] Triggers clear (`## When to Use` added)
- [x] Limitations documented (docs-only provenance)
- [x] Security review: `validate_skills --strict` ✅, `audit_skills --strict` ✅ (within updated budget `maxWarningOnlySkills` 755→757), `security_scanner` ✅, `docs_security_content` ✅, `validate_references` ✅
- [x] Manual logic review
- [x] Source-only PR (no `data/*`/`CATALOG.md`/`skills_index.json`)
- [x] Credits: `docs/sources/sources.md` + `README.md` + `tools/config/audit-skills-strict-budget.json` updated
- [x] License provenance declared

> **Fork-gate note:** No `skills/.../scripts/` and no `.mjs`/`.sh` extensions remain, so `pr-policy` should be `approval-safe` (only `canonical_skill` + `skill_support` under `assets|references` with `LOW_RISK_EXTENSIONS`).

Supersedes #1250 (closed per maintainer feedback to split docs-only).
