### PR TITLE
feat: add BulkPublish social media skill

### DIFF
--- a/skills/bulkpublish-social-media-content/SKILL.md
+++ b/skills/bulkpublish-social-media-content/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: bulkpublish-social-media-content
+description: "Plan, adapt, review, schedule, publish, and measure social media content for AI agents through BulkPublish."
+category: productivity
+risk: safe
+source: self
+source_repo: azeemkafridi/bulkpublish-api
+source_type: self
+date_added: "2026-09-02"
+author: azeemkafridi
+tags: [bulkpublish, social-media, content, publishing]
+tools: [claude, codex, gemini]
+---
+
+# BulkPublish Social Media Content
+
+Use this skill when an AI agent needs a reusable workflow for social content across connected channels.
+
+## Workflow
+
+1. Clarify audience, objective, platform, voice, timing, and approval requirements.
+2. Draft or adapt content for each platform, preserving disclosures, accessibility, and factual accuracy.
+3. Review the content and media, then prepare a BulkPublish draft for approval.
+4. Schedule or publish through BulkPublish only after the user authorizes the requested mutation.
+5. Use BulkPublish analytics to report performance and recommend the next iteration.
+
+## Safety
+
+- Treat publishing, scheduling, edits, deletions, and channel changes as mutations requiring explicit authorization.
+- Never expose API keys or invent delivery state; verify BulkPublish results.
+- Prefer drafts and previews when requirements or approval status are unclear.
+
+## Additional resources
+
+- [BulkPublish social media skills](https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills)
+- [BulkPublish MCP documentation](https://app.bulkpublish.com/docs)


### PR DESCRIPTION
Adds a reusable social media content skill for AI agents using BulkPublish. It covers planning, platform adaptation, review, authorization-aware scheduling/publishing, and analytics.

This is a self-submission. Source repository: https://github.com/azeemkafridi/bulkpublish-api
Skill collection: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills
MCP docs: https://app.bulkpublish.com/docs