### PR TITLE
fix: resolve exported security findings

### DIFF
--- a/skills/agent-qa-authoring/SKILL.md
+++ b/skills/agent-qa-authoring/SKILL.md
@@ -42,7 +42,9 @@ Author Agent QA tests, suites, and hooks without inventing schema fields or iden
 4. Generate every new ID with Agent QA tooling:
    - MCP: `agent_qa_generate_id`
    - CLI fallback: `agent-qa ids generate <test|suite|hook|run|observation>`
-   - Package fallback: `npx --yes agent-qa ids generate <type>`
+   - If neither surface is already installed, stop and ask the user to approve
+     an exact Agent QA installation. Do not fetch and execute the package at
+     runtime through `npx` or another moving package reference.
 5. Never hand-write IDs. Validate existing IDs with `agent_qa_validate_id` or `agent-qa ids validate <type> <id> --json`.
 6. Validate definitions before saving:
    - Tests: `agent_qa_validate_test` or `agent_qa_validate_definition` with `kind: "test"`

--- a/skills/agy-delegate/SKILL.md
+++ b/skills/agy-delegate/SKILL.md
@@ -3,7 +3,7 @@ name: agy-delegate
 description: Delegate coding tasks to the Google Antigravity CLI (`agy`) only when
   the user explicitly requests it, while the orchestrator retains review and landing
   responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/aider-delegate/SKILL.md
+++ b/skills/aider-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: aider-delegate
 description: Delegate coding tasks to Aider (`aider`) only when the user explicitly
   requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/atlas-cloud-media/SKILL.md
+++ b/skills/atlas-cloud-media/SKILL.md
@@ -2,7 +2,7 @@
 name: atlas-cloud-media
 description: "Generate Atlas Cloud images and videos through its asynchronous media API with schema-first model selection and credential-safe polling."
 category: media
-risk: safe
+risk: critical
 source: self
 source_type: self
 date_added: "2026-08-12"
@@ -64,6 +64,19 @@ Do not guess parameters from another model, because names such as `size`,
 
 ## Workflow
 
+### 0. Create a Private Per-Run Workspace
+
+Run the remaining shell snippets in the same shell session. Create a private
+directory before writing prompts, responses, prediction IDs, or signed URLs;
+the parameter expansion in later steps fails closed when this setup was skipped.
+
+```bash
+umask 077
+atlas_tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/atlas-cloud-media.XXXXXXXX") || exit 1
+chmod 700 -- "$atlas_tmp_dir"
+trap 'rm -rf -- "$atlas_tmp_dir"' EXIT
+```
+
 ### 1. Discover and Validate a Model
 
 Fetch the catalog, filter by `type` (`Image` or `Video`), and match the user's
@@ -76,10 +89,10 @@ Example discovery request:
 ```bash
 curl --fail --silent --show-error \
   "https://api.atlascloud.ai/api/v1/models" \
-  --output /tmp/atlas-models.json
+  --output "${atlas_tmp_dir:?run private workspace setup first}/models.json"
 
 jq -r '.data[] | select(.type == "Image") | [.model, .displayName, .schema] | @tsv' \
-  /tmp/atlas-models.json
+  "$atlas_tmp_dir/models.json"
 ```
 
 ### 2. Submit One Generation Task
@@ -94,15 +107,15 @@ jq -n \
   --arg model "qwen-image-3.0/text-to-image" \
   --arg prompt "A paper-cut city map in blue and white, clean editorial style" \
   '{model: $model, prompt: $prompt, size: "1024*1024", n: 1}' \
-  > /tmp/atlas-image-request.json
+  > "${atlas_tmp_dir:?run private workspace setup first}/request.json"
 
 curl --fail --silent --show-error \
   --request POST \
   "https://api.atlascloud.ai/api/v1/model/generateImage" \
   --header "Authorization: Bearer $ATLASCLOUD_API_KEY" \
   --header "Content-Type: application/json" \
-  --data @/tmp/atlas-image-request.json \
-  --output /tmp/atlas-submit.json
+  --data @"$atlas_tmp_dir/request.json" \
+  --output "$atlas_tmp_dir/submit.json"
 ```
 
 Video example using a catalog-confirmed model:
@@ -119,15 +132,15 @@ jq -n \
     ratio: "16:9",
     generate_audio: false,
     watermark: false
-  }' > /tmp/atlas-video-request.json
+  }' > "${atlas_tmp_dir:?run private workspace setup first}/request.json"
 
 curl --fail --silent --show-error \
   --request POST \
   "https://api.atlascloud.ai/api/v1/model/generateVideo" \
   --header "Authorization: Bearer $ATLASCLOUD_API_KEY" \
   --header "Content-Type: application/json" \
-  --data @/tmp/atlas-video-request.json \
-  --output /tmp/atlas-submit.json
+  --data @"$atlas_tmp_dir/request.json" \
+  --output "$atlas_tmp_dir/submit.json"
 ```
 
 Check that `.data.id` is a non-empty string before polling. Treat a non-2xx
@@ -142,21 +155,21 @@ for diagnostics, but never log request headers or the API key.
 
 ```bash
 prediction_id=$(jq -er '.data.id | select(type == "string" and length > 0)' \
-  /tmp/atlas-submit.json)
+  "${atlas_tmp_dir:?run private workspace setup first}/submit.json")
 
 for attempt in $(seq 1 200); do
   sleep 3
   curl --fail --silent --show-error \
     "https://api.atlascloud.ai/api/v1/model/prediction/$prediction_id" \
     --header "Authorization: Bearer $ATLASCLOUD_API_KEY" \
-    --output /tmp/atlas-prediction.json
+    --output "$atlas_tmp_dir/prediction.json"
 
-  status=$(jq -r '.data.status // "unknown"' /tmp/atlas-prediction.json)
+  status=$(jq -r '.data.status // "unknown"' "$atlas_tmp_dir/prediction.json")
   case "$status" in
     completed|succeeded) break ;;
     failed|timeout)
       jq -r '.data.error // "Atlas Cloud generation failed"' \
-        /tmp/atlas-prediction.json >&2
+        "$atlas_tmp_dir/prediction.json" >&2
       exit 1
       ;;
   esac
@@ -174,14 +187,33 @@ file's content type and size before treating it as a valid deliverable.
 
 ```bash
 output_url=$(jq -er '.data.outputs[0] | select(startswith("https://"))' \
-  /tmp/atlas-prediction.json)
+  "${atlas_tmp_dir:?run private workspace setup first}/prediction.json")
 
 curl --fail --silent --show-error --location \
   "$output_url" \
-  --output ./atlas-output.bin
+  --output "$atlas_tmp_dir/output.bin"
 
-test -s ./atlas-output.bin
-file ./atlas-output.bin
+test -s "$atlas_tmp_dir/output.bin"
+file "$atlas_tmp_dir/output.bin"
+
+# ATLAS_OUTPUT_DIR must be the user-approved destination. Resolve it to a
+# physical directory, copy into an exclusive same-directory temporary file,
+# then create the final name with one atomic hard-link operation. `ln` fails if
+# any target already exists, including a dangling symlink.
+atlas_output_dir=$(cd -- "${ATLAS_OUTPUT_DIR:?set the approved output directory}" && pwd -P) || exit 1
+atlas_output_path="$atlas_output_dir/atlas-output.bin"
+if ! (
+  set -eu
+  umask 077
+  atlas_publish_tmp=$(mktemp "$atlas_output_dir/.atlas-output.XXXXXXXX")
+  trap 'rm -f -- "$atlas_publish_tmp"' EXIT
+  cp -- "$atlas_tmp_dir/output.bin" "$atlas_publish_tmp"
+  chmod 644 -- "$atlas_publish_tmp"
+  ln -- "$atlas_publish_tmp" "$atlas_output_path"
+); then
+  printf '%s\n' "Refusing to overwrite or redirect $atlas_output_path" >&2
+  exit 1
+fi
 ```
 
 Rename the file only after its detected type is known. Report the local path,
@@ -205,6 +237,8 @@ or decode validation.
 ## Best Practices
 
 - Use the public catalog and per-model schema immediately before generation.
+- Keep request and response artifacts in one private per-run directory and let
+  the exit trap remove them, especially prediction payloads with signed URLs.
 - Submit one task at a time unless the user explicitly approves a batch and its
   cost.
 - Keep prompts, reference-media rights, and provider content policies visible

--- a/skills/babysit-pr/SKILL.md
+++ b/skills/babysit-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: babysit-pr
 description: 'Babysit a pull request through its bot review rounds: verify, fix, reply,
   resolve. Use for any babysit or watch-the-PR ask.'
-risk: safe
+risk: critical
 category: code-quality
 source: https://github.com/amElnagdy/review-skills
 source_repo: amElnagdy/review-skills

--- a/skills/boost-asio-pro/references/pre-cpp20.md
+++ b/skills/boost-asio-pro/references/pre-cpp20.md
@@ -112,13 +112,20 @@ void arm_timeout() {
 // members, NOT locals — they must survive until the handler runs
 uint32_t len_be_;
 std::string body_;
+static constexpr std::uint32_t max_frame_size = 1U << 20; // protocol limit: 1 MiB
 
 void read_frame() {
     auto self = shared_from_this();
     asio::async_read(socket_, asio::buffer(&len_be_, sizeof len_be_),
         asio::bind_executor(strand_, [this, self](boost::system::error_code ec, std::size_t) {
             if (ec) return;
-            body_.assign(ntohl(len_be_), '\0');
+            const std::uint32_t frame_length = ntohl(len_be_);
+            if (frame_length > max_frame_size) {
+                boost::system::error_code ignored;
+                socket_.close(ignored);                         // reject before allocation
+                return;
+            }
+            body_.assign(static_cast<std::size_t>(frame_length), '\0');
             asio::async_read(socket_, asio::buffer(body_),     // read exactly N bytes
                 asio::bind_executor(strand_, [this, self](boost::system::error_code ec2, std::size_t) {
                     if (ec2) return;

--- a/skills/claude-delegate/SKILL.md
+++ b/skills/claude-delegate/SKILL.md
@@ -3,7 +3,7 @@ name: claude-delegate
 description: Delegate coding tasks to a separate Claude Code CLI process or Claude
   session only when the user explicitly requests it, while the orchestrator retains
   review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/cline-delegate/SKILL.md
+++ b/skills/cline-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: cline-delegate
 description: Delegate coding tasks to the Cline CLI (`cline`) only when the user explicitly
   requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/codex-delegate/SKILL.md
+++ b/skills/codex-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: codex-delegate
 description: Delegate coding tasks to the OpenAI Codex CLI only when the user explicitly
   requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/commandcode-delegate/SKILL.md
+++ b/skills/commandcode-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: commandcode-delegate
 description: Delegate coding tasks to the Command Code CLI (`cmd`) only when the user
   explicitly requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/copilot-delegate/SKILL.md
+++ b/skills/copilot-delegate/SKILL.md
@@ -3,7 +3,7 @@ name: copilot-delegate
 description: Delegate coding tasks to the GitHub Copilot CLI (`copilot`) only when
   the user explicitly requests it, while the orchestrator retains review and landing
   responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -3,7 +3,7 @@ name: cursor-delegate
 description: Delegate coding tasks to the Cursor Agent CLI (`cursor-agent`) only when
   the user explicitly requests it, while the orchestrator retains review and landing
   responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/grok-delegate/SKILL.md
+++ b/skills/grok-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: grok-delegate
 description: Delegate coding tasks to the Grok Build CLI only when the user explicitly
   requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/kimi-delegate/SKILL.md
+++ b/skills/kimi-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: kimi-delegate
 description: Delegate coding tasks to the Kimi Code CLI (`kimi`) only when the user
   explicitly requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/liuguang-banlan-ui/SKILL.md
+++ b/skills/liuguang-banlan-ui/SKILL.md
@@ -90,9 +90,10 @@ Maintain a serializable manifest with these top-level fields:
 ### 7. Validate and report
 
 - Scaffold a clean starter with `scripts/scaffold_template.py` when a neutral implementation is needed.
-- Treat JavaScript manifests as executable code: inspect them first and run the
-  bundled helpers only on reviewed, locally authored configuration. Never pass
-  an untrusted or freshly downloaded manifest to either Python helper.
+- The bundled helpers parse only the restricted data-literal assignment used by
+  the starter. They reject expressions, function calls, duplicate keys,
+  unsupported syntax, trailing statements, and oversized manifests without
+  executing JavaScript. Keep runtime theme configs data-only as well.
 - Run `scripts/validate_manifest.py` on each theme config before rendering.
 - Capture desktop and mobile screenshots with a real browser. Inspect them directly if visual capability is available.
 - Run `scripts/measure_preview.py` on the pure field screenshot and retain measured chromatic ratio, luminance statistics, per-color coverage, and effective share.
@@ -122,7 +123,8 @@ Use the bundled starter under `assets/starter/` as a neutral base. Copy only the
 ### scripts/
 
 - `scaffold_template.py`: copy the neutral starter for `opal`, `obsidian`, or both.
-- `validate_manifest.py`: parse a JavaScript manifest through Node and validate required fields and ranges.
+- `manifest_parser.py`: statically parse the restricted data-only manifest grammar without executing JavaScript.
+- `validate_manifest.py`: validate required manifest fields and ranges.
 - `measure_preview.py`: measure a rendered pure-field PNG against the configured OKLCH palette.
 
 ### references/

--- a/skills/liuguang-banlan-ui/scripts/manifest_parser.py
+++ b/skills/liuguang-banlan-ui/scripts/manifest_parser.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Parse the data-only subset used by Liuguang theme manifests."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+from dataclasses import dataclass
+
+
+MAX_MANIFEST_BYTES = 256 * 1024
+MAX_NESTING_DEPTH = 64
+
+
+class ManifestSyntaxError(ValueError):
+    """Raised when a manifest contains code or unsupported JavaScript syntax."""
+
+
+@dataclass(frozen=True)
+class Token:
+    kind: str
+    value: str
+    offset: int
+
+
+TOKEN_RE = re.compile(
+    r"""
+    (?P<whitespace>\s+)
+  | (?P<line_comment>//[^\r\n]*)
+  | (?P<block_comment>/\*.*?\*/)
+  | (?P<string>"(?:\\["\\/bfnrt]|\\u[0-9A-Fa-f]{4}|[^"\\\x00-\x1f])*")
+  | (?P<number>-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)
+  | (?P<identifier>[A-Za-z_$][A-Za-z0-9_$]*)
+  | (?P<punctuation>[{}\[\]:,;=.])
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def tokenize(source: str) -> list[Token]:
+    tokens: list[Token] = []
+    offset = 0
+    while offset < len(source):
+        match = TOKEN_RE.match(source, offset)
+        if match is None:
+            raise ManifestSyntaxError(f"unsupported syntax at byte offset {offset}")
+        kind = match.lastgroup
+        if kind not in {"whitespace", "line_comment", "block_comment"}:
+            tokens.append(Token(kind or "unknown", match.group(0), offset))
+        offset = match.end()
+    tokens.append(Token("eof", "", len(source)))
+    return tokens
+
+
+class Parser:
+    def __init__(self, source: str) -> None:
+        self.tokens = tokenize(source)
+        self.index = 0
+
+    @property
+    def current(self) -> Token:
+        return self.tokens[self.index]
+
+    def take(self, value: str | None = None, kind: str | None = None) -> Token:
+        token = self.current
+        if value is not None and token.value != value:
+            raise ManifestSyntaxError(
+                f"expected {value!r} at byte offset {token.offset}, found {token.value!r}"
+            )
+        if kind is not None and token.kind != kind:
+            raise ManifestSyntaxError(
+                f"expected {kind} at byte offset {token.offset}, found {token.value!r}"
+            )
+        self.index += 1
+        return token
+
+    def accept(self, value: str) -> bool:
+        if self.current.value != value:
+            return False
+        self.index += 1
+        return True
+
+    def parse(self) -> dict:
+        self.take("window")
+        self.take(".")
+        self.take("SPECTRAL_THEME")
+        self.take("=")
+        value = self.parse_value(0)
+        self.accept(";")
+        self.take(kind="eof")
+        if not isinstance(value, dict):
+            raise ManifestSyntaxError("SPECTRAL_THEME must be an object")
+        return value
+
+    def parse_value(self, depth: int):
+        if depth > MAX_NESTING_DEPTH:
+            raise ManifestSyntaxError("manifest nesting limit exceeded")
+        token = self.current
+        if token.value == "{":
+            return self.parse_object(depth + 1)
+        if token.value == "[":
+            return self.parse_array(depth + 1)
+        if token.kind == "string":
+            self.index += 1
+            return json.loads(token.value)
+        if token.kind == "number":
+            self.index += 1
+            try:
+                return (
+                    float(token.value)
+                    if any(mark in token.value for mark in ".eE")
+                    else int(token.value)
+                )
+            except ValueError as error:
+                raise ManifestSyntaxError("numeric literal exceeds the supported range") from error
+        if token.kind == "identifier" and token.value in {"true", "false", "null"}:
+            self.index += 1
+            return {"true": True, "false": False, "null": None}[token.value]
+        raise ManifestSyntaxError(
+            f"only data literals are allowed at byte offset {token.offset}; found {token.value!r}"
+        )
+
+    def parse_object(self, depth: int) -> dict:
+        result: dict = {}
+        self.take("{")
+        if self.accept("}"):
+            return result
+        while True:
+            token = self.current
+            if token.kind == "identifier":
+                key = self.take(kind="identifier").value
+            elif token.kind == "string":
+                key = json.loads(self.take(kind="string").value)
+            else:
+                raise ManifestSyntaxError(
+                    f"object keys must be identifiers or strings at byte offset {token.offset}"
+                )
+            if key in result:
+                raise ManifestSyntaxError(f"duplicate object key: {key}")
+            self.take(":")
+            result[key] = self.parse_value(depth)
+            if self.accept("}"):
+                return result
+            self.take(",")
+            if self.accept("}"):
+                return result
+
+    def parse_array(self, depth: int) -> list:
+        result: list = []
+        self.take("[")
+        if self.accept("]"):
+            return result
+        while True:
+            result.append(self.parse_value(depth))
+            if self.accept("]"):
+                return result
+            self.take(",")
+            if self.accept("]"):
+                return result
+
+
+def parse_manifest(source: str) -> dict:
+    return Parser(source).parse()
+
+
+def load_manifest(path: pathlib.Path) -> dict:
+    with path.open("rb") as manifest:
+        raw = manifest.read(MAX_MANIFEST_BYTES + 1)
+    if len(raw) > MAX_MANIFEST_BYTES:
+        raise ManifestSyntaxError(
+            f"manifest exceeds the {MAX_MANIFEST_BYTES}-byte size limit"
+        )
+    try:
+        source = raw.decode("utf-8-sig")
+    except UnicodeDecodeError as error:
+        raise ManifestSyntaxError("manifest must be valid UTF-8") from error
+    return parse_manifest(source)

--- a/skills/liuguang-banlan-ui/scripts/measure_preview.py
+++ b/skills/liuguang-banlan-ui/scripts/measure_preview.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
-import subprocess
 import sys
+
+from manifest_parser import ManifestSyntaxError, load_manifest
 
 try:
     import numpy as np
@@ -27,21 +28,6 @@ except ModuleNotFoundError as exc:
         file=sys.stderr,
     )
     raise SystemExit(2)
-
-
-def load_config(path: pathlib.Path) -> dict:
-    source = (
-        "global.window={};require(require('path').resolve(process.argv[1]));"
-        "process.stdout.write(JSON.stringify(window.SPECTRAL_THEME));"
-    )
-    result = subprocess.run(
-        ["node", "-e", source, str(path)],
-        check=True,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-    )
-    return json.loads(result.stdout)
 
 
 def srgb_to_oklab(rgb: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
@@ -129,7 +115,18 @@ def main() -> None:
     parser.add_argument("--image", required=True, type=pathlib.Path)
     parser.add_argument("--config", required=True, type=pathlib.Path)
     args = parser.parse_args()
-    config = load_config(args.config.resolve())
+    try:
+        config = load_manifest(args.config.resolve())
+    except (ManifestSyntaxError, OSError) as error:
+        print(
+            json.dumps(
+                {"status": "invalid", "errors": [str(error)]},
+                ensure_ascii=False,
+                indent=2,
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from error
     payload = {
         "schemaVersion": "1.0",
         "theme": config["label"],

--- a/skills/liuguang-banlan-ui/scripts/validate_manifest.py
+++ b/skills/liuguang-banlan-ui/scripts/validate_manifest.py
@@ -8,23 +8,9 @@ import json
 import math
 import pathlib
 import re
-import subprocess
 import sys
 
-
-def load_manifest(path: pathlib.Path) -> dict:
-    program = (
-        "global.window={};require(require('path').resolve(process.argv[1]));"
-        "process.stdout.write(JSON.stringify(window.SPECTRAL_THEME));"
-    )
-    result = subprocess.run(
-        ["node", "-e", program, str(path)],
-        check=True,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-    )
-    return json.loads(result.stdout)
+from manifest_parser import ManifestSyntaxError, load_manifest
 
 
 def require(condition: bool, message: str, errors: list[str]) -> None:
@@ -161,7 +147,17 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("config", type=pathlib.Path)
     args = parser.parse_args()
-    config = load_manifest(args.config.resolve())
+    try:
+        config = load_manifest(args.config.resolve())
+    except (ManifestSyntaxError, OSError) as error:
+        print(
+            json.dumps(
+                {"status": "invalid", "errors": [str(error)]},
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        raise SystemExit(1) from error
     errors = validate(config)
     if errors:
         print(json.dumps({"status": "invalid", "errors": errors}, ensure_ascii=False, indent=2))

--- a/skills/lovable-cleanup/references/favicon-vercel-cleanup.md
+++ b/skills/lovable-cleanup/references/favicon-vercel-cleanup.md
@@ -12,27 +12,15 @@ production URL then keeps returning a valid icon while the new bytes establish
 a new content identity; browsers that request `/favicon.ico` implicitly do not
 fall back to an old cached asset merely because the HTML link changed.
 
-If no real brand icon is ready, write a valid transparent 1×1 ICO:
+If no real brand icon is ready, use the bundled helper to write a valid
+transparent 1×1 ICO. It resolves the physical project root, rejects a symlinked
+`public/` directory or favicon target, writes an exclusive same-directory
+temporary file with no-follow semantics where available, then atomically
+renames it into place.
 
 <!-- security-allowlist: writes a 70-byte ICO into the project's public/, local only -->
 ```bash
-node -e '
-const fs = require("fs");
-const b = Buffer.alloc(6 + 16 + 40 + 8);   // header + dir entry + DIB + pixels
-b.writeUInt16LE(1, 2);   b.writeUInt16LE(1, 4);   // type, count
-b.writeUInt8(1, 6);      b.writeUInt8(1, 7);      // width, height
-b.writeUInt16LE(1, 10);  b.writeUInt16LE(32, 12); // planes, bpp
-b.writeUInt32LE(40 + 8, 14);                     // image size
-b.writeUInt32LE(22, 18);                         // offset to DIB
-b.writeUInt32LE(40, 22);   // biSize
-b.writeInt32LE(1, 26);     // width
-b.writeInt32LE(2, 30);     // height (xor + and mask)
-b.writeUInt16LE(1, 34);    // planes
-b.writeUInt16LE(32, 36);   // bpp
-b.writeUInt32LE(0, 38);    // compression
-b.writeUInt32LE(8, 42);    // sizeImage (xor 4 + and 4)
-fs.writeFileSync("public/favicon.ico", b);
-'
+node "<skill-dir>/scripts/write-transparent-favicon.js" "$PWD"
 ```
 
 ## 2 · Link all icon flavours in `index.html`

--- a/skills/lovable-cleanup/scripts/write-transparent-favicon.js
+++ b/skills/lovable-cleanup/scripts/write-transparent-favicon.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function fail(message) {
+  throw new Error(`Refusing favicon write: ${message}`);
+}
+
+function existingStat(target) {
+  try {
+    return fs.lstatSync(target);
+  } catch (error) {
+    if (error && error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function transparentIco() {
+  const bytes = Buffer.alloc(6 + 16 + 40 + 8);
+  bytes.writeUInt16LE(1, 2);
+  bytes.writeUInt16LE(1, 4);
+  bytes.writeUInt8(1, 6);
+  bytes.writeUInt8(1, 7);
+  bytes.writeUInt16LE(1, 10);
+  bytes.writeUInt16LE(32, 12);
+  bytes.writeUInt32LE(40 + 8, 14);
+  bytes.writeUInt32LE(22, 18);
+  bytes.writeUInt32LE(40, 22);
+  bytes.writeInt32LE(1, 26);
+  bytes.writeInt32LE(2, 30);
+  bytes.writeUInt16LE(1, 34);
+  bytes.writeUInt16LE(32, 36);
+  bytes.writeUInt32LE(0, 38);
+  bytes.writeUInt32LE(8, 42);
+  return bytes;
+}
+
+function main() {
+  const requestedRoot = path.resolve(process.argv[2] || process.cwd());
+  const projectRoot = fs.realpathSync(requestedRoot);
+  const publicDirectory = path.join(projectRoot, "public");
+  const publicStat = fs.lstatSync(publicDirectory);
+  if (publicStat.isSymbolicLink() || !publicStat.isDirectory()) {
+    fail("public/ must be a real directory, not a symlink or special file");
+  }
+  if (fs.realpathSync(publicDirectory) !== publicDirectory) {
+    fail("public/ resolves outside the physical project path");
+  }
+
+  const target = path.join(publicDirectory, "favicon.ico");
+  const targetStat = existingStat(target);
+  if (targetStat && targetStat.isSymbolicLink()) {
+    fail("public/favicon.ico is a symbolic link");
+  }
+  if (targetStat && !targetStat.isFile()) {
+    fail("public/favicon.ico is not a regular file");
+  }
+
+  const temporary = path.join(
+    publicDirectory,
+    `.favicon.ico.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`,
+  );
+  const flags =
+    fs.constants.O_WRONLY |
+    fs.constants.O_CREAT |
+    fs.constants.O_EXCL |
+    (fs.constants.O_NOFOLLOW || 0);
+  let descriptor;
+  try {
+    descriptor = fs.openSync(temporary, flags, 0o600);
+    fs.writeFileSync(descriptor, transparentIco());
+    fs.fsyncSync(descriptor);
+    fs.fchmodSync(descriptor, 0o644);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    fs.renameSync(temporary, target);
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    const temporaryStat = existingStat(temporary);
+    if (temporaryStat && temporaryStat.isFile()) fs.unlinkSync(temporary);
+  }
+  process.stdout.write(`Wrote ${target}\n`);
+}
+
+main();

--- a/skills/multi-source-search/scripts/validate_report.py
+++ b/skills/multi-source-search/scripts/validate_report.py
@@ -21,6 +21,11 @@ def canonical_url(value):
     """Return a conservative identity for an HTTP(S) URL, or None if invalid."""
     if not nonempty(value):
         return None
+    if any(
+        character.isspace() or ord(character) < 0x20 or ord(character) == 0x7F
+        for character in value
+    ):
+        return None
     try:
         parsed = urlsplit(value)
         hostname = parsed.hostname

--- a/skills/omp-delegate/SKILL.md
+++ b/skills/omp-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: omp-delegate
 description: Delegate coding tasks to Oh My Pi (`omp`) only when the user explicitly
   requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: opencode-delegate
 description: Delegate coding tasks to the OpenCode CLI only when the user explicitly
   requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/pentest-tools/references/pentest-ai-agents-matrix.md
+++ b/skills/pentest-tools/references/pentest-ai-agents-matrix.md
@@ -10,11 +10,14 @@
 
 ## 安装方式（外部可选）
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/0xSteph/pentest-ai-agents/main/install.sh | bash  # security-allowlist: curl-pipe-bash
-```
+默认只参考其 prompt 模式，不安装外部代码。不得从可变的 `main` 分支
+下载并直接执行安装脚本，也不得把下载内容通过管道交给 shell。
 
-或者只参考其 prompt 模式，不实际安装。
+如果用户明确要求安装，先在仓库页面选择并记录一个完整的 40 位 commit
+SHA，在私有审查目录中下载该 commit 的完整源码，核对仓库身份、许可证、
+文件清单、安装脚本及其后续下载。只有在展示确切变更和命令并获得单独批准
+后，才可从已审查的本地副本执行；任一依赖仍指向分支、标签、`latest` 或未审查
+远程脚本时必须停止。
 
 ---
 

--- a/skills/pi-delegate/SKILL.md
+++ b/skills/pi-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: pi-delegate
 description: Delegate coding tasks to the Pi coding agent CLI (`pi`) only when the
   user explicitly requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/qoder-delegate/SKILL.md
+++ b/skills/qoder-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: qoder-delegate
 description: Delegate coding tasks to the Qoder CLI (`qodercli`) only when the user
   explicitly requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/unsloth-finetuning/SKILL.md
+++ b/skills/unsloth-finetuning/SKILL.md
@@ -72,10 +72,20 @@ libraries at import time; importing them first silently disables the optimizatio
 
 ```python
 import unsloth  # must be first
+import os
+import re
 from unsloth import FastLanguageModel
 
+def reviewed_revision(variable):
+    revision = os.environ.get(variable, "")
+    if re.fullmatch(r"[0-9a-fA-F]{40}", revision) is None:
+        raise RuntimeError(f"{variable} must be a reviewed full 40-character Hub commit SHA")
+    return revision.lower()
+
+model_revision = reviewed_revision("UNSLOTH_MODEL_REVISION")
 model, tokenizer = FastLanguageModel.from_pretrained(
     model_name = "unsloth/Qwen3-8B",
+    revision = model_revision,
     max_seq_length = 2048,
     load_in_4bit = True,
     dtype = None,  # auto-detects bf16 where supported
@@ -87,6 +97,9 @@ Pick the loader that matches the modality: `FastLanguageModel` for text-only cau
 
 The `unsloth/` Hub namespace holds pre-quantized copies that download faster and skip a local
 quantization pass. Upstream repos such as `Qwen/` or `meta-llama/` work identically.
+Before setting `UNSLOTH_MODEL_REVISION`, inspect that exact Hub commit and obtain approval for the
+download. Record the repository and full revision with the run; never substitute a branch, tag,
+range, or moving default.
 
 ### Step 3: Fix the chat template before training
 
@@ -194,20 +207,35 @@ cannot be cleanly re-quantized afterwards.
 
 ```python
 import unsloth
+import os
+import re
 from unsloth import FastLanguageModel
 from unsloth.chat_templates import get_chat_template, train_on_responses_only
 from datasets import load_dataset
 from trl import SFTTrainer, SFTConfig
 
+def reviewed_revision(variable):
+    revision = os.environ.get(variable, "")
+    if re.fullmatch(r"[0-9a-fA-F]{40}", revision) is None:
+        raise RuntimeError(f"{variable} must be a reviewed full 40-character Hub commit SHA")
+    return revision.lower()
+
+model_revision = reviewed_revision("UNSLOTH_MODEL_REVISION")
+dataset_revision = reviewed_revision("UNSLOTH_DATASET_REVISION")
 model, tokenizer = FastLanguageModel.from_pretrained(
     model_name = "unsloth/Qwen3-8B",
+    revision = model_revision,
     max_seq_length = 2048,
     load_in_4bit = True,
 )
 model = FastLanguageModel.get_peft_model(model, r = 16, lora_alpha = 16)
 
 tokenizer = get_chat_template(tokenizer, chat_template = "qwen3")
-dataset = load_dataset("mlabonne/FineTome-100k", split = "train[:5000]")
+dataset = load_dataset(
+    "mlabonne/FineTome-100k",
+    revision = dataset_revision,
+    split = "train[:5000]",
+)
 
 trainer = SFTTrainer(
     model = model,
@@ -239,11 +267,21 @@ Load with `fast_inference=True` to route sampling through vLLM in the same proce
 
 ```python
 import unsloth
+import os
+import re
 from unsloth import FastLanguageModel
 from trl import GRPOTrainer, GRPOConfig
 
+def reviewed_revision(variable):
+    revision = os.environ.get(variable, "")
+    if re.fullmatch(r"[0-9a-fA-F]{40}", revision) is None:
+        raise RuntimeError(f"{variable} must be a reviewed full 40-character Hub commit SHA")
+    return revision.lower()
+
+model_revision = reviewed_revision("UNSLOTH_MODEL_REVISION")
 model, tokenizer = FastLanguageModel.from_pretrained(
     model_name = "unsloth/Qwen3-4B",
+    revision = model_revision,
     max_seq_length = 1024,
     load_in_4bit = True,
     fast_inference = True,       # vLLM sampling backend
@@ -307,8 +345,13 @@ GRPO learning rates sit roughly two orders of magnitude below SFT. Reward functi
   committed token grants write access to every model the account owns.
 - Fine-tuning reproduces the training data's content and biases in the weights. Confirm the
   dataset is licensed for training and free of secrets before starting.
+- Pin every Hub model and dataset to a reviewed full commit SHA, obtain approval before changing
+  either revision, and record both values with the training artifact. Prefer the verified local
+  cache for repeat runs instead of re-resolving network defaults.
 - GGUF export builds llama.cpp from source on first use, compiling third-party code and
-  requiring network access. Expect it to be slow and to need a working toolchain.
+  requiring network access. Before the first export, identify and review the exact llama.cpp
+  revision that will be built; do not permit an unattended moving-revision fetch. Prefer a
+  user-approved, full-commit-pinned local toolchain and cache.
 - Unsloth is dual-licensed: the core package is Apache-2.0, while optional components such as
   the Studio UI are AGPL-3.0. Check a component's license before redistributing it.
 

--- a/skills/vibe-delegate/SKILL.md
+++ b/skills/vibe-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: vibe-delegate
 description: Delegate coding tasks to the Mistral Vibe CLI (`vibe`) only when the
   user explicitly requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/warp-delegate/SKILL.md
+++ b/skills/warp-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: warp-delegate
 description: Delegate coding tasks to the Warp Agent CLI (`oz`) only when the user
   explicitly requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/skills/zcode-delegate/SKILL.md
+++ b/skills/zcode-delegate/SKILL.md
@@ -2,7 +2,7 @@
 name: zcode-delegate
 description: Delegate coding tasks to the Z.AI ZCode CLI only when the user explicitly
   requests it, while the orchestrator retains review and landing responsibility.
-risk: safe
+risk: critical
 category: agent-orchestration
 source: https://github.com/amElnagdy/delegate-skills
 source_repo: amElnagdy/delegate-skills

--- a/tools/scripts/tests/security_findings_regressions.test.js
+++ b/tools/scripts/tests/security_findings_regressions.test.js
@@ -4,6 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const test = require("node:test");
+const { createSymlinkOrSkip } = require("./symlink-test-utils");
 
 const repoRoot = path.resolve(__dirname, "../../..");
 const telegramScript = path.join(
@@ -12,6 +13,13 @@ const telegramScript = path.join(
   "telegram-bot-messaging",
   "scripts",
   "telegram.sh",
+);
+const faviconScript = path.join(
+  repoRoot,
+  "skills",
+  "lovable-cleanup",
+  "scripts",
+  "write-transparent-favicon.js",
 );
 
 function read(relativePath) {
@@ -215,4 +223,124 @@ test("BrowserAct never delegates its operating policy to mutable provider guides
   assert.doesNotMatch(skill, /^browser-act get-skills\b/m);
   assert.match(skill, /checked-in Skill remains the complete operating policy/);
   assert.match(skill, /browser-act <subcommand> --help/);
+});
+
+test("Agent QA authoring never fetches a moving npm package at runtime", () => {
+  const skill = read("skills/agent-qa-authoring/SKILL.md");
+  assert.doesNotMatch(skill, /npx\s+--yes\s+agent-qa/);
+  assert.match(skill, /already installed/);
+  assert.match(skill, /Do not fetch and execute the package at\s+runtime/);
+});
+
+test("write-capable PR, cloud, and delegate skills are classified critical", () => {
+  const skills = [
+    "babysit-pr",
+    "atlas-cloud-media",
+    "aider-delegate",
+    "agy-delegate",
+    "claude-delegate",
+    "cline-delegate",
+    "codex-delegate",
+    "commandcode-delegate",
+    "copilot-delegate",
+    "cursor-delegate",
+    "grok-delegate",
+    "kimi-delegate",
+    "omp-delegate",
+    "opencode-delegate",
+    "pi-delegate",
+    "qoder-delegate",
+    "vibe-delegate",
+    "warp-delegate",
+    "zcode-delegate",
+  ];
+  for (const skill of skills) {
+    assert.match(read(`skills/${skill}/SKILL.md`), /^risk: critical$/m, skill);
+  }
+});
+
+test("pentest agent reference never pipes a mutable installer to a shell", () => {
+  const reference = read("skills/pentest-tools/references/pentest-ai-agents-matrix.md");
+  assert.doesNotMatch(reference, /curl[^\n]*install\.sh[^\n]*\|\s*(?:bash|sh|zsh)/i);
+  assert.match(reference, /40 位 commit\s+SHA/);
+  assert.match(reference, /私有审查目录/);
+  assert.match(reference, /获得单独批准/);
+});
+
+test("Atlas examples keep sensitive intermediates private and refuse output clobber", () => {
+  const skill = read("skills/atlas-cloud-media/SKILL.md");
+  assert.match(skill, /umask 077/);
+  assert.match(skill, /mktemp -d/);
+  assert.match(skill, /chmod 700/);
+  assert.match(skill, /trap .*atlas_tmp_dir.* EXIT/);
+  assert.doesNotMatch(skill, /\/tmp\/atlas-[A-Za-z0-9_-]+\.json/);
+  assert.match(skill, /pwd -P/);
+  assert.match(skill, /mktemp "\$atlas_output_dir\/\.atlas-output/);
+  assert.match(skill, /ln -- "\$atlas_publish_tmp" "\$atlas_output_path"/);
+  assert.doesNotMatch(skill, /mv -n --/);
+});
+
+test("favicon helper writes atomically but rejects symlink targets and parents", (t) => {
+  const normalRoot = fs.mkdtempSync(path.join(os.tmpdir(), "favicon-normal-"));
+  fs.mkdirSync(path.join(normalRoot, "public"));
+  const normal = spawnSync(process.execPath, [faviconScript, normalRoot], { encoding: "utf8" });
+  assert.equal(normal.status, 0, normal.stderr);
+  assert.equal(fs.readFileSync(path.join(normalRoot, "public", "favicon.ico")).length, 70);
+
+  const targetRoot = fs.mkdtempSync(path.join(os.tmpdir(), "favicon-target-link-"));
+  fs.mkdirSync(path.join(targetRoot, "public"));
+  const outside = path.join(targetRoot, "outside.txt");
+  fs.writeFileSync(outside, "unchanged");
+  if (!createSymlinkOrSkip(outside, path.join(targetRoot, "public", "favicon.ico"))) {
+    t.skip("symlink creation unavailable");
+    return;
+  }
+  const targetResult = spawnSync(process.execPath, [faviconScript, targetRoot], { encoding: "utf8" });
+  assert.notEqual(targetResult.status, 0);
+  assert.match(targetResult.stderr, /symbolic link/);
+  assert.equal(fs.readFileSync(outside, "utf8"), "unchanged");
+
+  const parentRoot = fs.mkdtempSync(path.join(os.tmpdir(), "favicon-parent-link-"));
+  const outsideDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "favicon-outside-"));
+  if (!createSymlinkOrSkip(outsideDirectory, path.join(parentRoot, "public"), "dir")) {
+    t.skip("directory symlink creation unavailable");
+    return;
+  }
+  const parentResult = spawnSync(process.execPath, [faviconScript, parentRoot], { encoding: "utf8" });
+  assert.notEqual(parentResult.status, 0);
+  assert.match(parentResult.stderr, /real directory/);
+  assert.equal(fs.existsSync(path.join(outsideDirectory, "favicon.ico")), false);
+});
+
+test("pre-C++20 framing checks the cap before allocating the body", () => {
+  const reference = read("skills/boost-asio-pro/references/pre-cpp20.md");
+  const decode = reference.indexOf("const std::uint32_t frame_length = ntohl(len_be_)");
+  const cap = reference.indexOf("frame_length > max_frame_size", decode);
+  const allocate = reference.indexOf("body_.assign", decode);
+  assert.ok(decode >= 0 && cap > decode && allocate > cap);
+  assert.match(reference.slice(cap, allocate), /socket_\.close/);
+});
+
+test("graceful shutdown already releases aborted and finished requests exactly once", () => {
+  const skill = read("skills/graceful-shutdown/SKILL.md");
+  assert.match(skill, /let counted = true;[\s\S]*if \(!counted\) return;[\s\S]*counted = false;/);
+  assert.match(skill, /res\.on\("finish", release\);/);
+  assert.match(skill, /res\.on\("close", release\);/);
+});
+
+test("Unsloth examples require full immutable model and dataset revisions", () => {
+  const skill = read("skills/unsloth-finetuning/SKILL.md");
+  const modelCalls = [...skill.matchAll(/FastLanguageModel\.from_pretrained\(([\s\S]*?)\n\)/g)];
+  assert.equal(modelCalls.length, (skill.match(/FastLanguageModel\.from_pretrained\(/g) || []).length);
+  assert.ok(modelCalls.length >= 3);
+  for (const call of modelCalls) assert.match(call[1], /\brevision\s*=\s*model_revision/);
+
+  const datasetCalls = [...skill.matchAll(/load_dataset\(([\s\S]*?)\n\)/g)];
+  assert.equal(datasetCalls.length, (skill.match(/load_dataset\(/g) || []).length);
+  assert.ok(datasetCalls.length >= 1);
+  for (const call of datasetCalls) assert.match(call[1], /\brevision\s*=\s*dataset_revision/);
+
+  assert.match(skill, /\[0-9a-fA-F\]\{40\}/);
+  assert.match(skill, /obtain approval before changing[\s\S]*revision/);
+  assert.match(skill, /full-commit-pinned local toolchain/);
 });

--- a/tools/scripts/tests/test_liuguang_manifest_security.py
+++ b/tools/scripts/tests/test_liuguang_manifest_security.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+SCRIPT_DIR = ROOT / "skills" / "liuguang-banlan-ui" / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from manifest_parser import MAX_MANIFEST_BYTES, ManifestSyntaxError, load_manifest  # noqa: E402
+
+
+class LiuguangManifestSecurityTests(unittest.TestCase):
+    def test_bundled_manifests_parse_without_javascript_execution(self):
+        starter = ROOT / "skills" / "liuguang-banlan-ui" / "assets" / "starter"
+        self.assertEqual(load_manifest(starter / "opal" / "theme-config.js")["mode"], "opal")
+        self.assertEqual(
+            load_manifest(starter / "obsidian" / "theme-config.js")["mode"],
+            "obsidian",
+        )
+
+    def test_trailing_code_is_rejected_without_running_it(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            sentinel = root / "must-not-exist"
+            manifest = root / "theme-config.js"
+            manifest.write_text(
+                "window.SPECTRAL_THEME = {mode: \"opal\"};\n"
+                f"require(\"fs\").writeFileSync({str(sentinel)!r}, \"owned\");\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(ManifestSyntaxError):
+                load_manifest(manifest)
+            self.assertFalse(sentinel.exists())
+
+    def test_expressions_and_duplicate_keys_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = pathlib.Path(directory) / "theme-config.js"
+            for source in (
+                "window.SPECTRAL_THEME = {seed: (() => 1)()};",
+                "window.SPECTRAL_THEME = {mode: \"opal\", mode: \"obsidian\"};",
+            ):
+                manifest.write_text(source, encoding="utf-8")
+                with self.assertRaises(ManifestSyntaxError):
+                    load_manifest(manifest)
+
+    def test_oversized_manifest_is_rejected_before_parsing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = pathlib.Path(directory) / "theme-config.js"
+            manifest.write_bytes(b" " * (MAX_MANIFEST_BYTES + 1))
+            with self.assertRaisesRegex(ManifestSyntaxError, "size limit"):
+                load_manifest(manifest)
+
+    def test_pathologically_long_integer_has_a_bounded_parser_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = pathlib.Path(directory) / "theme-config.js"
+            manifest.write_text(
+                "window.SPECTRAL_THEME = {seed: " + ("9" * 5000) + "};",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ManifestSyntaxError, "numeric literal"):
+                load_manifest(manifest)
+
+    def test_validator_accepts_both_bundled_manifests(self):
+        validator = SCRIPT_DIR / "validate_manifest.py"
+        starter = ROOT / "skills" / "liuguang-banlan-ui" / "assets" / "starter"
+        for mode in ("opal", "obsidian"):
+            result = subprocess.run(
+                [sys.executable, str(validator), str(starter / mode / "theme-config.js")],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_both_helpers_share_the_static_loader(self):
+        for name in ("validate_manifest.py", "measure_preview.py"):
+            source = (SCRIPT_DIR / name).read_text(encoding="utf-8")
+            self.assertIn("from manifest_parser import", source)
+            self.assertNotIn("subprocess", source)
+            self.assertNotIn("require(require", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/tests/test_multi_source_search_report.py
+++ b/tools/scripts/tests/test_multi_source_search_report.py
@@ -85,6 +85,15 @@ class MultiSourceReportTests(unittest.TestCase):
         result = self.run_report(payload)
         self.assertIn("duplicate source URL after normalization", result.stderr)
 
+    def test_rejects_raw_whitespace_and_control_characters_before_url_parsing(self):
+        for character in ("\n", "\r", "\t", "\x00", "\x1f", "\x7f", " "):
+            with self.subTest(character=repr(character)):
+                payload = copy.deepcopy(report())
+                payload["sources"][0]["url"] = f"https://example.org{character}.evil.test/a"
+                result = self.run_report(payload)
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("must be an HTTP(S) URL", result.stderr)
+
     def test_rejects_high_confidence_conflict(self):
         payload = report()
         payload["claims"][0]["conflict"] = True

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,19 @@
+# Codex security findings remediation - 2026-08-31
+
+- Re-evaluated all 14 exported Codex Security records against the current
+  protected `main`: 13 remained actionable and the graceful-shutdown counter
+  fix was already present and byte-identical in both plugin mirrors.
+- Replaced executable theme-manifest validation with a bounded static parser;
+  removed moving package and pipe-to-shell fallbacks; confined Atlas artifacts;
+  made favicon replacement symlink-safe and atomic; capped network frames before
+  allocation; rejected raw URL controls; and pinned model/dataset inputs by full
+  reviewed Hub revisions.
+- Corrected the risk metadata for Atlas, autonomous PR babysitting, and all 17
+  write-capable delegate skills, with focused regression coverage for each
+  affected trust boundary.
+- Kept the repair source-only. Generated registries, catalog metadata, and both
+  plugin distributions remain owned by protected canonical synchronization.
+
 # FLOSS/fund sustainability application - 2026-08-31
 
 - Added a public `funding.json` manifest using the current v1.1.0 schema for a


### PR DESCRIPTION
# Pull Request Description

Resolve the full exported security-findings batch from 2026-08-31 without including generated registry state.

This source PR:

- replaces JavaScript execution in the Liuguang Banlan manifest helpers with a strict, size-bounded static parser;
- removes the mutable `npx` fallback from Agent QA runtime guidance;
- corrects `risk:` metadata for the babysit, Atlas, and delegate skills;
- hardens pentest bootstrap guidance against mutable pipe-to-shell execution;
- hardens Atlas temporary-file and final-output handling against symlink and overwrite races;
- adds a symlink-safe favicon writer for Lovable Cleanup;
- enforces the Boost.Asio frame cap before allocation;
- rejects raw control characters and whitespace before URL parsing;
- pins Unsloth model and dataset revisions and requires approval/provenance checks.

The remaining exported item, graceful-shutdown finish-only cleanup, was already fixed on the protected base and was verified byte-for-byte across its existing mirrors.

Generated catalogs and plugin mirrors are intentionally excluded; the protected canonical-sync lane will regenerate them after this source PR merges.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

No linked issue; this is based on the exported Codex security findings supplied by the maintainer.

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [x] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: I have added the source credit in `README.md` (if applicable).
- [x] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Verification

- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run check:warning-budget`
- `npm run audit:maintainer`
- focused security regression tests
- disposable `npm run chain` followed by the complete `npm run test` suite (114 local test files)
- `npm run pr:evidence -- --base c559ef43b90e9ce4059a50580991f3bad8909ea1 --head 1d6b828d4e8702470588a886b61d972b06d28f33` (`blocking: false`)

## Screenshots (if applicable)

Not applicable.
