### PR TITLE
Add memory-shield (agent memory poisoning defense)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This is an independent community project. It is not affiliated with, sponsored b
 [![OpenCode](https://img.shields.io/badge/OpenCode-CLI-gray?style=for-the-badge)](https://github.com/opencode-ai/opencode)
 [![Antigravity](https://img.shields.io/badge/Antigravity-AI%20IDE-red?style=for-the-badge)](https://github.com/sickn33/agentic-awesome-skills)
 
+- [memory-shield](https://github.com/vnbochkarev-netizen/memory-shield) - Defend agent memory against prompt-injection poisoning: snapshots before compaction, poisoned-content quarantine, masked secrets, diff audit (MIT, zero deps)
 ## AAS Core: Agent-First Preview
 
 > **The agent composes. You control. AAS keeps the stack reproducible.**


### PR DESCRIPTION
Adds [memory-shield](https://github.com/vnbochkarev-netizen/memory-shield) — open-source (MIT, zero-deps) skill that defends agent memory against prompt-injection poisoning: snapshots before compaction, poisoned-content quarantine, masked secrets, diff audit. Works with Claude Code / OpenClaw. CI: SkillQA grade A on every PR.

### Quality checklist
- [x] Reviewed the change: one source-only listing added to `README.md` (no generated artifacts)
- [x] Did **not** include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`)
- [x] Change is documentation/listing only — no code, no dependencies
- [x] Description matches the skill's actual behavior (local-first, no telemetry)