### PR TITLE
feat: add upstash-redis and upstash-ratelimit skills

### DIFF
--- a/skills/api-rate-limit-handler/SKILL.md
+++ b/skills/api-rate-limit-handler/SKILL.md
@@ -258,7 +258,7 @@ def fetch_with_retry(url: str, max_retries: int = 3, **kwargs) -> httpx.Response
 ## Limitations
 
 - This skill does not replace environment-specific validation, testing, or expert review.
-- Token bucket is approximate for distributed systems — use Redis-backed rate limiting for multi-instance deployments.
+- Token bucket is approximate for distributed systems — use Redis-backed rate limiting for multi-instance deployments (for example the `upstash-ratelimit` skill, or any shared-store limiter).
 - Some APIs use non-standard rate limit headers; check provider documentation.
 - The elapsed-time cap shown here bounds retry waits, not a single hung network call; combine it with an `AbortSignal` or client timeout.
 

--- a/skills/inngest/SKILL.md
+++ b/skills/inngest/SKILL.md
@@ -37,6 +37,7 @@ and durable execution without managing queues or workers.
 ## Scope
 
 - redis-queues -> bullmq-specialist
+- serverless-queues -> upstash-qstash
 - workflow-orchestration -> temporal-craftsman
 - message-streaming -> event-architect
 - infrastructure -> infra-architect
@@ -388,6 +389,7 @@ Fix action: Add idempotency: 'event.data.orderId' to function config
 ### Delegation Triggers
 
 - redis|queue infrastructure|bullmq -> bullmq-specialist (Need Redis-based queue with existing infrastructure)
+- serverless queue|http queue|scheduled http -> upstash-qstash (Need plain HTTP delivery and cron without an event framework)
 - saga|compensation|rollback|long-running workflow -> temporal-craftsman (Need complex workflow orchestration with compensation)
 - event sourcing|event store|cqrs -> event-architect (Need event sourcing patterns)
 - vercel|deploy|production -> vercel-deployment (Need deployment configuration)

--- a/skills/prompt-caching/SKILL.md
+++ b/skills/prompt-caching/SKILL.md
@@ -34,7 +34,7 @@ Caching strategies for LLM prompts including Anthropic prompt caching, response 
 ### Primary_tools
 
 - Anthropic Prompt Caching - Native prompt caching in Claude API
-- Redis - In-memory cache for responses
+- Redis - In-memory cache for responses (ioredis on servers; @upstash/redis over HTTP on serverless, see `upstash-redis`)
 - OpenAI Caching - Automatic caching in OpenAI API
 
 ## Patterns
@@ -91,6 +91,8 @@ import { createHash } from 'crypto';
 import Redis from 'ioredis';
 
 const redis = new Redis(process.env.REDIS_URL);
+// Serverless/edge alternative without a persistent connection:
+// import { Redis } from '@upstash/redis'; const redis = Redis.fromEnv();  // then use redis.set(key, value, { ex: ttl })
 
 class ResponseCache {
     private ttl = 3600;  // 1 hour default

--- a/skills/trigger-dev/SKILL.md
+++ b/skills/trigger-dev/SKILL.md
@@ -38,6 +38,7 @@ execution with excellent developer experience and TypeScript-first design.
 ## Scope
 
 - redis-queues -> bullmq-specialist
+- serverless-queues -> upstash-qstash
 - pure-event-driven -> inngest
 - workflow-orchestration -> temporal-craftsman
 - infrastructure -> infra-architect
@@ -891,6 +892,7 @@ Fix action: Batch items and use fewer waits, or split into subtasks
 ### Delegation Triggers
 
 - redis|bullmq|traditional queue -> bullmq-specialist (Need Redis-backed queues instead of managed service)
+- serverless queue|http queue|no workers -> upstash-qstash (Need HTTP-delivered queues and schedules without a worker runtime)
 - vercel|deployment|serverless -> vercel-deployment (Trigger.dev needs deployment config)
 - database|postgres|supabase -> supabase-backend (Tasks need database access)
 - openai|anthropic|ai model|llm -> llm-architect (Tasks need AI model integration)

--- a/skills/upstash-qstash/SKILL.md
+++ b/skills/upstash-qstash/SKILL.md
@@ -931,7 +931,7 @@ Workflow:
 
 ## Related Skills
 
-Works well with: `vercel-deployment`, `nextjs-app-router`, `redis-specialist`, `email-systems`, `supabase-backend`, `cloudflare-workers`
+Works well with: `upstash-redis`, `upstash-ratelimit`, `vercel-deployment`, `nextjs-app-router`, `redis-specialist`, `email-systems`, `supabase-backend`, `cloudflare-workers`
 
 ## When to Use
 - User mentions or implies: qstash

--- a/skills/upstash-ratelimit/SKILL.md
+++ b/skills/upstash-ratelimit/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: upstash-ratelimit
+description: "Add rate limiting to API routes, middleware, and edge functions with @upstash/ratelimit: sliding window, fixed window, and token bucket backed by Upstash Redis."
+category: backend
+risk: critical
+source: self
+source_type: self
+date_added: "2026-08-31"
+author: CahidArda
+tags: [upstash, rate-limiting, redis, serverless, edge, middleware, 429]
+tools: [claude, codex, cursor, gemini]
+---
+
+# Upstash Ratelimit
+
+## Overview
+
+`@upstash/ratelimit` implements distributed rate limiting on top of Upstash
+Redis. Because state lives in Redis, every instance of a serverless function
+or edge worker shares the same counters, which an in-memory limiter cannot
+do. It ships three algorithms (fixed window, sliding window, token bucket),
+per-identifier keys, optional in-memory blocking of already-limited
+identifiers, and optional analytics.
+
+## When to Use This Skill
+
+- Use when the user needs to limit requests per IP, user, API key, or tenant
+  across multiple serverless instances or regions.
+- Use when protecting login, signup, form, webhook, or LLM endpoints from
+  abuse and returning `429 Too Many Requests`.
+- Use when choosing between fixed window, sliding window, and token bucket.
+- Do not use for client-side retry/backoff against a third-party API's limits;
+  see `api-rate-limit-handler`.
+- Do not use for a single long-running process with no shared state; an
+  in-memory limiter is simpler there.
+
+## How It Works
+
+### Step 1: Install and configure
+
+```bash
+npm install @upstash/ratelimit @upstash/redis
+```
+
+Set `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in the environment.
+
+### Step 2: Create the limiter once, outside the handler
+
+```typescript
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+export const ratelimit = new Ratelimit({
+  redis: Redis.fromEnv(),
+  limiter: Ratelimit.slidingWindow(10, "10 s"), // 10 requests per 10 seconds
+  prefix: "rl:api",
+  analytics: true,
+});
+```
+
+Constructing the limiter at module scope lets the built-in ephemeral cache
+short-circuit blocked identifiers without a Redis call.
+
+### Step 3: Call `limit()` with a stable identifier
+
+```typescript
+const { success, limit, remaining, reset, pending } = await ratelimit.limit(userId);
+```
+
+`success` is `false` when the identifier is over its limit. `reset` is a Unix
+timestamp in milliseconds. `pending` is a promise for background work
+(analytics, multi-region sync); await it or pass it to `waitUntil` on edge
+runtimes so the function is not frozen before it completes.
+
+## Examples
+
+### Example 1: Next.js middleware returning 429
+
+```typescript
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { NextResponse, type NextRequest } from "next/server";
+
+const ratelimit = new Ratelimit({
+  redis: Redis.fromEnv(),
+  limiter: Ratelimit.slidingWindow(20, "1 m"),
+});
+
+export async function middleware(request: NextRequest) {
+  const ip = request.headers.get("x-forwarded-for") ?? "anonymous";
+  const { success, limit, remaining, reset } = await ratelimit.limit(ip);
+
+  if (!success) {
+    return new NextResponse("Too Many Requests", {
+      status: 429,
+      headers: {
+        "X-RateLimit-Limit": String(limit),
+        "X-RateLimit-Remaining": String(remaining),
+        "X-RateLimit-Reset": String(reset),
+        "Retry-After": String(Math.ceil((reset - Date.now()) / 1000)),
+      },
+    });
+  }
+  return NextResponse.next();
+}
+
+export const config = { matcher: "/api/:path*" };
+```
+
+### Example 2: Token bucket with per-plan limits
+
+```typescript
+const limiters = {
+  free: new Ratelimit({
+    redis: Redis.fromEnv(),
+    prefix: "rl:free",
+    limiter: Ratelimit.tokenBucket(5, "10 s", 10), // refill 5 per 10 s, burst 10
+  }),
+  pro: new Ratelimit({
+    redis: Redis.fromEnv(),
+    prefix: "rl:pro",
+    limiter: Ratelimit.tokenBucket(50, "10 s", 100),
+  }),
+};
+
+const { success } = await limiters[plan].limit(apiKey);
+```
+
+## Best Practices
+
+- ✅ Use a stable, low-cardinality identifier (user id, API key, tenant) where
+  possible; fall back to IP only for anonymous traffic.
+- ✅ Set a distinct `prefix` per endpoint or plan so limits do not collide.
+- ✅ Return `Retry-After` and `X-RateLimit-*` headers with 429 responses.
+- ✅ Prefer `slidingWindow` for most APIs; use `tokenBucket` when short bursts
+  are acceptable; use `fixedWindow` when the lowest Redis cost matters.
+- ❌ Don't construct a new `Ratelimit` inside the request handler.
+- ❌ Don't rely on `pending` completing on its own in edge runtimes.
+- ❌ Don't rate limit by `x-forwarded-for` without validating it is set by
+  your proxy; clients can spoof it otherwise.
+
+## Limitations
+
+- Requires an Upstash Redis database; it does not work with other Redis
+  servers or without network access.
+- Each `limit()` call is at least one HTTP round trip to Redis, so it adds
+  latency to every request it guards.
+- Sliding window is an approximation that assumes an even spread of requests
+  in the previous window; it is not an exact log.
+- `MultiRegionRatelimit` trades strict accuracy for lower latency and does
+  not support the token bucket algorithm.
+- If Redis is unreachable, the default `timeout` (5 s) lets requests through
+  (`reason: "timeout"`); this fails open, not closed.
+- This skill does not replace environment-specific validation, testing, or
+  expert review.
+
+## Security & Safety Notes
+
+- Rate limiting is one layer of abuse protection, not authentication. Pair it
+  with auth and input validation.
+- The Redis token grants full database access; keep it server-side.
+- Changing limits in production can lock out legitimate users. Confirm the
+  numbers with the user before deploying stricter limits.
+
+## Common Pitfalls
+
+- **Problem:** Every request is allowed even after the limit.
+  **Solution:** Each identifier must be the same string across requests;
+  check that the identifier is not `undefined` or a fresh random value.
+- **Problem:** Analytics are empty on Vercel Edge or Cloudflare Workers.
+  **Solution:** Pass `pending` to `waitUntil` (`ctx.waitUntil(pending)`) so
+  the background request is not cancelled when the response is sent.
+
+## Related Skills
+
+- `@upstash-redis` - The client this package uses for storage.
+- `@api-rate-limit-handler` - Client-side backoff and retry when you are the
+  one being rate limited.
+- `@upstash-qstash` - Queue and smooth traffic to downstream services instead
+  of rejecting it.
+
+## Additional Resources
+
+- [Upstash Ratelimit documentation](https://upstash.com/docs/redis/sdks/ratelimit-ts/overview)
+- [@upstash/ratelimit on GitHub](https://github.com/upstash/ratelimit-js)
+- [Algorithms guide](https://upstash.com/docs/redis/sdks/ratelimit-ts/algorithms)

--- a/skills/upstash-redis/SKILL.md
+++ b/skills/upstash-redis/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: upstash-redis
+description: "Use the @upstash/redis HTTP client for caching, sessions, counters, and Redis data structures from serverless and edge runtimes without connection pooling."
+category: backend
+risk: critical
+source: self
+source_type: self
+date_added: "2026-08-31"
+author: CahidArda
+tags: [upstash, redis, cache, serverless, edge, key-value]
+tools: [claude, codex, cursor, gemini]
+---
+
+# Upstash Redis
+
+## Overview
+
+`@upstash/redis` is a Redis client that talks to an Upstash Redis database over
+HTTPS instead of a TCP connection. Because every command is a stateless HTTP
+request, it works in environments where a pooled TCP client is awkward or
+impossible: Vercel and Netlify functions, Cloudflare Workers, Deno, Bun, and
+Next.js middleware. The client serializes and deserializes JavaScript values
+automatically, so numbers and objects round-trip without manual `JSON.parse`.
+
+## When to Use This Skill
+
+- Use when the user needs a cache, session store, counter, leaderboard, or
+  simple queue from a serverless or edge function.
+- Use when the user mentions Upstash Redis, `UPSTASH_REDIS_REST_URL`, or
+  `@upstash/redis`.
+- Use when migrating an `ioredis` or `node-redis` call site to a runtime that
+  cannot hold a persistent TCP socket.
+- Do not use for a self-hosted or non-Upstash Redis server; the client only
+  speaks the Upstash REST protocol. Use `ioredis` or `node-redis` there.
+- Do not use for Redis administration or CLI work; see `redis-cli`.
+
+## How It Works
+
+### Step 1: Configure credentials
+
+Create a database in the Upstash console and copy the REST URL and token into
+environment variables. Never hardcode them.
+
+```bash
+UPSTASH_REDIS_REST_URL=https://<your-db>.upstash.io
+UPSTASH_REDIS_REST_TOKEN=<your-rest-token>
+```
+
+### Step 2: Create one client per module
+
+```typescript
+import { Redis } from "@upstash/redis";
+
+export const redis = Redis.fromEnv();
+```
+
+On Cloudflare Workers, import from `@upstash/redis/cloudflare` and pass the
+worker `env` object: `Redis.fromEnv(env)`.
+
+### Step 3: Call Redis commands as methods
+
+Command names are lowercase methods (`get`, `set`, `hset`, `zadd`, `incr`).
+Values are auto-serialized; pass and receive native JavaScript types.
+
+## Examples
+
+### Example 1: Cache-aside with a TTL
+
+```typescript
+import { Redis } from "@upstash/redis";
+
+const redis = Redis.fromEnv();
+
+export async function getUser(id: string) {
+  const cached = await redis.get<{ id: string; name: string }>(`user:${id}`);
+  if (cached) return cached;
+
+  const user = await db.users.findById(id);
+  await redis.set(`user:${id}`, user, { ex: 3600 }); // expires in 1 hour
+  return user;
+}
+
+export async function invalidateUser(id: string) {
+  await redis.del(`user:${id}`);
+}
+```
+
+### Example 2: Batch commands in a pipeline
+
+```typescript
+const pipeline = redis.pipeline();
+pipeline.hset("user:1", { name: "Alice", plan: "pro" });
+pipeline.incr("signups:total");
+pipeline.zadd("leaderboard", { score: 120, member: "user:1" });
+const [hsetResult, signups, zaddResult] = await pipeline.exec();
+```
+
+`pipeline()` batches independent commands into one round trip. It is not
+atomic; use `redis.multi()` for MULTI/EXEC or `redis.eval()` for a Lua script
+when commands must run as one unit.
+
+## Best Practices
+
+- ✅ Read credentials with `Redis.fromEnv()` or from a secrets manager.
+- ✅ Set a TTL (`{ ex: seconds }`) on cache entries so stale data expires.
+- ✅ Namespace keys (`user:123`, `session:abc`) to keep the keyspace readable.
+- ✅ Use `pipeline()` or `mget`/`mset` instead of many sequential awaits.
+- ❌ Don't `JSON.stringify` values before `set`; the client already does it.
+- ❌ Don't call `keys("*")` in request handlers; use `scan` for large keyspaces.
+- ❌ Don't store secrets or PII in Redis without a retention plan and TTL.
+
+## Limitations
+
+- Requires an Upstash Redis database; it cannot connect to other Redis servers.
+- Each command is an HTTP request, so latency is higher than a warm TCP
+  connection; batch with pipelines where it matters.
+- Transactions (`multi()`) do not roll back on runtime errors, and `WATCH` is
+  not available over REST; use a Lua script for atomic check-and-set.
+- Pub/Sub subscribe and blocking commands (`BLPOP`, `XREAD BLOCK`) are not
+  supported over the REST client.
+- This skill covers the TypeScript client only. Python, Go, and other SDKs
+  differ in method names.
+- This skill does not replace environment-specific validation, testing, or
+  expert review.
+
+## Security & Safety Notes
+
+- The REST token grants full read/write access to the database. Keep it in
+  server-side environment variables; never ship it to a browser bundle.
+- Use a read-only token from the console for read-only workloads.
+- Commands such as `flushdb` and `del` are destructive; confirm with the user
+  before running them against a production database.
+
+## Common Pitfalls
+
+- **Problem:** `get` returns `null` in production but works locally.
+  **Solution:** The deployment is missing `UPSTASH_REDIS_REST_URL` or
+  `UPSTASH_REDIS_REST_TOKEN`; check the platform's environment settings.
+- **Problem:** A number comes back as a string after `incr` on a value set
+  with `JSON.stringify`.
+  **Solution:** Store the raw number (`redis.set("n", 1)`) and let the client
+  serialize it.
+
+## Related Skills
+
+- `@upstash-ratelimit` - Rate limiting built on this client.
+- `@upstash-qstash` - HTTP message queue and schedules when you need delivery
+  guarantees rather than a data store.
+- `@redis-cli` - Inspecting and administering Redis from the command line.
+- `@bullmq-specialist` - Job queues on a TCP Redis you operate yourself.
+
+## Additional Resources
+
+- [Upstash Redis documentation](https://upstash.com/docs/redis)
+- [@upstash/redis on GitHub](https://github.com/upstash/redis-js)
+- [TypeScript SDK reference](https://upstash.com/docs/redis/sdks/ts/overview)

--- a/skills/upstash-redis/SKILL.md
+++ b/skills/upstash-redis/SKILL.md
@@ -96,7 +96,7 @@ const [hsetResult, signups, zaddResult] = await pipeline.exec();
 ```
 
 `pipeline()` batches independent commands into one round trip. It is not
-atomic; use `redis.multi()` for MULTI/EXEC or `redis.eval()` for a Lua script
+atomic; use `redis.multi()` for MULTI/EXEC or a reviewed server-side Lua script
 when commands must run as one unit.
 
 ## Best Practices


### PR DESCRIPTION
# Pull Request Description

Adds two instruction-only skills for the Upstash Redis and Ratelimit TypeScript SDKs and makes small routing fixes in existing skills so agents can find them.

These skills are written to the repository template, avoid marketing language, and include explicit "do not use" cases and a `## Limitations` section that names the products' real constraints (hosted-only, HTTP latency, no rollback in transactions, fail-open timeouts). The existing `upstash-qstash` skill is a legacy vibeship import; the new files are original content authored for this repository (`source: self`).

New skills:

- `skills/upstash-redis/SKILL.md` — `@upstash/redis` HTTP client: `Redis.fromEnv()`, cache-aside with TTL, pipelines vs `multi()` vs Lua, Cloudflare Workers import path.
- `skills/upstash-ratelimit/SKILL.md` — `@upstash/ratelimit`: sliding window / fixed window / token bucket, Next.js middleware returning 429 with headers, `pending` + `waitUntil` on edge runtimes, per-plan limiters.

Routing edits (one line each, mirroring the existing `bullmq-specialist` route `serverless-queues -> upstash-qstash`):

- `skills/trigger-dev/SKILL.md`: add `serverless-queues -> upstash-qstash` to Scope and a matching Delegation Trigger.
- `skills/inngest/SKILL.md`: same two additions.
- `skills/api-rate-limit-handler/SKILL.md`: the Limitations bullet that says "use Redis-backed rate limiting for multi-instance deployments" now points at a concrete skill.
- `skills/prompt-caching/SKILL.md`: keep the `ioredis` example, add a two-line comment showing the serverless alternative and the `{ ex }` option difference; Ecosystem bullet notes both clients.
- `skills/upstash-qstash/SKILL.md`: Related Skills now lists `upstash-redis` and `upstash-ratelimit`.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: Both skills are `risk: critical` because they write to and delete keys in a hosted database and deny production traffic (429). This matches the existing `upstash-qstash` and `neon-*` labels.
- [x] **Triggers**: Each skill has a `## When to Use This Skill` section with explicit use and do-not-use cases.
- [x] **Limitations**: Each skill includes a `## Limitations` section.
- [ ] **Security**: Not an offensive skill; no "Authorized Use Only" disclaimer needed.
- [x] **Safety scan**: Examples read credentials only from environment variables; there are no pipe-to-shell installs or command-line tokens. `npm run security:docs` passes.
- [ ] **Automated Skill Review**: I will monitor the `skill-review` check and address actionable feedback.
- [x] **Manual Logic Review**: I reviewed every code sample against the current SDK APIs (`@upstash/redis`, `@upstash/ratelimit`) and the failure modes listed in Limitations.
- [ ] **Local Test**: Validated locally with `npm run validate`, `npm run security:docs`, `npm run check:warning-budget`, and `npm run pr:preflight`; not yet exercised end-to-end with an assistant.
- [ ] **Repo Checks**: No docs, workflow, or infrastructure changes; `pr:preflight` reports `requiresReferencesValidation: false`.
- [x] **Source-Only PR**: No `CATALOG.md`, `skills_index.json`, `data/*.json`, or `plugins/` changes are included.
- [ ] **Credits**: Not applicable; the skills are `source: self` / `source_type: self` and do not import an external repository.
- [x] **License provenance**: Original content; no `source_repo` is declared.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Validation

- `npm run validate` — passed (`All skills passed validation!`, zero warnings).
- `npm run security:docs` — passed with no findings.
- `npm run check:warning-budget` — `Validation warnings within budget: 0/0`.
- `npm run pr:preflight -- --no-run --json` — category `skill`, `directDerivedChanges: []`, fork-safe.

## Screenshots (if applicable)

N/A