### PR TITLE
fix: satisfy FLOSS manifest validation

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -53,7 +53,7 @@
         "guid": "aas-sustainability-2026",
         "status": "active",
         "name": "AAS 12-month sustainability programme",
-        "description": "Fund one year of maintainer capacity to keep AAS reliable as adoption grows: triage and review community contributions; maintain releases, the public catalog, and npm, MCP, and plugin distribution; strengthen provenance, dependency, documentation, and security checks; improve contributor and user documentation; and cover CI, hosting, and testing infrastructure. Proposed allocation: USD 10,000 for maintainer and reviewer time, USD 7,500 for security and provenance work, USD 5,000 for CI and catalog infrastructure, and USD 2,500 for documentation and community support. Progress and significant outputs will be reported publicly in the repository.",
+        "description": "Support one year of AAS maintenance: triage and review community contributions; maintain releases, the public catalog, and npm, MCP, and plugin distribution; strengthen provenance and security checks; improve documentation; and cover CI, hosting, and testing. Allocation: USD 10,000 maintainer/reviewer time; USD 7,500 security/provenance; USD 5,000 CI/catalog infrastructure; USD 2,500 documentation/community support. Progress and significant outputs will be reported publicly.",
         "amount": 25000,
         "currency": "USD",
         "frequency": "one-time",

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -5,6 +5,8 @@
 - Tied the request to a concrete 12-month allocation covering maintainer and
   reviewer time, security and provenance work, CI and catalog infrastructure,
   and documentation and community support.
+- Kept the plan description within the directory's 500-character validation
+  limit while retaining the complete allocation.
 - Kept bank details and funding history out of the public manifest; payment and
   tax documentation remain private follow-up items if the application is
   selected.


### PR DESCRIPTION
## Summary

- shorten the FLOSS funding-plan description from 650+ characters to 479 characters
- preserve the complete USD 25,000 allocation and every stated workstream
- record the portal-specific 500-character constraint in `walkthrough.md`

The published v1.1.0 JSON Schema does not declare this limit, but the live FLOSS directory validator enforces it.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Verification

- live `POST https://dir.floss.fund/api/validate`: HTTP 200 and normalized manifest returned
- plan description: 479 characters
- requested amount: USD 25,000; allocation sum: USD 25,000
- `npm run validate`
- `npm run validate:references`
- `npm run test` — 113 test files passed
- `npm run security:docs`
- `npm run pr:preflight -- --base origin/main --head HEAD --no-run --check-policy --json`

## Quality Bar Checklist ✅

- [x] **Standards**: Current contributor and maintainer policies were read from this exact base.
- [ ] **Metadata**: N/A — no `SKILL.md` change.
- [ ] **Risk Label**: N/A — no `SKILL.md` change.
- [ ] **Triggers**: N/A — no `SKILL.md` change.
- [ ] **Limitations**: N/A — no `SKILL.md` change.
- [ ] **Security**: N/A — no offensive skill change.
- [x] **Safety scan**: `npm run security:docs` passed.
- [ ] **Automated Skill Review**: N/A — no `SKILL.md` change.
- [ ] **Manual Logic Review**: N/A — no `SKILL.md` or risky guidance change.
- [x] **Local Test**: Portal validation and the complete repository test suite passed.
- [x] **Repo Checks**: `npm run validate:references` passed.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: N/A — no external source material was imported.
- [ ] **License provenance**: N/A — no skill or external source import.
- [x] **Maintainer Edits**: Same-repository branch; maintainer edits are available.

## Screenshots (if applicable)

Not applicable.