### PR TITLE
chore: prepare v16.7.0 maintenance

### DIFF
--- a/.github/workflows/aas-agent-first-preview.yml
+++ b/.github/workflows/aas-agent-first-preview.yml
@@ -41,7 +41,7 @@ jobs:
           cache: npm
 
       - name: Install without lifecycle scripts
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --audit=false
 
       - name: Verify deterministic catalog and preview contracts
         run: |
@@ -59,7 +59,7 @@ jobs:
         run: npm pack --ignore-scripts
 
       - name: Upload the exact candidate tarball
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aas-preview-candidate
           path: agentic-awesome-skills-*.tgz
@@ -90,7 +90,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Download the exact candidate
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aas-preview-candidate
           path: ${{ runner.temp }}/aas-preview-candidate
@@ -99,7 +99,7 @@ jobs:
         run: node verification/aas-preview/run-installed-candidate.mjs --artifact-root "${{ runner.temp }}/aas-preview-candidate" --install-root "${{ runner.temp }}/aas-preview-install" --work-root "${{ runner.temp }}/aas-preview-work" --job-id "${{ matrix.job-id }}" --out "${{ runner.temp }}/aas-preview-${{ matrix.job-id }}.json"
 
       - name: Upload the functional receipt
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aas-preview-${{ matrix.job-id }}
           path: ${{ runner.temp }}/aas-preview-${{ matrix.job-id }}.json
@@ -125,14 +125,21 @@ jobs:
 
       - name: Test and build the local review UI
         run: |
-          npm ci --ignore-scripts
-          npm run app:install
+          npm ci --ignore-scripts --audit=false
+          npm run plugin-compat:sync
+          npm run index
+          npm run bundles:sync
+          npm run sync:metadata
+          npm run catalog
+          npm run build:aas-v1-catalog
+          npm run sync:web-assets
+          npm run app:install -- --audit=false
           npm run app:test
           npm run app:build
           node verification/aas-preview/write-workbench-receipt.mjs "$RUNNER_TEMP/aas-preview-workbench.json"
 
       - name: Upload the Workbench receipt
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aas-preview-workbench
           path: ${{ runner.temp }}/aas-preview-workbench.json
@@ -156,7 +163,7 @@ jobs:
           node-version: 22.23.1
 
       - name: Download all preview receipts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: aas-preview-*
           path: ${{ runner.temp }}/aas-preview-receipts
@@ -173,7 +180,7 @@ jobs:
             --out "$RUNNER_TEMP/aas-agent-first-preview.json"
 
       - name: Upload the aggregate preview receipt
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aas-agent-first-preview-receipt
           path: ${{ runner.temp }}/aas-agent-first-preview.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           trusted_root="$RUNNER_TEMP/pr-policy-main"
           git worktree add --detach "$trusted_root" "${{ github.event.pull_request.base.sha }}"
-          npm ci --ignore-scripts --prefix "$trusted_root"
+          npm ci --ignore-scripts --prefix "$trusted_root" --audit=false
           NODE_PATH="$trusted_root/node_modules" node "$trusted_root/tools/scripts/pr_preflight.cjs" \
             --repo "$GITHUB_WORKSPACE" \
             --base "${{ github.event.pull_request.base.sha }}" \
@@ -100,7 +100,7 @@ jobs:
           git worktree add --detach "$trusted_root" origin/main
           cd "$trusted_root"
           pip install -r tools/requirements.txt
-          npm ci --ignore-scripts
+          npm ci --ignore-scripts --audit=false
           npm run sync:repo-state
 
           mapfile -t managed_files < <(node tools/scripts/generated_files.js --include-mixed)
@@ -174,7 +174,7 @@ jobs:
 
       - name: Install npm dependencies
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
-        run: npm ci
+        run: npm ci --audit=false
 
       - name: Verify directory structure
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
@@ -249,7 +249,7 @@ jobs:
 
       - name: Upload exact-head artifact preview manifest
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: source-preview-${{ github.run_id }}-${{ github.run_attempt }}
           path: .tmp/artifact-preview/manifest.json
@@ -287,7 +287,7 @@ jobs:
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: |
           pip install -r tools/requirements.txt
-          npm ci --ignore-scripts
+          npm ci --ignore-scripts --audit=false
 
       - name: Fetch base branch
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
@@ -341,7 +341,7 @@ jobs:
 
       - name: Upload advisory evidence
         if: always() && github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-evidence-${{ github.event.pull_request.number }}
           path: .tmp/pr-evidence/
@@ -387,11 +387,11 @@ jobs:
 
       - name: Install npm dependencies
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
-        run: npm ci
+        run: npm ci --audit=false
 
       - name: Download exact-head artifact preview manifest
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source-preview-${{ github.run_id }}-${{ github.run_attempt }}
           path: .tmp/artifact-preview
@@ -477,7 +477,7 @@ jobs:
           node-version: "lts/*"
 
       - name: Install npm dependencies
-        run: npm ci
+        run: npm ci --audit=false
 
       - name: Verify directory structure
         run: |
@@ -497,7 +497,18 @@ jobs:
         run: npm run validate:references
 
       - name: Audit npm dependencies
-        run: npm audit --audit-level=high
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if npm audit --audit-level=high --fetch-timeout=60000 --fetch-retries=0; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            echo "npm audit attempt $attempt failed; retrying after a bounded delay."
+            sleep "$((attempt * 10))"
+          done
 
       - name: Run tests
         run: npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,135 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.7.0] - 2026-09-04 - "Replayable Agents and Grounded Engineering Knowledge"
+
+> Added agent-run forensics, an embodied-AI knowledge compiler, and a focused
+> Laravel repair workflow; resolved the current fast-uri and qs advisories.
+> The published catalog contains 2,111 skills.
+
+This release helps Claude Code, Cursor, Codex CLI, Gemini CLI, Antigravity, and
+related AI coding assistants investigate recorded agent behavior, compile
+evidence-backed embodied-AI knowledge, and repair Laravel applications with
+explicit safety and verification boundaries.
+
+Start here:
+
+- Install: `npx agentic-awesome-skills`
+- [`orca-replay`](skills/orca-replay/) for reading model, shell, file-change,
+  and MCP traces before explaining or replaying a past agent run.
+- [`entropy-box`](skills/entropy-box/) for querying and compiling a live
+  embodied-AI knowledge graph with provenance and confidence preserved.
+- [`laravel-development-workflow`](skills/laravel-development-workflow/) for
+  root-cause-oriented Laravel maintenance and regression testing.
+- [Choose your tool](https://github.com/sickn33/agentic-awesome-skills#choose-your-tool)
+- [Best skills by tool](https://github.com/sickn33/agentic-awesome-skills#best-skills-by-tool)
+- [Bundles](https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/bundles.md)
+- [Workflows](https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/workflows.md)
+
+### Added
+
+- Added [`orca-replay`](skills/orca-replay/) for evidence-first diagnosis of
+  recorded coding-agent runs, including model traffic, shell results,
+  per-turn filesystem changes, MCP calls, replay, and bounded multi-model
+  comparison ([#1330](https://github.com/sickn33/agentic-awesome-skills/pull/1330)).
+- Added [`entropy-box`](skills/entropy-box/) for searching and consulting a
+  hosted embodied-AI knowledge graph, preserving source identity, confidence,
+  temporal scope, and the distinction between retrieved evidence and optional
+  LLM synthesis ([#1331](https://github.com/sickn33/agentic-awesome-skills/pull/1331)).
+- Added [`laravel-development-workflow`](skills/laravel-development-workflow/)
+  for diagnosing Laravel and PHP defects at the root cause, matching the
+  existing application architecture, adding regression coverage, and running
+  proportionate verification
+  ([#1327](https://github.com/sickn33/agentic-awesome-skills/pull/1327)).
+
+### Changed
+
+- Updated the web catalog from `highlight.js` 11.11.2 to 11.12.0
+  ([#1332](https://github.com/sickn33/agentic-awesome-skills/pull/1332)).
+- Updated artifact upload and download steps to the Node 24-based v7 and v8
+  GitHub Actions, removing the runner deprecation warnings from protected
+  validation and failing downloads closed on digest mismatch.
+- Kept the protected npm advisory gate fail-closed while disabling its
+  redundant install-time request and adding three bounded attempts for
+  transient registry timeouts and 503 responses.
+- Regenerated ephemeral canonical data in the Workbench preview before its
+  tests and build so source-only pull requests are evaluated against their
+  exact skill catalog rather than the previous canonical snapshot.
+- Disabled redundant install-time advisory requests in pull-request validation
+  and preview jobs; dependency review and the protected fail-closed npm audit
+  remain mandatory.
+- Regenerated the canonical catalog, offline AAS Core data, tracked web assets,
+  marketplaces, editorial bundles, compatibility reports, and Codex/Claude
+  plugin distributions for 2,111 skills.
+
+### Fixed
+
+- Raised the root `fast-uri` floor and refreshed its lockfile to resolve the
+  host-confusion and repeated-hostname-decoding SSRF advisories
+  ([#1328](https://github.com/sickn33/agentic-awesome-skills/pull/1328)).
+- Raised the Loki example backend's `qs` override to 6.16.0 and synchronized
+  its lockfiles, resolving the bracket-key comma parsing array-limit advisory
+  in both canonical and mirrored package trees
+  ([#1328](https://github.com/sickn33/agentic-awesome-skills/pull/1328)).
+
+### Security and Reliability
+
+- Treats OrcaReplay trace content as untrusted evidence rather than agent
+  instructions, requires approval before worktree mutation, and makes the
+  network and token cost of multi-model comparison explicit.
+- Treats Entropy Box responses as untrusted hosted data, preserves citations
+  and confidence markers, and distinguishes the default non-synthesizing
+  consult response from the optional integrated LLM path.
+- Keeps Laravel diagnosis bounded to the repository's real architecture and
+  existing approval, secret, data-mutation, and deployment policies.
+- Verified zero known npm vulnerabilities in the root package, web app, and
+  repaired Loki example backend after the dependency updates.
+
+### Who should care
+
+- Teams debugging why an agent changed a file, invoked a tool, or produced a
+  particular answer during a recorded run.
+- Robotics and embodied-AI researchers who need a cited knowledge map rather
+  than uncited synthesis presented as established fact.
+- Laravel maintainers who want a disciplined repair loop that preserves local
+  conventions and proves the regression is covered.
+- Catalog users who depend on the web application and its dependency chain.
+
+### Validation
+
+- Passed validation for 2,111 canonical skills, reference validation,
+  documentation-security checks, warning-budget enforcement, strict catalog
+  audit and security scan, plugin and bundle convergence, repository tests,
+  web-app tests and coverage, production build, npm audits, and protected
+  exact-head merge gates.
+- Release publication additionally verifies clean final `main`, tag and npm
+  parity, CI, CodeQL, release-only Pages, current and legacy public surfaces,
+  and every already-configured local AAS MCP host.
+
+### Limitations
+
+- OrcaReplay can only explain events present in a captured trace; replay and
+  multi-model comparison can mutate a worktree, reach external services, and
+  incur cost when explicitly enabled.
+- Entropy Box coverage and freshness depend on its hosted graph and declared
+  sources; low-confidence and proposed capabilities still require primary
+  source verification.
+- The Laravel workflow cannot infer undocumented business requirements or
+  replace framework-specific tests, production review, and deployment gates.
+- Dependency audits cover known advisories in resolved package graphs and are
+  not an independent security audit of every skill or upstream service.
+
+### Credits
+
+- **[@xizhuomengcontin](https://github.com/xizhuomengcontin)** for
+  `orca-replay` in
+  [#1330](https://github.com/sickn33/agentic-awesome-skills/pull/1330).
+- **[@chenli-yy](https://github.com/chenli-yy)** for `entropy-box` in
+  [#1331](https://github.com/sickn33/agentic-awesome-skills/pull/1331).
+- **[@Junaid-PK](https://github.com/Junaid-PK)** for
+  `laravel-development-workflow` in
+  [#1327](https://github.com/sickn33/agentic-awesome-skills/pull/1327).
+
 ## [16.6.0] - 2026-09-02 - "Evidence-First Instructions and Safer Dependencies"
 
 > Added focused email cleanup, made AGENTS.md maintenance evidence-first, and

--- a/tools/scripts/tests/automation_workflows.test.js
+++ b/tools/scripts/tests/automation_workflows.test.js
@@ -11,6 +11,7 @@ function readText(relativePath) {
 const packageJson = JSON.parse(readText("package.json"));
 const generatedFiles = JSON.parse(readText("tools/config/generated-files.json"));
 const ciWorkflow = readText(".github/workflows/ci.yml");
+const previewWorkflow = readText(".github/workflows/aas-agent-first-preview.yml");
 const hygieneWorkflowForPages = readText(".github/workflows/repo-hygiene.yml");
 const offlineCatalogBuilder = readText("tools/scripts/build-aas-v1-offline-catalog.js");
 const canonicalMergeScript = readText("tools/scripts/merge_canonical_sync_pr.cjs");
@@ -192,8 +193,35 @@ assert.match(
 );
 assert.match(
   ciWorkflow,
-  /- name: Audit npm dependencies[\s\S]*?run: npm audit --audit-level=high/,
-  "CI should run npm audit at high severity",
+  /main-validation-and-sync:[\s\S]*?- name: Install npm dependencies\n\s+run: npm ci --audit=false[\s\S]*?- name: Audit npm dependencies[\s\S]*?for attempt in 1 2 3; do[\s\S]*?npm audit --audit-level=high --fetch-timeout=60000 --fetch-retries=0[\s\S]*?if \[ "\$attempt" -eq 3 \]; then\n\s+exit 1/,
+  "main CI should avoid a redundant install-time audit and keep three bounded explicit audit attempts fail-closed",
+);
+const ciInstallCommands = ciWorkflow.match(/npm ci[^\n]*/g) || [];
+assert.ok(ciInstallCommands.length >= 6, "main CI should retain its expected deterministic install boundaries");
+assert.ok(
+  ciInstallCommands.every((command) => command.includes("--audit=false")),
+  "CI installs should never duplicate the explicit protected npm audit request",
+);
+for (const workflow of [ciWorkflow, previewWorkflow]) {
+  assert.doesNotMatch(
+    workflow,
+    /actions\/(?:upload|download)-artifact@(?:ea165f8d65b6e75b540449e92b4886f43607fa02|d3f86a106a0bac45b974a628896c90dbdf5c8093)/,
+    "artifact workflows should not regress to the Node 20 action pins",
+  );
+}
+assert.match(ciWorkflow, /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7\.0\.1/);
+assert.match(ciWorkflow, /actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/);
+assert.match(previewWorkflow, /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7\.0\.1/);
+assert.match(previewWorkflow, /actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/);
+assert.match(
+  previewWorkflow,
+  /candidate:[\s\S]*?run: npm ci --ignore-scripts --audit=false[\s\S]*?workbench:[\s\S]*?npm ci --ignore-scripts --audit=false[\s\S]*?npm run app:install -- --audit=false/,
+  "preview installs should avoid redundant registry audit requests covered by the protected fail-closed audit gate",
+);
+assert.match(
+  previewWorkflow,
+  /workbench:[\s\S]*?npm run plugin-compat:sync[\s\S]*?npm run index[\s\S]*?npm run bundles:sync[\s\S]*?npm run sync:metadata[\s\S]*?npm run catalog[\s\S]*?npm run build:aas-v1-catalog[\s\S]*?npm run sync:web-assets[\s\S]*?npm run app:install[\s\S]*?npm run app:test[\s\S]*?npm run app:build/,
+  "Workbench preview should regenerate source-only canonical data before testing and building the review UI",
 );
 assert.match(
   ciWorkflow,
@@ -251,11 +279,6 @@ assert.match(
   ciWorkflow,
   /source-validation:[\s\S]*?- name: Fetch base branch[\s\S]*?- name: Install npm dependencies[\s\S]*?- name: Verify README source credits for changed skills/,
   "source-validation should fetch the base branch before running the changed-skill README credit check",
-);
-assert.match(
-  ciWorkflow,
-  /main-validation-and-sync:[\s\S]*?- name: Audit npm dependencies[\s\S]*?run: npm audit --audit-level=high/,
-  "main validation should enforce npm audit before syncing canonical state",
 );
 assert.doesNotMatch(
   ciWorkflow,


### PR DESCRIPTION
## Summary

- add the v16.7.0 changelog entry for the completed maintainer batch
- move artifact upload/download workflows to signed, immutable Node 24 action releases
- keep the protected npm advisory gate fail-closed while bounding transient registry retries and removing redundant install-time audit requests from CI and preview jobs
- make the Workbench preview regenerate exact source-only canonical data before testing and building

The release covers the new Laravel maintenance, OrcaReplay, and Entropy Box skills; the fast-uri and qs advisory repairs; and the highlight.js 11.12.0 update. Canonical generated state remains delegated to the protected synchronization PR.

## Change Classification

- [x] Maintainer batch
- [x] Docs/release notes
- [x] CI reliability
- [ ] Protected release PR

## Quality Bar Checklist

- [x] Read the current-base repository instructions and maintainer skill.
- [x] Kept generated registry and plugin artifacts out of this source PR.
- [x] Verified the exact upload-artifact v7.0.1 and download-artifact v8.0.1 signed commit pins and Node 24 runtimes.
- [x] Kept npm advisory failures blocking; implicit install-time requests are replaced by the explicit protected three-attempt gate.
- [x] Ran npm run validate.
- [x] Ran npm run validate:references.
- [x] Ran npm run security:docs.
- [x] Ran npm run check:warning-budget (0/0).
- [x] Ran npm run lint:workflows and workflow contract tests.
- [x] Reproduced the Workbench/catalog count mismatch and added exact source-only regeneration plus permanent workflow-contract coverage.
- [x] Ran git diff --check.

## Release boundary

This PR does not publish, tag, deploy Pages, or update local MCP configuration. Those steps remain gated behind the protected release workflow after merge and canonical convergence.
