### PR TITLE
fix: sync canonical state before reference validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,13 +488,13 @@ jobs:
           test -f README.md
           test -f CONTRIBUTING.md
 
-      - name: Validate references
-        run: npm run validate:references
-
       - name: Run repo-state sync
         env:
           GH_TOKEN: ${{ github.token }}
         run: npm run sync:repo-state
+
+      - name: Validate references
+        run: npm run validate:references
 
       - name: Audit npm dependencies
         run: npm audit --audit-level=high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,13 +198,13 @@ jobs:
         if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: npm run check:readme-credits -- --base "origin/${{ github.base_ref }}" --head HEAD
 
-      - name: Validate references
-        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true' && needs.pr-policy.outputs.requires_references == 'true'
-        run: npm run validate:references
-
       - name: Refresh ephemeral derived sources for tests
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: npm run plugin-compat:sync && npm run index && npm run bundles:sync && npm run sync:metadata && npm run catalog && npm run build:aas-v1-catalog && npm run sync:web-assets
+
+      - name: Validate references
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true' && needs.pr-policy.outputs.requires_references == 'true'
+        run: npm run validate:references
 
       - name: Run tests
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'

--- a/tools/scripts/tests/workflow_contracts.test.js
+++ b/tools/scripts/tests/workflow_contracts.test.js
@@ -251,6 +251,17 @@ assert.doesNotMatch(
   "PR and push CI must not depend on mutable upstream network clones",
 );
 assert.match(ciWorkflow, /^permissions:\n  contents: read$/m);
+const mainValidationJobStart = ciWorkflow.indexOf("  main-validation-and-sync:");
+assert.ok(mainValidationJobStart >= 0, "main-validation-and-sync job must exist");
+const mainValidationJob = ciWorkflow.slice(mainValidationJobStart);
+const mainSyncIndex = mainValidationJob.indexOf("- name: Run repo-state sync");
+const mainReferenceValidationIndex = mainValidationJob.indexOf("- name: Validate references");
+assert.ok(
+  mainSyncIndex >= 0 &&
+    mainReferenceValidationIndex >= 0 &&
+    mainSyncIndex < mainReferenceValidationIndex,
+  "main canonical sync must regenerate source-derived bundle data before validating cross-references",
+);
 assert.match(
   ciWorkflow,
   /source-validation:[\s\S]*?- name: Refresh ephemeral derived sources for tests\n\s+if: env\.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'\n\s+run: npm run plugin-compat:sync && npm run index && npm run bundles:sync && npm run sync:metadata && npm run catalog && npm run build:aas-v1-catalog && npm run sync:web-assets\n[\s\S]*?- name: Run tests\n\s+if: env\.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'\n\s+run: npm run test/,

--- a/tools/scripts/tests/workflow_contracts.test.js
+++ b/tools/scripts/tests/workflow_contracts.test.js
@@ -300,6 +300,14 @@ assert.match(
 const sourceValidationJob = ciWorkflow.match(/^  source-validation:\n([\s\S]*?)(?=^  pr-evidence:)/m)?.[0] || "";
 assert.match(sourceValidationJob, /needs: pr-policy/, "source validation should not wait for independent PR evidence");
 assert.doesNotMatch(sourceValidationJob, /needs:.*pr-evidence/);
+const sourceRefreshIndex = sourceValidationJob.indexOf("- name: Refresh ephemeral derived sources for tests");
+const sourceReferenceValidationIndex = sourceValidationJob.indexOf("- name: Validate references");
+assert.ok(
+  sourceRefreshIndex >= 0 &&
+    sourceReferenceValidationIndex >= 0 &&
+    sourceRefreshIndex < sourceReferenceValidationIndex,
+  "source validation must refresh source-derived bundle data before validating cross-references",
+);
 assert.match(
   sourceValidationJob,
   /actions\/checkout@[0-9a-f]{40}[\s\S]*?ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,


### PR DESCRIPTION
## Summary

- Run `sync:repo-state` before `validate:references` in the protected main lane so source-only skill deletions regenerate bundle and web state before cross-reference validation.
- Add a workflow contract test that locks the required ordering.

This repairs the failure on main run 33299323505, where stale generated bundles still referenced the retired `ui-slop-score` skill and prevented the canonical-sync PR from being created.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Current-base maintainer instructions and security guardrails were reviewed.
- [x] **Local Test**: The exact source patch was validated locally.
- [x] **Repo Checks**: `validate`, `validate:references`, warning budget, actionlint, docs security, and the complete root suite passed.
- [x] **Web Checks**: Web coverage passed with 21 test files and 176 tests.
- [x] **Source-Only PR**: No generated registry, bundle, mirror, catalog, or web asset is committed.
- [x] **Credits**: Not applicable; no external source content is introduced.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

## Verification

- `npm run lint:workflows`
- `npm run validate`
- `npm run chain`
- `npm run sync:web-assets`
- `npm run validate:references`
- `npm run check:warning-budget`
- `npm run security:docs`
- `npm run test` (113 groups)
- `npm run app:test:coverage` (21 files, 176 tests)
