### PR TITLE
feat: add shortlist comparison and fix skill documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Catalog shortlist comparison with declared risk, setup, plugin packaging, source, and license metadata; a previewable agent brief carries the selected IDs, catalog version, project goal, and target into agent-owned stack selection.
+- Skill bundle links pinned to the catalog release and a Workbench guide from catalog selection to manifest and plan review.
+
+### Fixed
+
+- Skill documentation links resolve bundled files against the same repository release; fragment links stay on the current skill page under the GitHub Pages base path. Outline and rendered heading IDs now agree for inline markup, duplicate headings, and non-English text.
+- Workflow installation guidance uses explicit skill selection and a dry run; the shortlist appears before catalog results and handles clipboard failures with a selectable brief.
+- Updated the web app's transitive `qs` dependency to its patched release.
+
 ## [16.7.0] - 2026-09-04 - "Replayable Agents and Grounded Engineering Knowledge"
 
 > Added agent-run forensics, an embodied-AI knowledge compiler, and a focused

--- a/apps/web-app/package-lock.json
+++ b/apps/web-app/package-lock.json
@@ -21,7 +21,9 @@
         "react-virtuoso": "^4.18.11",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
-        "sanitize-filename": "^1.6.4"
+        "remark-parse": "^11.0.0",
+        "sanitize-filename": "^1.6.4",
+        "unified": "^11.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -5847,9 +5849,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -29,7 +29,9 @@
     "react-virtuoso": "^4.18.11",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "sanitize-filename": "^1.6.4"
+    "remark-parse": "^11.0.0",
+    "sanitize-filename": "^1.6.4",
+    "unified": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/apps/web-app/src/components/ShortlistReview.tsx
+++ b/apps/web-app/src/components/ShortlistReview.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import type { Skill } from '../types';
+import { SkillRequirements } from './SkillRequirements';
+import { buildShortlistBrief, type BriefTarget } from '../utils/shortlistBrief';
+import { catalogVersion } from '../utils/catalogRelease';
+
+interface Props {
+  skills: Skill[];
+  onRemove: (id: string) => void;
+  onClear: () => void;
+}
+
+export function ShortlistReview({ skills, onRemove, onClear }: Props): React.ReactElement {
+  const [goal, setGoal] = useState('');
+  const [target, setTarget] = useState<BriefTarget>('codex:project');
+  const [message, setMessage] = useState('');
+  const [copyFailed, setCopyFailed] = useState(false);
+  const ids = skills.map((skill) => skill.id);
+  const brief = buildShortlistBrief(ids, goal, target);
+
+  async function copy(text: string, success: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyFailed(false);
+      setMessage(success);
+    } catch {
+      setCopyFailed(true);
+      setMessage('Clipboard unavailable. Select and copy the text from the brief preview below.');
+    }
+  }
+
+  return (
+    <section className="shortlist-review" aria-labelledby="shortlist-title">
+      <div className="catalog-shortlist">
+        <div>
+          <p>Browser-local shortlist</p>
+          <h2 id="shortlist-title">Compare skills before you choose.</h2>
+          <span>{skills.length} selected · catalog v{catalogVersion}</span>
+        </div>
+        {skills.length ? (
+          <div className="catalog-shortlist__actions">
+            <button type="button" aria-label="Copy exact IDs" onClick={() => void copy(ids.join('\n'), 'Canonical skill IDs copied to your clipboard.')}>{message.startsWith('Canonical skill IDs copied') ? 'IDs copied' : 'Copy exact IDs'}</button>
+            <button type="button" onClick={() => { onClear(); setMessage(''); setCopyFailed(false); }}>Clear shortlist</button>
+          </div>
+        ) : <p>Add skills from the catalog, compare their requirements, then give your agent a focused brief.</p>}
+      </div>
+      {message ? <p role="status" className="shortlist-review__status">{message}</p> : null}
+      {skills.length ? (
+        <details className="shortlist-review__details" open={copyFailed || undefined}>
+          <summary>Compare {skills.length} selected {skills.length === 1 ? 'skill' : 'skills'} and prepare an agent brief</summary>
+          <div className="shortlist-review__table" tabIndex={0} role="region" aria-label="Selected skills comparison">
+            <table>
+              <thead><tr><th scope="col">Skill</th><th scope="col">Purpose</th><th scope="col">Requirements and provenance</th></tr></thead>
+              <tbody>{skills.map((skill) => (
+                <tr key={skill.id}>
+                  <th scope="row">
+                    <Link to={`/skill/${encodeURIComponent(skill.id)}/`}>{skill.id}</Link>
+                    <button type="button" aria-label={`Remove ${skill.id}`} onClick={() => onRemove(skill.id)}>Remove</button>
+                  </th>
+                  <td>{skill.description}</td>
+                  <td><SkillRequirements skill={skill} /></td>
+                </tr>
+              ))}</tbody>
+            </table>
+          </div>
+          <p className="shortlist-review__note">Metadata describes the catalog record. Plugin packaging does not determine whether an agent can select a skill; inspect its full instructions before use.</p>
+          <div className="shortlist-review__brief">
+            <label htmlFor="shortlist-goal">What do you want to accomplish?
+              <textarea id="shortlist-goal" rows={3} value={goal} placeholder="Describe the outcome and constraints for your project" onChange={(event) => { setGoal(event.target.value); setMessage(''); }} />
+            </label>
+            <label htmlFor="shortlist-target">Target
+              <select id="shortlist-target" value={target} onChange={(event) => { setTarget(event.target.value as BriefTarget); setMessage(''); }}>
+                <option value="codex:project">Codex · this project</option>
+                <option value="claude:project">Claude · this project</option>
+              </select>
+            </label>
+            <p>Your goal stays in this page until you copy it. Only shortlisted IDs are saved in this browser.</p>
+            <div className="catalog-shortlist__actions">
+              <button type="button" aria-label="Copy agent brief" disabled={!goal.trim()} onClick={() => void copy(brief, 'Agent brief copied. Paste it into your coding agent to start the review.')}>{message.startsWith('Agent brief copied') ? 'Brief copied' : 'Copy agent brief'}</button>
+              <Link to="/workbench/">Review the resulting stack and plan</Link>
+            </div>
+            <details open={copyFailed || undefined}>
+              <summary>Preview the brief</summary>
+              <textarea aria-label="Agent brief preview" readOnly rows={12} value={brief} />
+            </details>
+          </div>
+        </details>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web-app/src/components/SkillCard.tsx
+++ b/apps/web-app/src/components/SkillCard.tsx
@@ -45,6 +45,7 @@ export const SkillCard = React.memo(({ skill, starCount, shortlisted = false, on
             type="button"
             className={`skill-row__shortlist ${shortlisted ? 'is-active' : ''}`}
             aria-pressed={shortlisted}
+            aria-label={shortlisted ? 'In shortlist' : 'Add to shortlist'}
             onClick={() => onToggleShortlist(skill.id)}
           >
             {shortlisted ? 'In shortlist' : 'Add to shortlist'}

--- a/apps/web-app/src/components/SkillRequirements.tsx
+++ b/apps/web-app/src/components/SkillRequirements.tsx
@@ -1,0 +1,20 @@
+import type { Skill } from '../types';
+import { releaseFileUrl, skillSourcePath } from '../utils/catalogRelease';
+
+export function SkillRequirements({ skill }: { skill: Skill }): React.ReactElement {
+  const plugin = skill.plugin;
+  const upstream = skill.source_repo && /^https?:\/\//i.test(skill.source_repo) ? skill.source_repo : null;
+  const source = skillSourcePath(skill.path);
+  const setupDocs = plugin?.setup.docs && source ? releaseFileUrl(plugin.setup.docs, source) : '';
+  return (
+    <dl className="skill-requirements">
+      <div><dt>Declared risk</dt><dd>{skill.risk || 'unknown'}</dd></div>
+      <div><dt>Setup</dt><dd>{plugin ? plugin.setup.type === 'manual' ? `Manual: ${plugin.setup.summary || 'Read the skill instructions.'}` : 'No extra setup declared' : 'Not recorded'}</dd></div>
+      {setupDocs ? <div><dt>Setup guide</dt><dd><a href={setupDocs}>Read setup instructions</a></dd></div> : null}
+      <div><dt>Plugin packaging</dt><dd>{plugin ? `Codex: ${plugin.targets.codex === 'supported' ? 'included' : 'not packaged'} · Claude: ${plugin.targets.claude === 'supported' ? 'included' : 'not packaged'}` : 'Not recorded'}</dd></div>
+      {plugin?.reasons.length ? <div><dt>Packaging notes</dt><dd>{plugin.reasons.join('; ')}</dd></div> : null}
+      <div><dt>Source</dt><dd>{upstream ? <a href={upstream}>{skill.source || 'Upstream repository'}</a> : skill.source || 'Not recorded'}</dd></div>
+      <div><dt>License metadata</dt><dd>{skill.license || 'Not recorded in catalog'}</dd></div>
+    </dl>
+  );
+}

--- a/apps/web-app/src/components/__tests__/ShortlistReview.test.tsx
+++ b/apps/web-app/src/components/__tests__/ShortlistReview.test.tsx
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { ShortlistReview } from '../ShortlistReview';
+import { renderWithRouter } from '../../utils/testUtils';
+import { createMockSkill } from '../../factories/skill';
+import { catalogVersion } from '../../utils/catalogRelease';
+
+const skills = [createMockSkill({
+  id: 'slides', description: 'Build a presentation', license: 'MIT',
+  plugin: { targets: { codex: 'supported', claude: 'blocked' }, setup: { type: 'manual', summary: 'Configure the presentation API.', docs: 'SKILL.md' }, reasons: ['Requires a local dependency'] },
+}), createMockSkill({ id: 'review', description: 'Review the presentation', risk: 'unknown' })];
+
+describe('shortlist comparison and agent handoff', () => {
+  beforeEach(() => {
+    vi.mocked(navigator.clipboard.writeText).mockReset().mockResolvedValue();
+    vi.mocked(localStorage.setItem).mockClear();
+  });
+
+  it('compares visible requirements and copies a previewable goal-specific brief without persisting it', async () => {
+    renderWithRouter(<ShortlistReview skills={skills} onRemove={vi.fn()} onClear={vi.fn()} />, { useProvider: false });
+    fireEvent.click(screen.getByText('Compare 2 selected skills and prepare an agent brief'));
+    expect(screen.getByText('Manual: Configure the presentation API.')).toBeInTheDocument();
+    expect(screen.getByText('Codex: included · Claude: not packaged')).toBeInTheDocument();
+    expect(screen.getByText('MIT')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy agent brief' })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('What do you want to accomplish?'), { target: { value: 'Prepare a quarterly review' } });
+    fireEvent.change(screen.getByLabelText('Target'), { target: { value: 'claude:project' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Copy agent brief' }));
+    await screen.findByRole('status');
+    const brief = vi.mocked(navigator.clipboard.writeText).mock.calls[0][0];
+    expect(brief).toContain('Prepare a quarterly review');
+    expect(brief).toContain('Target: claude:project');
+    expect(brief).toContain(`catalog v${catalogVersion}`);
+    expect(brief).toContain('- slides\n- review');
+    expect(brief).toContain('candidates to inspect, not a complete or approved stack');
+    expect(brief).toContain('Do not install or apply skills.');
+    expect(screen.getByLabelText('Agent brief preview')).toHaveValue(brief);
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('exports exact IDs and handles blocked clipboard access with a visible manual fallback', async () => {
+    const onRemove = vi.fn();
+    const onClear = vi.fn();
+    renderWithRouter(<ShortlistReview skills={skills} onRemove={onRemove} onClear={onClear} />, { useProvider: false });
+    fireEvent.click(screen.getByRole('button', { name: 'Copy exact IDs' }));
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('slides\nreview'));
+    vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error('Denied'));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy exact IDs' }));
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Clipboard unavailable'));
+    expect(screen.getByLabelText('Agent brief preview')).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove slides' }));
+    expect(onRemove).toHaveBeenCalledWith('slides');
+    fireEvent.click(screen.getByRole('button', { name: 'Clear shortlist' }));
+    expect(onClear).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web-app/src/index.css
+++ b/apps/web-app/src/index.css
@@ -699,6 +699,39 @@ textarea {
   align-items: start;
 }
 
+.shortlist-review { margin-top: 28px; min-width: 0; }
+.shortlist-review .catalog-shortlist { margin-top: 0; padding: 20px 0; }
+.shortlist-review__details { border-bottom: 1px solid var(--stroke-subtle); }
+.shortlist-review summary { padding: 14px 0; cursor: pointer; font-size: 0.85rem; font-weight: 650; }
+.shortlist-review__table { max-width: 100%; overflow-x: auto; }
+.shortlist-review table { width: 100%; min-width: 650px; border-collapse: collapse; text-align: left; font-size: 0.8rem; }
+.shortlist-review th, .shortlist-review td { padding: 14px; border: 1px solid var(--stroke-subtle); vertical-align: top; }
+.shortlist-review thead th { background: var(--surface-card); font-size: 0.72rem; }
+.shortlist-review tbody th { width: 23%; overflow-wrap: anywhere; }
+.shortlist-review td:nth-child(2) { width: 35%; line-height: 1.6; }
+.shortlist-review a, .skill-requirements a, .skill-requirements-panel > a { color: var(--accent-solid); text-decoration: underline; text-underline-offset: 3px; }
+.shortlist-review tbody th button { display: block; margin-top: 12px; font-size: 0.72rem; font-weight: 400; cursor: pointer; text-decoration: underline; }
+.shortlist-review__brief { display: grid; gap: 16px; padding: 12px 0 20px; }
+.shortlist-review__brief label { display: grid; gap: 6px; font-size: 0.82rem; font-weight: 650; }
+.shortlist-review textarea, .shortlist-review select { width: 100%; border: 1px solid var(--stroke-subtle); border-radius: var(--radius-sm); background: var(--surface-card); color: var(--text-primary); padding: 10px 12px; font: inherit; }
+.shortlist-review textarea { resize: vertical; }
+.shortlist-review select { max-width: 320px; min-height: 44px; }
+.shortlist-review__brief > p, .shortlist-review__note, .shortlist-review__status { font-size: 0.78rem; line-height: 1.6; color: var(--text-muted); margin: 10px 0; }
+.shortlist-review .catalog-shortlist__actions { flex-wrap: wrap; align-items: center; }
+.shortlist-review .catalog-shortlist__actions a { font-size: 0.8rem; }
+.shortlist-review button:disabled { opacity: 0.5; cursor: not-allowed; }
+.skill-requirements { margin: 0; display: grid; gap: 8px; font-size: 0.78rem; line-height: 1.5; }
+.skill-requirements dt { color: var(--text-muted); font-size: 0.7rem; }
+.skill-requirements dd { margin: 0; overflow-wrap: anywhere; }
+.skill-requirements-panel { margin-top: 24px; border-top: 1px solid var(--stroke-subtle); padding-top: 18px; }
+.skill-requirements-panel h2 { margin: 0 0 14px; font-size: 1rem; font-weight: 650; }
+.skill-requirements-panel .skill-requirements { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 14px; }
+.skill-requirements-panel > a { display: inline-block; margin-top: 16px; font-size: 0.85rem; }
+.skill-requirements-panel > p { margin-top: 8px; font-size: 0.78rem; line-height: 1.6; color: var(--text-muted); }
+.markdown-body :is(h1, h2, h3, h4, h5, h6) { scroll-margin-top: 96px; }
+.workbench-boundary ol { padding-left: 22px; list-style: decimal; font-size: 0.88rem; line-height: 1.7; }
+.workbench-boundary a { color: var(--accent-solid); text-decoration: underline; text-underline-offset: 3px; }
+
 .catalog-health dl {
   display: grid;
   grid-template-columns: repeat(4, minmax(108px, 1fr));

--- a/apps/web-app/src/pages/Home.tsx
+++ b/apps/web-app/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 import { VirtuosoGrid } from 'react-virtuoso';
 import { SkillCard } from '../components/SkillCard';
+import { ShortlistReview } from '../components/ShortlistReview';
 import { Icon } from '../components/ui/Icon';
 import { useSkills } from '../context/SkillContext';
 import { seoLandingPages } from '../data/seoLandingPages';
@@ -228,7 +229,6 @@ export function Home(): React.ReactElement {
   }, [skills]);
 
   const shortlistSkills = useMemo(() => skills.filter((skill) => shortlistIds.includes(skill.id)), [shortlistIds, skills]);
-  const shortlistRisks = useMemo(() => new Set(shortlistSkills.map((skill) => skill.risk || 'unknown')), [shortlistSkills]);
 
   const clearFilters = () => {
     setSearch('');
@@ -237,12 +237,6 @@ export function Home(): React.ReactElement {
     setSourceFilter('all');
     setScopeFilter('all');
     setSortBy('default');
-  };
-
-  const copyShortlist = async () => {
-    await navigator.clipboard.writeText(shortlistSkills.map((skill) => skill.id).join('\n'));
-    setSyncMsg({ type: 'success', text: 'Canonical skill IDs copied to your clipboard.' });
-    window.setTimeout(() => setSyncMsg(null), 5000);
   };
 
   const handleSync = async () => {
@@ -377,6 +371,8 @@ export function Home(): React.ReactElement {
           </div>
         </section>
 
+        <ShortlistReview skills={shortlistSkills} onRemove={toggleShortlist} onClear={clearShortlist} />
+
         <section className="catalog-results" aria-labelledby="catalog-results-title">
           <header>
             <div>
@@ -427,20 +423,6 @@ export function Home(): React.ReactElement {
           )}
         </section>
 
-        <section className="catalog-shortlist" aria-labelledby="shortlist-title">
-          <div>
-            <p>Browser-local shortlist</p>
-            <h2 id="shortlist-title">Build a stack before you ask your agent to act.</h2>
-            <span>{shortlistSkills.length} selected · {shortlistRisks.size || 0} risk levels</span>
-          </div>
-          {shortlistSkills.length > 0 ? (
-            <div className="catalog-shortlist__actions">
-              <button type="button" onClick={() => void copyShortlist()}>Copy exact IDs</button>
-              <button type="button" onClick={clearShortlist}>Clear shortlist</button>
-            </div>
-          ) : <p>Add skills from the catalog to compare and export their exact IDs. Nothing leaves this browser.</p>}
-        </section>
-
         <section className="catalog-health" aria-labelledby="catalog-health-title">
           <div><p>Catalog health</p><h2 id="catalog-health-title">A quick view of the library you are choosing from.</h2></div>
           <dl>
@@ -449,7 +431,7 @@ export function Home(): React.ReactElement {
             <div><dt>Tagged for discovery</dt><dd>{skills.length ? Math.round((catalogHealth.documented / skills.length) * 100) : 0}%</dd></div>
             <div><dt>Latest addition</dt><dd>{catalogHealth.latest || 'Not recorded'}</dd></div>
           </dl>
-          <p>Discovery interactions stay in this browser. Connect a consent-based analytics provider later if you want aggregate search-gap reporting.</p>
+          <p>Search and shortlist stay in this browser. Check each skill's setup, source, and instructions before using it.</p>
         </section>
 
         <section className="catalog-support" aria-label="Catalog guides">

--- a/apps/web-app/src/pages/SkillDetail.tsx
+++ b/apps/web-app/src/pages/SkillDetail.tsx
@@ -8,6 +8,9 @@ import { useSkillShortlist } from '../hooks/useSkillShortlist';
 import { buildSkillFallbackMeta, buildSkillMeta, selectTopSkills, toIndexableRoutePath } from '../utils/seo';
 import { getSkillMarkdownCandidateUrls } from '../utils/publicAssetUrls';
 import { getRelatedSeoLandingPagesForSkill } from '../data/seoLandingPages';
+import { getSkillHeadings, remarkSkillHeadings, skillMarkdownUrl } from '../utils/skillMarkdown';
+import { catalogVersion, skillBundleUrl } from '../utils/catalogRelease';
+import { SkillRequirements } from '../components/SkillRequirements';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 
@@ -76,14 +79,6 @@ function parseFrontmatterRows(frontmatter: string): Array<{ key: string; value: 
     .filter((row): row is { key: string; value: string } => row !== null);
 }
 
-function slugifyHeading(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[`*_~[\]()]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
 interface RouteParams {
   id: string;
   [key: string]: string | undefined;
@@ -131,14 +126,7 @@ export function SkillDetail(): React.ReactElement {
   const communityCount = useMemo(() => (id ? stars[id] || 0 : 0), [stars, id]);
   const { frontmatter, body: markdownBody } = useMemo(() => splitFrontmatter(content), [content]);
   const frontmatterRows = useMemo(() => parseFrontmatterRows(frontmatter), [frontmatter]);
-  const headingLinks = useMemo(() => markdownBody
-    .split('\n')
-    .flatMap((line) => {
-      const match = line.match(/^##\s+(.+)$/);
-      if (!match) return [];
-      const label = match[1].replace(/[`*_~]/g, '').trim();
-      return label ? [{ label, id: slugifyHeading(label) }] : [];
-    }), [markdownBody]);
+  const headingLinks = useMemo(() => getSkillHeadings(markdownBody), [markdownBody]);
   const relatedTopicPages = useMemo(
     () => skill ? getRelatedSeoLandingPagesForSkill(skill) : [],
     [skill],
@@ -374,7 +362,7 @@ export function SkillDetail(): React.ReactElement {
             Interactive Prompt Builder (Optional)
           </label>
           <p className="mb-3 text-xs text-slate-500 dark:text-slate-400">
-            Add specific details below (e.g. &quot;Use React 19 and Tailwind&quot;). The &quot;Copy Prompt&quot; button will automatically attach your context.
+            Add specific details below (e.g. &quot;Use React 19 and Tailwind&quot;). Both copy buttons above will attach your context.
           </p>
           <textarea
             id="context"
@@ -384,6 +372,12 @@ export function SkillDetail(): React.ReactElement {
             value={customContext}
             onChange={(e) => setCustomContext(e.target.value)}
           />
+          <section className="skill-requirements-panel" aria-label="Setup and provenance">
+            <h2>Before you use this skill</h2>
+            <SkillRequirements skill={skill} />
+            <a href={skillBundleUrl(skill.path)}>Browse all skill files · v{catalogVersion}</a>
+            <p>Copy Full Content includes SKILL.md only. Linked scripts, templates, and references open in the same repository release.</p>
+          </section>
         </div>
       </div>
 
@@ -488,14 +482,9 @@ export function SkillDetail(): React.ReactElement {
           <div className="markdown-body" style={{ backgroundColor: 'transparent' }}>
             <Suspense fallback={<div className="h-24 animate-pulse rounded-lg bg-slate-100 dark:bg-slate-800"></div>}>
               <Markdown
-                remarkPlugins={[remarkGfm]}
+                remarkPlugins={[remarkGfm, remarkSkillHeadings]}
                 rehypePlugins={[rehypeHighlight]}
-                components={{
-                  h2: ({ children }) => {
-                    const label = String(children);
-                    return <h2 id={slugifyHeading(label)}>{children}</h2>;
-                  },
-                }}
+                urlTransform={(url, key) => skillMarkdownUrl(url, key, skill.path, window.location.href)}
               >
                 {markdownBody}
               </Markdown>
@@ -506,7 +495,7 @@ export function SkillDetail(): React.ReactElement {
           <h2>On this page</h2>
           {headingLinks.length > 0 ? (
             <nav>
-              {headingLinks.map((heading) => <a key={heading.id} href={`#${heading.id}`}>{heading.label}</a>)}
+              {headingLinks.map((heading) => <a key={heading.id} href={`${window.location.href.split('#')[0]}#${heading.id}`}>{heading.label}</a>)}
             </nav>
           ) : <p>Skill documentation</p>}
           <dl>

--- a/apps/web-app/src/pages/Workbench.tsx
+++ b/apps/web-app/src/pages/Workbench.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { usePageMeta } from '../hooks/usePageMeta';
+import { Link } from 'react-router';
+import { releaseFileUrl } from '../utils/catalogRelease';
 import {
   WORKBENCH_MAX_IMPORT_BYTES,
   WORKBENCH_MAX_JSON_DEPTH,
@@ -375,6 +377,16 @@ export function Workbench(): React.ReactElement {
           </dl>
         </div>
       </header>
+
+      <section className="workbench-boundary" aria-labelledby="workbench-start-title">
+        <h2 id="workbench-start-title">Need a stack to review?</h2>
+        <ol>
+          <li><Link to="/">Compare skills in the catalog</Link> and copy an agent brief with your goal and target.</li>
+          <li>Give the brief to your coding agent with AAS MCP configured. Let it inspect your project and select exact IDs; review its choices before saving <code>aas-stack.json</code>.</li>
+          <li>Validate the manifest and generate a preview plan with the CLI, then import both files below.</li>
+        </ol>
+        <a href={releaseFileUrl('docs/users/aas-core.md')}>Configuration and preview commands</a>
+      </section>
 
       <section className="workbench-boundary" aria-labelledby="workbench-boundary-title">
         <h2 id="workbench-boundary-title">Review surface, not an installer</h2>

--- a/apps/web-app/src/pages/__tests__/Home.test.tsx
+++ b/apps/web-app/src/pages/__tests__/Home.test.tsx
@@ -209,7 +209,7 @@ describe('Home', () => {
 
       fireEvent.click(screen.getByRole('button', { name: /Add to shortlist/i }));
       expect(screen.getByRole('button', { name: /In shortlist/i })).toBeInTheDocument();
-      expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+      expect(screen.getByText(/^1 selected · catalog/)).toBeInTheDocument();
     });
   });
 

--- a/apps/web-app/src/pages/__tests__/SkillDetail.links.test.tsx
+++ b/apps/web-app/src/pages/__tests__/SkillDetail.links.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import { SkillDetail } from '../SkillDetail';
+import { renderWithRouter } from '../../utils/testUtils';
+import { createMockSkill } from '../../factories/skill';
+import { useSkills } from '../../context/SkillContext';
+import { catalogVersion } from '../../utils/catalogRelease';
+
+vi.mock('../../context/SkillContext', async (importOriginal) => ({
+  ...await importOriginal<object>(), useSkills: vi.fn(),
+}));
+vi.mock('../../components/SkillStarButton', () => ({ SkillStarButton: () => null }));
+
+const markdown = `# Slides
+
+## Create **without a template**
+[Read the guide](html2pptx.md)
+[Read the script](scripts/html2pptx.js)
+[Go to creation](#create-without-a-template)
+
+## Create *without a template*
+## Résumé 中文
+
+\`\`\`markdown
+## Not a heading
+\`\`\`
+
+<script>alert('unsafe')</script>
+`;
+
+describe('SkillDetail rendered documentation links', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/agentic-awesome-skills/skill/pptx-official/');
+    const base = document.createElement('base');
+    base.href = '/agentic-awesome-skills/';
+    document.head.appendChild(base);
+    vi.mocked(useSkills).mockReturnValue({
+      skills: [createMockSkill({ id: 'pptx-official', name: 'pptx-official', path: 'skills/pptx-official' })],
+      stars: {}, loading: false, error: null, refreshSkills: vi.fn(),
+    });
+    vi.mocked(fetch).mockResolvedValue({ ok: true, text: async () => markdown } as Response);
+  });
+
+  afterEach(() => {
+    document.querySelector('base')?.remove();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('keeps fragments on the skill route and sends bundled files to the pinned release', async () => {
+    const { container } = renderWithRouter(<SkillDetail />, { route: '/skill/pptx-official/', path: '/skill/:id', useProvider: false });
+    const guide = await screen.findByRole('link', { name: 'Read the guide' }, { timeout: 5000 });
+    expect(guide).toHaveAttribute('href', `https://github.com/sickn33/agentic-awesome-skills/blob/v${catalogVersion}/skills/pptx-official/html2pptx.md`);
+    expect(screen.getByRole('link', { name: 'Read the script' })).toHaveAttribute('href', `https://github.com/sickn33/agentic-awesome-skills/blob/v${catalogVersion}/skills/pptx-official/scripts/html2pptx.js`);
+    expect(screen.getByRole('link', { name: 'Go to creation' })).toHaveAttribute('href', `${window.location.href}#create-without-a-template`);
+    expect(screen.getByRole('link', { name: /Browse all skill files/ })).toHaveAttribute('href', `https://github.com/sickn33/agentic-awesome-skills/tree/v${catalogVersion}/skills/pptx-official`);
+
+    const toc = within(screen.getByRole('complementary', { name: 'On this page' }));
+    const links = toc.getAllByRole('link');
+    expect(links).toHaveLength(3);
+    for (const link of links) {
+      const url = new URL((link as HTMLAnchorElement).href);
+      expect(url.pathname).toBe('/agentic-awesome-skills/skill/pptx-official/');
+      expect(document.getElementById(decodeURIComponent(url.hash.slice(1)))).toHaveTextContent(link.textContent!);
+    }
+    expect(container.querySelector('.markdown-body #create-without-a-template-1')).toBeInTheDocument();
+    expect(container.querySelector('.markdown-body script')).not.toBeInTheDocument();
+    await waitFor(() => expect(container.textContent).not.toContain('[object Object]'));
+  });
+});

--- a/apps/web-app/src/pages/__tests__/Workbench.test.tsx
+++ b/apps/web-app/src/pages/__tests__/Workbench.test.tsx
@@ -98,6 +98,9 @@ describe('Workbench review UI', () => {
     renderWithRouter(<Workbench />, { route: '/workbench', path: '/workbench', useProvider: false });
 
     expect(screen.getByRole('heading', { level: 1, name: 'Review what your agent selected.' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Need a stack to review?' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Compare skills in the catalog' })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: 'Configuration and preview commands' })).toHaveAttribute('href', expect.stringMatching(/\/blob\/v[^/]+\/docs\/users\/aas-core\.md$/));
 
     paste('Paste JSON', stackFixture());
     fireEvent.click(screen.getByRole('button', { name: 'Review pasted stack' }));

--- a/apps/web-app/src/utils/__tests__/skillMarkdown.test.ts
+++ b/apps/web-app/src/utils/__tests__/skillMarkdown.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { catalogVersion, releaseFileUrl, skillBundleUrl } from '../catalogRelease';
+import { skillMarkdownUrl } from '../skillMarkdown';
+
+const release = `https://github.com/sickn33/agentic-awesome-skills/blob/v${catalogVersion}/`;
+
+describe('release-pinned documentation URLs', () => {
+  it('resolves nested skill support files and repository-relative documentation', () => {
+    expect(skillBundleUrl('skills/game-development/2d-games')).toBe(release.replace('/blob/', '/tree/') + 'skills/game-development/2d-games');
+    expect(skillBundleUrl('skills/android_ui_verification')).toBe(release.replace('/blob/', '/tree/') + 'skills/android_ui_verification');
+    expect(releaseFileUrl('../../docs/guide.md', 'skills/example/SKILL.md')).toBe(release + 'docs/guide.md');
+    expect(releaseFileUrl('guide.md?raw=true#example', 'skills/example/SKILL.md')).toBe(release + 'skills/example/guide.md#example');
+    expect(skillMarkdownUrl('images/demo.png', 'src', 'skills/example', 'https://catalog.test/skill/example/')).toBe(`https://raw.githubusercontent.com/sickn33/agentic-awesome-skills/v${catalogVersion}/skills/example/images/demo.png`);
+  });
+
+  it.each(['../../../../other', '//evil.test/file', 'javascript:alert(1)', 'data:text/html,hello', 'bad%2Fpath', 'bad%5cpath', 'bad%00path', 'bad%252fpath', 'bad%zz', 'bad\\path'])('rejects unsafe relative file targets: %s', (path) => {
+    expect(releaseFileUrl(path, 'skills/example/SKILL.md')).toBe('');
+  });
+
+  it('keeps ordinary external links and rejects unsafe skill paths', () => {
+    expect(skillMarkdownUrl('https://example.com/docs', 'href', 'skills/example', 'https://catalog.test/')).toBe('https://example.com/docs');
+    expect(skillMarkdownUrl('guide.md', 'href', 'skills/../../other', 'https://catalog.test/')).toBe('');
+    expect(skillMarkdownUrl('javascript:alert(1)', 'href', 'skills/example', 'https://catalog.test/')).toBe('');
+  });
+});

--- a/apps/web-app/src/utils/catalogRelease.ts
+++ b/apps/web-app/src/utils/catalogRelease.ts
@@ -1,0 +1,39 @@
+import { version } from '../../../../package.json';
+
+export const catalogVersion = version;
+const repository = 'https://github.com/sickn33/agentic-awesome-skills';
+const releaseRoot = `${repository}/blob/v${version}/`;
+
+function hasControlCharacters(value: string): boolean {
+  return Array.from(value).some((character) => character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127);
+}
+
+/** Resolve repository files within the same release, never against the Pages base. */
+export function releaseFileUrl(path: string, from = '', image = false): string {
+  if (!path || path.includes('\\') || hasControlCharacters(path) || path.startsWith('//') || /^[a-z][a-z0-9+.-]*:/i.test(path)) return '';
+  try {
+    const url = new URL(path, `${releaseRoot}${from}`);
+    if (!url.href.startsWith(releaseRoot)) return '';
+    // Reject encoded separators and nested encodings before the hosting service decodes them.
+    for (const segment of url.pathname.split('/')) {
+      const decoded = decodeURIComponent(segment);
+      if (/[\\/%]/.test(decoded) || hasControlCharacters(decoded)) return '';
+    }
+    url.search = '';
+    if (image) return url.href.replace(`${repository}/blob/`, 'https://raw.githubusercontent.com/sickn33/agentic-awesome-skills/');
+    return url.href;
+  } catch {
+    return '';
+  }
+}
+
+export function skillSourcePath(path: string): string {
+  const normalized = path.startsWith('skills/') ? path : `skills/${path}`;
+  if (!/^skills\/[a-z0-9_-]+(?:\/[a-z0-9_-]+)*(?:\/SKILL\.md)?$/.test(normalized)) return '';
+  return normalized.endsWith('/SKILL.md') ? normalized : `${normalized}/SKILL.md`;
+}
+
+export function skillBundleUrl(path: string): string {
+  const source = skillSourcePath(path);
+  return source ? releaseFileUrl(source).replace('/blob/', '/tree/').replace(/\/SKILL\.md$/, '') : '';
+}

--- a/apps/web-app/src/utils/shortlistBrief.ts
+++ b/apps/web-app/src/utils/shortlistBrief.ts
@@ -1,0 +1,19 @@
+import { catalogVersion } from './catalogRelease';
+
+export type BriefTarget = 'codex:project' | 'claude:project';
+
+export function buildShortlistBrief(ids: string[], goal: string, target: BriefTarget): string {
+  return `Help me prepare an AAS Core skill stack for this project.
+
+Desired outcome:
+${goal.trim()}
+
+Target: ${target}
+I shortlisted these exact IDs in catalog v${catalogVersion}:
+${ids.map((id) => `- ${id}`).join('\n')}
+
+Treat this shortlist as candidates to inspect, not a complete or approved stack.
+Inspect the repository and identify its capability areas. Search and read the complete local AAS catalog; compare candidates, including these IDs, against the goal and constraints. Explain any additions, omissions, redundancy, manual setup, and catalog gaps. Plugin packaging and risk metadata are informational, not eligibility rules.
+Confirm the local catalog version and report any difference from v${catalogVersion}; do not silently substitute missing IDs. Choose the exact skill IDs yourself, then use compose_stack and inspect_stack to return a validated schema 2 manifest with the project profile and target. Review it with me before persisting aas-stack.json.
+After that review, validate the manifest and generate an immutable plan with the CLI using explicit paths and integrity inputs. Write only the requested artifacts. I will import aas-stack.json and the plan into Workbench to review them. Do not install or apply skills.`;
+}

--- a/apps/web-app/src/utils/skillMarkdown.ts
+++ b/apps/web-app/src/utils/skillMarkdown.ts
@@ -1,0 +1,56 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import { releaseFileUrl, skillSourcePath } from './catalogRelease';
+
+interface MarkdownNode {
+  type: string;
+  value?: string;
+  alt?: string | null;
+  depth?: number;
+  children?: MarkdownNode[];
+  data?: { hProperties?: Record<string, unknown> };
+}
+
+function plainText(node: MarkdownNode): string {
+  return node.value ?? node.alt ?? node.children?.map(plainText).join('') ?? '';
+}
+
+// Both the rendered headings and the outline use the Markdown AST. This also
+// excludes headings inside code fences and handles inline markup and duplicates.
+function assignHeadings(tree: MarkdownNode): Array<{ label: string; id: string }> {
+  const used = new Set<string>();
+  const outline: Array<{ label: string; id: string }> = [];
+  function visit(node: MarkdownNode) {
+    if (node.type === 'heading') {
+      const label = plainText(node).trim();
+      const slug = label.toLowerCase().replace(/[^\p{L}\p{N}\s_-]/gu, '').replace(/\s/g, '-') || 'section';
+      let id = slug;
+      let suffix = 0;
+      while (used.has(id)) id = `${slug}-${++suffix}`;
+      used.add(id);
+      node.data = { ...node.data, hProperties: { ...node.data?.hProperties, id } };
+      if (node.depth === 2) outline.push({ label, id });
+    }
+    node.children?.forEach(visit);
+  }
+  visit(tree);
+  return outline;
+}
+
+const parser = unified().use(remarkParse).use(remarkGfm);
+
+export function getSkillHeadings(markdown: string) {
+  return assignHeadings(parser.parse(markdown));
+}
+
+export function remarkSkillHeadings() {
+  return (tree: MarkdownNode) => { assignHeadings(tree); };
+}
+
+export function skillMarkdownUrl(url: string, key: string, skillPath: string, pageUrl: string): string {
+  if (/^https?:\/\//i.test(url) || (key === 'href' && /^mailto:/i.test(url))) return url;
+  if (url.startsWith('#')) return key === 'href' ? `${pageUrl.split('#')[0]}${url}` : '';
+  const source = skillSourcePath(skillPath);
+  return source ? releaseFileUrl(url, source, key === 'src') : '';
+}

--- a/docs/users/aas-core.md
+++ b/docs/users/aas-core.md
@@ -63,6 +63,16 @@ During preview, AAS checks the ownership of the configuration parent directory (
 
 ## Ask the agent to choose the stack
 
+### Start from a catalog shortlist
+
+In the [hosted catalog](https://sickn33.github.io/agentic-awesome-skills/), add candidate skills to your shortlist. Open the comparison above the search results to inspect descriptions, declared risk, manual setup, plugin packaging, source, and license metadata. Missing metadata is shown explicitly; it does not make a skill unavailable to Core.
+
+Enter the project outcome and select Codex or Claude as the project target, preview the brief, then copy it into your coding agent with the local AAS MCP configured. The brief includes exact candidate IDs and the catalog version. It asks the agent to inspect the complete catalog and explain its final selection, including any additions or omissions. A shortlist is input to that review, not an approved stack.
+
+The catalog stores shortlisted IDs in browser-local storage. The goal and brief remain in page memory until copied. Workbench does not consume the brief: after the agent returns a manifest and you review it, persist and validate the manifest, generate the immutable CLI plan, then explicitly import those two artifacts into Workbench. If clipboard access is unavailable, select the brief text from its preview.
+
+### Start directly in the coding agent
+
 Give the agent the desired outcome and constraints, and leave selection judgment with the agent:
 
 ```text

--- a/docs/users/workflows.md
+++ b/docs/users/workflows.md
@@ -15,8 +15,8 @@ If bundles are your toolbox, workflows are your execution playbook.
 
 ## How to Use Workflows
 
-1. Install the repository once (`npx agentic-awesome-skills`).
-2. Pick a workflow matching your immediate goal.
+1. Pick a workflow matching your immediate goal and review the listed skills and their setup instructions.
+2. Install only your selected skills. For example, preview a Codex install with `npx agentic-awesome-skills --codex --skills concise-planning,verification-before-completion --dry-run`, review the destination and file list, then repeat without `--dry-run` to install. Replace the example IDs with your selection; a bare install requires an explicit selection.
 3. Execute steps in order and invoke the listed skills in each step.
 4. Keep output artifacts at each step (plan, decisions, tests, validation evidence).
 


### PR DESCRIPTION
# Pull Request Description

The catalog now supports comparing shortlisted skills and handing a goal-specific brief to the coding agent. Selected IDs remain candidates for agent-owned selection; the brief pins the catalog version, goal, and project target, and explains how to reach manifest and plan review in Workbench.

Skill documentation now resolves relative files against the matching repository release. Its outline and rendered headings share Markdown parsing, so inline formatting, duplicate headings, Unicode, and GitHub Pages fragment navigation work together. Setup and provenance are visible on detail and comparison views. The web lockfile updates qs to 6.16.0, and workflow install guidance uses an explicit selection and dry run.

Co-authored-by: sck_0 <188885273+sck000@users.noreply.github.com>

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Validation

- Full repository suite: 114 test files passed; Core suite: 152 tests passed.
- Web suite: 24 files / 191 tests passed, including real Markdown rendering under a Pages base URL, unsafe URL rejection, nested skill files, shortlist export, clipboard denial, and Workbench entry guidance.
- Web lint, TypeScript, Vite build and prerender with `VITE_BASE_PATH=/agentic-awesome-skills/` passed.
- Validation chain, references, docs security, warning budget, stale claims, repository consistency, source credits, and offline catalog integrity passed.
- Root and web npm audits: zero reported vulnerabilities, including development dependencies.
- Browser verification passed via in-app CUA and isolated headless Edge at 390x844 and 1280x900: search, shortlist comparison, clipboard contents, horizontal containment, Workbench navigation, release-pinned links, and heading scrolling beneath the fixed header. No runtime or console errors.

## Quality Bar Checklist ✅

- [x] **Standards**: Read quality-bar.md and security-guardrails.md.
- [x] **Metadata**: Repository validation passed; skill frontmatter is unchanged.
- [x] **Risk Label**: N/A; no canonical skill changes or risk relabeling.
- [x] **Triggers**: N/A; no canonical skill changes.
- [x] **Limitations**: UI and docs explain metadata limits, candidate selection, clipboard behavior, and preview-only operation.
- [x] **Security**: N/A; no offensive skill changes.
- [x] **Safety scan**: `npm run security:docs` passed; relative file links cannot escape the pinned release or execute unsafe URL schemes.
- [x] **Automated Skill Review**: N/A; no files under canonical or mirrored skill trees changed. No Tessl review is claimed.
- [x] **Manual Logic Review**: Reviewed URL handling, heading identity, clipboard failure, memory-only goal/brief state, and the agent-owned selection boundary.
- [x] **Local Test**: Web behavior and existing Core contracts verified locally.
- [x] **Repo Checks**: `npm run validate:references` and relevant repository checks passed.
- [x] **Source-Only PR**: No generated registries, web data, or plugin mirrors are included.
- [x] **Credits**: N/A; no imported skill content or source credit changes.
- [x] **License provenance**: N/A; no skill import or license changes.
- [x] **Maintainer Edits**: Owner-authored same-repository branch.

## Scope

This batch does not alter Core selection/search policy or publish a release. Catalog metadata and skill content quality remain separate editorial work; deployment follows the protected release workflow.
