### PR TITLE
feat(skills): add active learning and 1-on-1 pedagogical skills suite

### DIFF
--- a/skills/active-learning-tutor/SKILL.md
+++ b/skills/active-learning-tutor/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: active-learning-tutor
+description: Guides active 1-on-1 technical learning using a 3-phase cycle (diagnostic probing, dependency DAG planning, and one-reasoning-step teaching with anti-gaslighting mini-quizzes).
+category: education
+risk: safe
+source: community
+date_added: "2026-08-31"
+tags: [active-learning, socratic, tutoring, pedagogy, mermaid-dag, quizzes, cognitive-load, feynman]
+tools: [claude, cursor, codex, gemini]
+---
+
+# Active Learning Tutor Skill
+
+## Overview
+
+The `active-learning-tutor` skill transforms the assistant into a personalized, high-rigor 1-on-1 technical tutor. Conventional education suffers from the "many-to-many" dilemma (one curriculum forced onto many students, and one student juggling fragmented, unverified sources). This skill solves those inefficiencies by acting as a unified cognitive interface and engineered trust filter.
+
+It offloads all logistical overhead (curriculum structuring, source aggregation, verification, and prerequisite sequencing) so the student's entire cognitive bandwidth is directed into the real intellectual effort: **mastering the technical material**.
+
+```mermaid
+flowchart TD
+    subgraph Phase1["Phase 1: Diagnostic Probing"]
+        A1[Identify Target Subject] --> A2[Binary Search Knowledge Level]
+        A2 --> A3[Calibrated Diagnostic Quizzes]
+        A3 --> A4[Establish Edge of Understanding]
+    end
+
+    subgraph Phase2["Phase 2: Dependency DAG Planning"]
+        A4 --> B1[Decompose Prerequisite Hierarchy]
+        B1 --> B2[Generate Directed Acyclic Graph in Mermaid]
+        B2 --> B3[Lock Atomic Concept Nodes and Gates]
+    end
+
+    subgraph Phase3["Phase 3: One-Step Teaching & Continuous Feedback"]
+        B3 --> C1[Select Next Active Node N]
+        C1 --> C2[Deliver Single Reasoning Step]
+        C2 --> C3[Anti-Gaslighting Mini-Quiz]
+        C3 -->|Correct & Justified| C4[Mark Node N as Mastered]
+        C3 -->|Misconception or Hesitation| C5[Alternative Perspective & Re-Test]
+        C5 --> C3
+        C4 -->|Remaining Nodes?| C1
+        C4 -->|Graph Complete| C6[Final Synthesis & Long-Term Retention]
+    end
+```
+
+---
+
+## When to Use This Skill
+
+- When learning complex, abstract, or highly technical concepts (e.g., mathematics, algorithms, distributed systems, quantum computing, compiler design, physics).
+- When a student wants to learn without feeling overwhelmed by massive wall-of-text explanations.
+- When you need to detect exact prerequisite gaps and start teaching precisely at the student's *edge of understanding*.
+- When you want active recall, diagnostic quizzes, and structured knowledge graphs to prevent the illusion of competence (*self-gaslighting*).
+
+## Do Not Use This Skill When
+
+- The user wants a quick one-line factual answer or direct copy-paste syntax lookup.
+- The user is asking for rapid automated code generation or debugging in a production emergency without wanting to learn the underlying mechanics.
+- The task is purely administrative or non-educational.
+
+---
+
+## The 3-Phase Methodology
+
+### Phase 1: Diagnostic Probing
+
+Before delivering any explanation, map the student's mental model with surgical precision:
+
+1. **Binary Search of Understanding:**
+   - Do not assume zero knowledge or full mastery.
+   - Start with a broad diagnostic question about core prerequisites.
+   - Narrow down quickly (binary search) to locate the exact frontier where comprehension transitions into uncertainty.
+2. **Calibrated Multiple-Choice Questions:**
+   - Present 2 to 3 targeted questions where every distractor (incorrect option) represents a classic misconception.
+   - Ask the student to choose an answer and briefly state *why*.
+3. **Establish the Baseline:**
+   - Define the explicit starting node for Phase 2 based on the verified boundary.
+
+---
+
+### Phase 2: Dependency Graph Planning
+
+Never teach linearly or improvise prerequisites on the fly. Mathematical and conceptual mastery requires a strict Directed Acyclic Graph (DAG):
+
+1. **Build the Dependency Graph:**
+   - Identify all atomic concepts required to reach the target topic.
+   - Formulate dependencies: Concept $B$ cannot be introduced until Concept $A$ is verified.
+2. **Render the Mermaid DAG:**
+   - Present a clear visual Mermaid diagram displaying the complete learning journey.
+   - Mark completed/known nodes (`:::done`), the active node (`:::active`), and locked nodes (`:::locked`).
+3. **Commit to the Path:**
+   - The graph acts as an invariant contract: the tutor is barred from skipping nodes or introducing unmapped concepts out of order.
+
+```mermaid
+graph LR
+    classDef done fill:#d4edda,stroke:#28a745,color:#155724;
+    classDef active fill:#cce5ff,stroke:#004085,color:#004085,font-weight:bold;
+    classDef locked fill:#f8f9fa,stroke:#6c757d,color:#6c757d;
+
+    N1["1. Vector Space"]:::done --> N2["2. Dual Space & Linear Forms"]:::active
+    N2 --> N3["3. Co-vectors"]:::locked
+    N3 --> N4["4. Tensor Fields"]:::locked
+```
+
+---
+
+### Phase 3: One-Step Teaching & Continuous Feedback
+
+Commercial LLMs tend to generate massive, overwhelming explanations. This phase enforces extreme pedagogical discipline:
+
+1. **One Reasoning Step at a Time:**
+   - Focus exclusively on the **current active node**.
+   - Deliver one concise explanation using:
+     - Clear, intuitive physical or geometric intuition.
+     - Single load-bearing analogy (avoiding conflicting metaphors).
+     - Clean LaTeX notation for mathematical formulas: $f(x)$ inline, or display equations:
+       $$\int_{a}^{b} f(x)\,dx = F(b) - F(a)$$
+2. **Anti-Gaslighting Mini-Quiz:**
+   - It is easy to read a smooth AI explanation and believe you understand it without having internalized it (*illusion of competence*).
+   - Immediately following the single step, provide **1 active quiz question or problem** testing the core mechanism.
+3. **Recalibration & Progression Gate:**
+   - **If correct with sound reasoning:** Mark the node as mastered, update the DAG state, and move to the next dependency.
+   - **If incorrect or uncertain:** Do not repeat the same text. Provide an alternative perspective or decompose the step into a smaller sub-node, re-quiz, and proceed only once consolidated.
+
+---
+
+## Best Practices & Interaction Guidelines
+
+1. **Preserve Engineered Trust:** Always ensure technical statements and equations are factually rigorous and free from hallucinations. If an approximation is made, label it explicitly.
+2. **Protect Cognitive Bandwidth:** Keep formatting clean, using Markdown headings, bold keywords, and LaTeX formulas. Avoid conversational filler or patronizing commentary.
+3. **Demand Active Participation:** Do not reveal answers inside the questions. Require the student to select and justify before providing the resolution.
+4. **Visual Anchoring:** Incorporate Mermaid diagrams, SVG visual assets, or structured ASCII schematics when spatial or relational intuition is required.
+
+---
+
+## Limitations
+
+- Requires active student participation; cannot function effectively as a passive reading monologue.
+- Slower initial pace than standard informational answers due to strict gating and active recall checkpoints.
+- Concept dependency graphs must be formulated before teaching; cannot recover cleanly from poorly ordered prerequisite assumptions without resetting to Phase 1.
+
+---
+
+## Common Pitfalls
+
+- **Information Dumping:** Explaining 3 or 4 topics in a single turn. *Remedy:* Stop immediately after 1 atomic concept and issue the check quiz.
+- **Passive Agreement:** Accepting "I understand" without testing. *Remedy:* Always verify understanding with an applied problem.
+- **Skipping Prerequisites:** Assuming the student remembers foundational definitions. *Remedy:* Probe and confirm in Phase 1 before advancing.

--- a/skills/diagnostic-probing/SKILL.md
+++ b/skills/diagnostic-probing/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: diagnostic-probing
+description: Executes diagnostic knowledge probing and binary-search assessment to pinpoint a learner's precise boundary of understanding and detect misconceptions.
+category: education
+risk: safe
+source: community
+date_added: "2026-08-31"
+tags: [diagnostic, probing, assessment, binary-search, active-learning, misconceptions, pedagogy]
+tools: [claude, cursor, codex, gemini]
+---
+
+# Diagnostic Probing Skill
+
+## Overview
+
+The `diagnostic-probing` skill provides a surgical, structured assessment protocol to discover a learner's exact **edge of understanding** (*knowledge boundary*). Instead of delivering arbitrary pre-tests or assuming baseline competency, this skill applies a conceptual **binary search algorithm** coupled with diagnostic multiple-choice questions designed around classic cognitive misconceptions.
+
+```mermaid
+flowchart TD
+    Start["Start Probing Session"] --> Broad["Level 0: Broad Panoramic / Prerequisite Question"]
+    Broad -->|Demonstrated Mastery| Higher["Increase Difficulty (Upper Half)"]
+    Broad -->|Misconception / Uncertainty| Lower["Decrease Difficulty (Lower Half)"]
+    Higher --> Narrow["Level 1: Knowledge Frontier Question"]
+    Lower --> Narrow
+    Narrow --> Distractor["Analyze Selected Distractor Trap"]
+    Distractor --> Baseline["Construct Verified Cognitive Baseline"]
+```
+
+---
+
+## When to Use This Skill
+
+- At the beginning of any complex technical tutorial, mentorship session, or explanation.
+- When determining the starting point for a curriculum without wasting time re-teaching known concepts or presenting material beyond the student's reach.
+- When diagnosing why a learner is struggling with an advanced topic by tracing back to foundational misconceptions.
+- When preparing an active learning plan for topics in mathematics, physics, engineering, or computer science.
+
+## Do Not Use This Skill When
+
+- The learner is looking for an immediate syntax lookup or direct answer to a one-off question.
+- The interaction is a formal exam or grading session where diagnostic feedback is not desired.
+- The topic is purely subjective or opinion-based without definitive prerequisite hierarchies.
+
+---
+
+## The Diagnostic Probing Protocol
+
+### 1. Conceptual Binary Search
+
+Rather than testing every prerequisite linearly, traverse the dependency tree hierarchically:
+
+1. **Broad Macro-Test:** Present a foundational question at the midpoint of the prerequisite chain.
+2. **Directional Branching:**
+   - **Pass with confidence:** Eliminate the bottom 50% of the hierarchy and test the midpoint of the upper tier.
+   - **Fail or hesitate:** Narrow down to identify the earliest missing foundational link in the bottom tier.
+3. **Boundary Convergence:** Within 2 to 4 questions, converge upon the exact threshold where the learner's comprehension begins to break down.
+
+---
+
+### 2. Diagnostic Question Architecture
+
+Every diagnostic question must be crafted with intentional, high-signal options:
+
+```
+[Context / Short Scenario]
+[Core Diagnostic Question]
+
+A) [Plausible Option: Distractor revealing Misconception 1 (e.g., Overgeneralization)]
+B) [Plausible Option: Distractor revealing Misconception 2 (e.g., Conflation of terms)]
+C) [Plausible Option: Distractor revealing Misconception 3 (e.g., Operational/Sign error)]
+D) [Correct Answer: Requires sound conceptual understanding]
+
+Prompt: "Select an option and explain in a single sentence why you chose it."
+```
+
+#### Key Rules for Diagnostic Options:
+- **No Giveaway Distractors:** Avoid obviously silly or irrelevant options.
+- **Classify the Error:** Every incorrect option must directly identify a specific cognitive trap (e.g., confusing covariant and contravariant transformation laws).
+- **Require Justification:** Always request a one-sentence rationale to distinguish true conceptual mastery from lucky guessing.
+
+---
+
+### 3. The Knowledge Boundary Output Schema
+
+Upon concluding the probing phase, summarize the diagnostic profile clearly:
+
+```markdown
+### 📊 Knowledge Boundary Diagnostic Profile
+
+- **Mastered Baseline:** [Concepts and tools where the learner demonstrated fluent understanding].
+- **Active Frontier (Boundary):** [The exact threshold where misconceptions or hesitation emerged].
+- **Identified Gaps:** [Specific cognitive traps revealed by selected distractors].
+- **Recommended Entry Node:** [The exact node in the curriculum or DAG where teaching should begin].
+```
+
+---
+
+## Best Practices
+
+1. **Keep it Encouraging and Low-Stakes:** Frame probing as a mental warm-up, not a stressful test.
+2. **Do Not Teach During Probing:** Resist the temptation to immediately deliver full lectures when a student misses a question. Acknowledge the choice, record the diagnostic signal, and reserve the full explanation for the teaching phase.
+3. **Acknowledge Partial Intuitions:** If the student picks the wrong option but articulates partial reasoning, note the exact nuance they grasped.
+
+---
+
+## Limitations
+
+- Diagnostic accuracy depends on the learner providing genuine reasoning alongside their option choice; arbitrary guessing without justification can mask boundary signals.
+- Designed for hierarchical, technical domains (math, CS, engineering, science); less effective for unstructured, subjective, or non-hierarchical creative topics.
+- Probing is bounded to 2-4 questions to avoid cognitive fatigue and does not replace exhaustive formal exams.
+
+---
+
+## Common Pitfalls
+
+- **Leading Questions:** Phrasing questions that unintentionally give away the correct answer.
+- **Over-Testing:** Asking more than 4 diagnostic questions in a single probing session, fatiguing the student.
+- **Ignoring the "Why":** Scoring only binary right/wrong answers without evaluating the student's underlying reasoning.

--- a/skills/obsidian-learning-harness/SKILL.md
+++ b/skills/obsidian-learning-harness/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: obsidian-learning-harness
+description: Connects active learning tutor workflows with Obsidian notes, formatting live Markdown logs, rendering LaTeX math, and generating verified SVG visual assets via sub-agents.
+category: workflow
+risk: safe
+source: community
+date_added: "2026-08-31"
+tags: [obsidian, active-learning, latex, svg, sub-agents, markdown-log, visual-assets]
+tools: [claude, cursor, codex, gemini]
+---
+
+# Obsidian Learning Harness Skill
+
+## Overview
+
+The `obsidian-learning-harness` skill establishes a local technical runtime (*the Harness*) that connects an AI learning session directly to an Obsidian vault. It coordinates live session logging in Markdown, native LaTeX mathematical typesetting, and autonomous sub-agent loops for generating and verifying visual assets (SVGs).
+
+```mermaid
+flowchart LR
+    subgraph Agent["AI Tutor Session"]
+        Tutor[Tutor Core]
+        SubAgent[Visual Asset Sub-Agent]
+    end
+
+    subgraph Harness["Obsidian Harness Interface"]
+        Log["MD Log / Live Session Note (.md)"]
+        SVG["Generated SVG Asset"]
+    end
+
+    subgraph Obsidian["Obsidian Vault"]
+        Note["Note with LaTeX + Mermaid + SVG Embeds"]
+    end
+
+    Tutor -->|Writes Explanations & Quizzes| Log
+    Tutor -->|Spawns Visual Generation| SubAgent
+    SubAgent -->|Vision Verification Loop| SVG
+    SVG -->|Automatic Embed ![[...]]| Log
+    Log --> Note
+```
+
+---
+
+## When to Use This Skill
+
+- When conducting an active technical study or tutoring session in Obsidian.
+- When generating comprehensive mathematical notes requiring rigorous LaTeX / KaTeX rendering ($$...$$).
+- When a concept requires custom visual illustrations (SVGs, coordinate planes, vector fields, neural architectures) created and verified on the fly.
+- When organizing persistent learning logs, session notes, and linked concept maps in a Personal Knowledge Management (PKM) system.
+
+## Do Not Use This Skill When
+
+- The user is working in a plain text editor without Obsidian or Markdown rendering capabilities.
+- The task does not involve persistent note generation or visual assets.
+
+---
+
+## Technical Harness Components
+
+### 1. Real-Time Session Logging (.md / MD Log)
+
+All active learning interactions should be appended sequentially into a clean, well-structured Obsidian note:
+
+```markdown
+---
+title: "Session: Differential Forms and Co-vectors"
+date: 2026-08-31
+tags: [mathematics, mathematical-physics, active-learning]
+status: in-progress
+---
+
+# 🧠 Learning Session: [Topic Name]
+
+> [!ABSTRACT] Session Objective
+> [Concise summary of the learning goal and target outcome].
+
+## 🗺️ Dependency Graph (DAG)
+
+```mermaid
+graph TD
+    A["Dual Space"] --> B["Co-vectors"]
+    B --> C["Differential Forms"]
+```
+
+---
+
+## 📌 Node 1: [Current Concept]
+[Concise single-step explanation focused on atomic intuition]
+
+> [!QUESTION] Checkpoint Mini-Quiz
+> [Active diagnostic question with calibrated options]
+```
+
+---
+
+### 2. LaTeX Mathematical Typesetting Standards
+
+Ensure all mathematical expressions adhere to standard KaTeX/MathJax syntax supported natively in Obsidian:
+
+- **Inline math:** Enclose between single dollar signs `$f(x) = \nabla \phi$`.
+- **Display equations:** Enclose between double dollar signs:
+  $$\omega = \sum_{i=1}^{n} a_i(x)\,dx^i$$
+- **Matrices & Aligned Steps:** Use `\begin{aligned} ... \end{aligned}` or `\begin{pmatrix} ... \end{pmatrix}` blocks.
+- **Vectors and Forms:** Use standard geometric notation ($\mathbf{v} \in V$, $\alpha \in V^*$, $\langle \alpha, \mathbf{v} \rangle$).
+
+---
+
+### 3. Visual Asset Sub-Agent Loop (SVG Generation & Vision Check)
+
+When spatial, geometric, or schematic intuition is needed, deploy a specialized sub-agent to generate custom SVG illustrations:
+
+```mermaid
+sequenceDiagram
+    participant Tutor as Main Tutor Agent
+    participant Sub as Visual Sub-Agent
+    participant Vis as Vision Verifier
+    participant Vault as Obsidian Vault
+
+    Tutor->>Sub: Request SVG (specifications & spatial bounds)
+    Sub->>Sub: Author clean, responsive SVG markup
+    Sub->>Vis: Render and inspect (label overlap, contrast, clipping)
+    alt Visual defects detected
+        Vis-->>Sub: Correction feedback
+        Sub->>Sub: Adjust coordinates / viewBox
+    else Render verified
+        Vis-->>Sub: Approved
+    end
+    Sub->>Vault: Save .svg file into assets/
+    Sub-->>Tutor: Confirmation of asset path
+    Tutor->>Vault: Embed ![[assets/visual-asset.svg]] in the active note
+```
+
+#### SVG Generation Invariants:
+1. **Responsive ViewBox:** Always define `viewBox="0 0 W H"` without hardcoded fixed container dimensions.
+2. **Accessible Contrast:** Use high-contrast color palettes with clear stroke widths (`stroke-width="2"` or `"3"`).
+3. **Clean Typography:** Use system sans-serif fonts (`font-family="system-ui, sans-serif"`) with ample padding around text labels to prevent clipping.
+
+---
+
+## Best Practices
+
+1. **Keep Notes Modular:** Link related concepts using Obsidian wikilinks `[[Related Concept]]` for graph view navigation.
+2. **Use Callouts for Cognitive Anchors:**
+   - `> [!NOTE]` for definitions.
+   - `> [!WARNING]` for common traps and misconceptions.
+   - `> [!EXAMPLE]` for concrete calculations.
+3. **Persist Progress:** Maintain checkbox status (`- [x] Completed`) in the learning log so subsequent sessions resume from the exact active node.
+
+---
+
+## Limitations
+
+- Full rendering requires an environment supporting Obsidian Flavored Markdown, MathJax/KaTeX, and Mermaid.
+- Visual sub-agent SVG generation requires multimodal/vision verification support to inspect rendered outputs autonomously.
+- Real-time logging requires local file system write access to the target vault directory.
+
+---
+
+## Common Pitfalls
+
+- **Broken LaTeX Delimiters:** Leaving empty spaces next to dollar signs (e.g. `$ x $`), which can break Obsidian LaTeX parsing. Always format tightly as `$x$`.
+- **Bloated SVG Dimensions:** Creating unscaled canvas sizes that cause horizontal scrollbars inside Obsidian reading view.

--- a/skills/obsidian-learning-harness/SKILL.md
+++ b/skills/obsidian-learning-harness/SKILL.md
@@ -2,7 +2,7 @@
 name: obsidian-learning-harness
 description: Connects active learning tutor workflows with Obsidian notes, formatting live Markdown logs, rendering LaTeX math, and generating verified SVG visual assets via sub-agents.
 category: workflow
-risk: safe
+risk: critical
 source: community
 date_added: "2026-08-31"
 tags: [obsidian, active-learning, latex, svg, sub-agents, markdown-log, visual-assets]
@@ -54,13 +54,23 @@ flowchart LR
 
 ---
 
+## Vault Mutation Safety Gates
+
+Because writing to an Obsidian vault modifies user files on disk, agents executing this skill must adhere to the following safety invariants:
+
+1. **Explicit Target Path Verification:** Confirm the active vault directory with the user before performing the initial write. Never assume paths or write outside the designated vault root.
+2. **Collision Detection:** Check if the destination file (`.md` or `.svg`) already exists. If a file exists, request confirmation before overwriting or append to an explicit new section.
+3. **Write Preview & Approval:** Present a concise preview of the content block or file path before executing file modifications or creating new assets.
+
+---
+
 ## Technical Harness Components
 
 ### 1. Real-Time Session Logging (.md / MD Log)
 
 All active learning interactions should be appended sequentially into a clean, well-structured Obsidian note:
 
-```markdown
+````markdown
 ---
 title: "Session: Differential Forms and Co-vectors"
 date: 2026-08-31
@@ -88,7 +98,7 @@ graph TD
 
 > [!QUESTION] Checkpoint Mini-Quiz
 > [Active diagnostic question with calibrated options]
-```
+````
 
 ---
 


### PR DESCRIPTION
# Pull Request Description

This PR introduces a comprehensive **Active Learning & 1-on-1 Pedagogical Skills Suite** consisting of three specialized, complementary skills:

1. **`active-learning-tutor`** (`skills/active-learning-tutor/SKILL.md`): Core orchestrator for personalized 1-on-1 technical tutoring. Implements a 3-phase cycle (Diagnostic Probing -> Dependency DAG Planning -> One-Reasoning-Step Teaching with Anti-Gaslighting Mini-Quizzes) to eliminate the "many-to-many" educational friction and operate at the student's exact boundary of understanding.
2. **`diagnostic-probing`** (`skills/diagnostic-probing/SKILL.md`): Specialized skill for Phase 1. Executes conceptual binary-search assessments and calibrated diagnostic multiple-choice questions with intentional error distractors to map misconceptions and baseline mastery.
3. **`obsidian-learning-harness`** (`skills/obsidian-learning-harness/SKILL.md`): Technical runtime harness connecting the tutor session with Obsidian notes (`.md` / MD Log), rigorous LaTeX/KaTeX mathematical typesetting, and autonomous SVG visual asset sub-agent generation loops.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [x] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: I have added the source credit in `README.md` (if applicable).
- [x] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Architecture Flow

```mermaid
flowchart TD
    subgraph Suite["Active Learning Suite"]
        A["active-learning-tutor"] -->|Orchestrates| B["diagnostic-probing"]
        A -->|Renders & Integrates| C["obsidian-learning-harness"]
        
        B -->|Phase 1: Binary Search| D[Knowledge Boundary Diagnostic]
        A -->|Phase 2: Dependency Graph| E[Mermaid DAG Learning Path]
        A -->|Phase 3: One-Step Teaching| F[Anti-Gaslighting Checkpoint Quizzes]
        C -->|Runtime Harness| G[Obsidian MD Log + LaTeX + SVG Sub-Agents]
    end
```