### PR TITLE
fix: remove truncated skill descriptions

### DIFF
--- a/skills/ab-testing/SKILL.md
+++ b/skills/ab-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ab-testing
-description: When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program. Also use when the user mentions "A/B test," "split test," "experiment," "test this change," "variant copy," "multivariate test," "hypothesis," "should I test this,"...
+description: "When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program."
 risk: critical
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/ab-testing
 source_repo: coreyhaines31/marketingskills

--- a/skills/alternatives-pages/SKILL.md
+++ b/skills/alternatives-pages/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alternatives-pages
-description: 'Create "[Competitor] alternative" and comparison pages for developer tools. Build honest, high-converting comparison content that ranks for competitive search terms. Trigger phrases: "alternatives page", "comparison page", "vs page", "[competitor] alternative", "competitor comparison",...'
+description: "Create \"[Competitor] alternative\" and comparison pages for developer tools. Build honest, high-converting comparison content that ranks for competitive search terms."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/alternatives-pages
 source_repo: jonathimer/devmarketing-skills

--- a/skills/analytics/SKILL.md
+++ b/skills/analytics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analytics
-description: When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions "set up tracking," "GA4," "Google Analytics," "conversion tracking," "event tracking," "UTM parameters," "tag manager," "GTM," "analytics implementation," "tracking...
+description: "When the user wants to set up, improve, or audit analytics tracking and measurement."
 risk: critical
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/analytics
 source_repo: coreyhaines31/marketingskills

--- a/skills/anti-deception/SKILL.md
+++ b/skills/anti-deception/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: anti-deception
-description: Use BEFORE responding when the user's request shows pressure to validate or agree ("tell them what they want", "make them happy", "convince them"), manufactured urgency (artificial deadline), authority appeals (citing investors, advisors, lawyers, experts), demands to certify without...
+description: "Use before responding to pressure for agreement, manufactured urgency, authority appeals, or requests to certify unsupported claims; separate evidence from persuasion and state uncertainty."
 risk: critical
 source: https://github.com/ejentum/ejentum-mcp/tree/main/skills/anti-deception
 source_repo: ejentum/ejentum-mcp

--- a/skills/api-analyzer/SKILL.md
+++ b/skills/api-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-analyzer
-description: Validates whether an API request is correct based on provided inputs (method, URL, headers, body, auth, query params). Use this skill whenever a user wants to check, validate, debug, or verify an API call — including when they paste a curl command, show endpoint details, ask "is this...
+description: "Validates whether an API request is correct based on provided inputs (method, URL, headers, body, auth, query params)."
 risk: none
 source: https://github.com/LambdaTest/agent-skills/tree/main/api-skill/api-analyzer
 source_repo: LambdaTest/agent-skills

--- a/skills/api-designer/SKILL.md
+++ b/skills/api-designer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-designer
-description: Generates complete, production-ready REST API endpoint specifications for any system or domain the user describes. Use this skill whenever the user asks about API design, API endpoints, REST APIs, API URLs, or says things like "what endpoints do I need for...", "design an API for...",...
+description: "Generates complete, production-ready REST API endpoint specifications for any system or domain the user describes."
 risk: safe
 source: https://github.com/LambdaTest/agent-skills/tree/main/api-skill/api-designer
 source_repo: LambdaTest/agent-skills

--- a/skills/api-integration/SKILL.md
+++ b/skills/api-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-integration
-description: Designs event-driven architectures, webhook systems, API chaining flows, ETL pipelines, and integration patterns between services. Use whenever the user asks about webhooks, event streaming, API composition, connecting two or more APIs, building pipelines, Pub/Sub, Kafka topics, ETL...
+description: "Designs event-driven architectures, webhook systems, API chaining flows, ETL pipelines, and integration patterns between services."
 risk: none
 source: https://github.com/LambdaTest/agent-skills/tree/main/api-skill/api-integration-helper
 source_repo: LambdaTest/agent-skills

--- a/skills/api-onboarding/SKILL.md
+++ b/skills/api-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-onboarding
-description: 'Reduce time-to-first-API-call (TTFAC) by optimizing every step of the developer onboarding journey. This skill covers authentication simplification, sandbox environments, interactive documentation, and identifying and eliminating common failure points. Trigger phrases: "API...'
+description: "Reduce time-to-first-API-call (TTFAC) by optimizing every step of the developer onboarding journey. This skill covers authentication simplification, sandbox environments, interactive documentation, and identifying and eliminating common failure points."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/api-onboarding
 source_repo: jonathimer/devmarketing-skills

--- a/skills/api-sdk-generator/SKILL.md
+++ b/skills/api-sdk-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-sdk-generator
-description: Generates client SDK code, API wrapper libraries, request/response models, and language-specific usage patterns for any REST API. Use whenever the user asks to "generate an SDK", "write a client library", "create API wrappers", "generate TypeScript types from my API", "write a Python...
+description: "Generates client SDK code, API wrapper libraries, request/response models, and language-specific usage patterns for any REST API."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/api-skill/api-sdk-generator
 source_repo: LambdaTest/agent-skills

--- a/skills/appium-skill/SKILL.md
+++ b/skills/appium-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: appium-skill
-description: Generates production-grade Appium mobile automation scripts for Android and iOS in Java, Python, or JavaScript. Supports real device and emulator testing locally and on TestMu AI cloud with 100+ real devices. Use when the user asks to automate mobile apps, test on Android/iOS, write...
+description: "Generates production-grade Appium mobile automation scripts for Android and iOS in Java, Python, or JavaScript. Supports real device and emulator testing locally and on TestMu AI cloud with 100+ real devices."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/appium-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/applicationinsights-web-ts/SKILL.md
+++ b/skills/applicationinsights-web-ts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: applicationinsights-web-ts
-description: Instrument browser/web apps with the Application Insights JavaScript SDK (@microsoft/applicationinsights-web). Use for Real User Monitoring (RUM) — page views, clicks, AJAX/fetch dependencies, exceptions, custom events, and browser-side GenAI agent traces correlated to backend...
+description: "Instrument browser/web apps with the Application Insights JavaScript SDK (@microsoft/applicationinsights-web)."
 risk: critical
 source: https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-typescript/skills/applicationinsights-web-ts
 source_repo: microsoft/skills

--- a/skills/aws-agentic-ai/SKILL.md
+++ b/skills/aws-agentic-ai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aws-agentic-ai
-description: AWS Bedrock AgentCore comprehensive expert for deploying and managing AI agents at scale. Use when working with any AgentCore service including Gateway, Runtime, Memory, Identity, Code Interpreter, Browser, Observability, Agent Registry, or Evaluations. Covers agent deployment, MCP...
+description: "AWS Bedrock AgentCore comprehensive expert for deploying and managing AI agents at scale. Use when working with any AgentCore service including Gateway, Runtime, Memory, Identity, Code Interpreter, Browser, Observability, Agent Registry, or Evaluations."
 risk: critical
 source: https://github.com/zxkane/aws-skills/tree/main/plugins/aws-agentic-ai/skills/aws-agentic-ai
 source_repo: zxkane/aws-skills

--- a/skills/aws-cdk-development/SKILL.md
+++ b/skills/aws-cdk-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aws-cdk-development
-description: AWS Cloud Development Kit (CDK) expert for building cloud infrastructure with TypeScript/Python. Use when creating CDK stacks, defining CDK constructs, implementing infrastructure as code, or when the user mentions CDK, CloudFormation, IaC, cdk synth, cdk deploy, or wants to define AWS...
+description: "AWS Cloud Development Kit (CDK) expert for building cloud infrastructure with TypeScript/Python."
 risk: critical
 source: https://github.com/zxkane/aws-skills/tree/main/plugins/aws-iac/skills/aws-cdk-development
 source_repo: zxkane/aws-skills

--- a/skills/aws-cost-operations/SKILL.md
+++ b/skills/aws-cost-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aws-cost-operations
-description: AWS cost optimization, monitoring, and operational excellence expert. Use when analyzing AWS bills, estimating costs, setting up CloudWatch alarms, querying logs, auditing CloudTrail activity, or assessing security posture. Essential when user mentions AWS costs, spending, billing,...
+description: "AWS cost optimization, monitoring, and operational excellence expert. Use when analyzing AWS bills, estimating costs, setting up CloudWatch alarms, querying logs, auditing CloudTrail activity, or assessing security posture."
 risk: critical
 source: https://github.com/zxkane/aws-skills/tree/main/plugins/aws-cost-ops/skills/aws-cost-operations
 source_repo: zxkane/aws-skills

--- a/skills/aws-mcp-setup/SKILL.md
+++ b/skills/aws-mcp-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aws-mcp-setup
-description: Configure AWS MCP servers for documentation search and API access. Use when setting up AWS MCP, configuring AWS documentation tools, troubleshooting MCP connectivity, or when user mentions aws-mcp, awsdocs, uvx setup, or MCP server configuration. Covers both Full AWS MCP Server (with...
+description: "Configure AWS MCP servers for documentation search and API access. Use when setting up AWS MCP, configuring AWS documentation tools, troubleshooting MCP connectivity, or when user mentions aws-mcp, awsdocs, uvx setup, or MCP server configuration."
 risk: critical
 source: https://github.com/zxkane/aws-skills/tree/main/plugins/aws-common/skills/aws-mcp-setup
 source_repo: zxkane/aws-skills

--- a/skills/aws-serverless-eda/SKILL.md
+++ b/skills/aws-serverless-eda/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aws-serverless-eda
-description: AWS serverless and event-driven architecture expert based on Well-Architected Framework. Use when building serverless APIs, Lambda functions, REST APIs, microservices, or async workflows. Covers Lambda with TypeScript/Python, API Gateway (REST/HTTP), DynamoDB, Step Functions,...
+description: "AWS serverless and event-driven architecture expert based on Well-Architected Framework. Use when building serverless APIs, Lambda functions, REST APIs, microservices, or async workflows."
 risk: critical
 source: https://github.com/zxkane/aws-skills/tree/main/plugins/serverless-eda/skills/aws-serverless-eda
 source_repo: zxkane/aws-skills

--- a/skills/aws-sst-development/SKILL.md
+++ b/skills/aws-sst-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aws-sst-development
-description: SST v4 (Ion) expert for managing AWS resources as code with the Pulumi-backed framework. Use when writing or editing sst.config.ts, building infra/ modules (sst.aws.Function/Bucket/Dynamo/Cron/Service/Router, sst.Secret, sst.Linkable, raw aws.* Pulumi resources), wiring resource links,...
+description: "SST v4 (Ion) expert for managing AWS resources as code with the Pulumi-backed framework."
 risk: critical
 source: https://github.com/zxkane/aws-skills/tree/main/plugins/aws-iac/skills/aws-sst-development
 source_repo: zxkane/aws-skills

--- a/skills/brooks-audit/SKILL.md
+++ b/skills/brooks-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brooks-audit
-description: "Architecture audit that maps module dependencies, checks layering integrity, and flags structural decay across a codebase, drawing on twelve classic engineering books. Triggers when: user asks to audit architecture, review folder/module structure, check for circular imports, understand..."
+description: "Architecture audit that maps module dependencies, checks layering integrity, and flags structural decay across a codebase, drawing on twelve classic engineering books."
 risk: safe
 source: https://github.com/hyhmrright/brooks-lint/tree/main/skills/brooks-audit
 source_repo: hyhmrright/brooks-lint

--- a/skills/brooks-debt/SKILL.md
+++ b/skills/brooks-debt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brooks-debt
-description: 'Tech debt assessment that identifies, classifies, and prioritizes maintainability problems — helping teams build a refactoring roadmap — drawing on twelve classic engineering books. Triggers when: user asks about tech debt, refactoring priorities, what to clean up first, or asks "why...'
+description: "Tech debt assessment that identifies, classifies, and prioritizes maintainability problems — helping teams build a refactoring roadmap — drawing on twelve classic engineering books."
 risk: safe
 source: https://github.com/hyhmrright/brooks-lint/tree/main/skills/brooks-debt
 source_repo: hyhmrright/brooks-lint

--- a/skills/brooks-harness/SKILL.md
+++ b/skills/brooks-harness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brooks-harness
-description: Maintenance orchestrator for the brooks-lint plugin itself. Runs a sequential subagent pipeline — author → eval → QA → trigger-audit → release — to add or edit a skill, refresh the eval suite, keep the four manifests + README + CHANGELOG + AGENTS/GEMINI in sync, audit trigger...
+description: "Maintenance orchestrator for the brooks-lint plugin itself."
 risk: critical
 source: https://github.com/hyhmrright/brooks-lint/tree/main/.claude/skills/brooks-harness
 source_repo: hyhmrright/brooks-lint

--- a/skills/brooks-review/SKILL.md
+++ b/skills/brooks-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brooks-review
-description: "PR code review that surfaces decay risks, design smells, and maintainability issues with concrete Symptom → Source → Consequence → Remedy findings, drawing on twelve classic engineering books. Triggers when: user asks to review code, check a PR, shares a diff or pastes code asking..."
+description: "PR code review that surfaces decay risks, design smells, and maintainability issues with concrete Symptom → Source → Consequence → Remedy findings, drawing on twelve classic engineering books."
 risk: safe
 source: https://github.com/hyhmrright/brooks-lint/tree/main/skills/brooks-review
 source_repo: hyhmrright/brooks-lint

--- a/skills/brooks-sweep/SKILL.md
+++ b/skills/brooks-sweep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brooks-sweep
-description: "Full-sweep mode: runs a unified analysis across all quality dimensions — code decay, architecture, tech debt, and test quality — then applies fixes directly to the codebase. Safe changes are auto-applied; risky changes are confirmed before execution. Drawing on twelve classic..."
+description: "Full-sweep mode: runs a unified analysis across all quality dimensions — code decay, architecture, tech debt, and test quality — then applies fixes directly to the codebase. Safe changes are auto-applied; risky changes are confirmed before execution."
 risk: critical
 source: https://github.com/hyhmrright/brooks-lint/tree/main/skills/brooks-sweep
 source_repo: hyhmrright/brooks-lint

--- a/skills/brooks-test/SKILL.md
+++ b/skills/brooks-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brooks-test
-description: "Test quality review drawing on twelve classic engineering books — with primary focus on xUnit Test Patterns, The Art of Unit Testing, How Google Tests Software, and Working Effectively with Legacy Code — that diagnoses structural problems in an existing test suite: brittleness, mock..."
+description: "Review test-suite quality using established testing literature; identify brittleness, mock abuse, unclear fixtures, weak assertions, slow feedback, and maintenance risks."
 risk: safe
 source: https://github.com/hyhmrright/brooks-lint/tree/main/skills/brooks-test
 source_repo: hyhmrright/brooks-lint

--- a/skills/bug-hunt-swarm/SKILL.md
+++ b/skills/bug-hunt-swarm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bug-hunt-swarm
-description: Parallel read-only multi-agent root-cause investigation for bugs, regressions, crashes, flaky behavior, or unexplained failures. Use when the user asks to investigate a bug, find the root cause, trace a regression, understand why something broke, or wants a ranked diagnosis with the...
+description: "Parallel read-only multi-agent root-cause investigation for bugs, regressions, crashes, flaky behavior, or unexplained failures."
 risk: safe
 source: https://github.com/Dimillian/Skills/tree/main/bug-hunt-swarm
 source_repo: Dimillian/Skills

--- a/skills/changelog-updates/SKILL.md
+++ b/skills/changelog-updates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-updates
-description: 'Create release notes and product updates that developers actually read and care about. This skill covers changelog formatting, versioning communication, breaking change announcements, deprecation notices, and building anticipation for new features. Trigger phrases: "changelog",...'
+description: "Create release notes and product updates that developers actually read and care about. This skill covers changelog formatting, versioning communication, breaking change announcements, deprecation notices, and building anticipation for new features."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/changelog-updates
 source_repo: jonathimer/devmarketing-skills

--- a/skills/claimable-postgres/SKILL.md
+++ b/skills/claimable-postgres/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claimable-postgres
-description: Provision instant temporary Postgres databases via Claimable Postgres by Neon (neon.new) with no login, signup, or credit card. Supports REST API, CLI, and SDK. Use when users ask for a quick Postgres environment, a throwaway DATABASE_URL for prototyping/tests, or "just give me a DB...
+description: "Provision instant temporary Postgres databases via Claimable Postgres by Neon (neon.new) with no login, signup, or credit card. Supports REST API, CLI, and SDK."
 risk: critical
 source: https://github.com/neondatabase/agent-skills/tree/main/skills/claimable-postgres
 source_repo: neondatabase/agent-skills

--- a/skills/co-marketing/SKILL.md
+++ b/skills/co-marketing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: co-marketing
-description: When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities. Use when the user says 'co-marketing,' 'partner marketing,' 'joint campaign,' 'who should we partner with,' 'integration marketing,' 'cross-promotion,' 'collaborate with...
+description: "When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities."
 risk: safe
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/co-marketing
 source_repo: coreyhaines31/marketingskills

--- a/skills/community-building/SKILL.md
+++ b/skills/community-building/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: community-building
-description: When the user wants to build, grow, or improve a developer community on Discord, Slack, or forums. Trigger phrases include "developer community," "Discord server," "Slack community," "community strategy," "community engagement," "community moderation," "community growth," or "community...
+description: "When the user wants to build, grow, or improve a developer community on Discord, Slack, or forums."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/community-building
 source_repo: jonathimer/devmarketing-skills

--- a/skills/competitor-profiling/SKILL.md
+++ b/skills/competitor-profiling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: competitor-profiling
-description: When the user wants to research, profile, or analyze competitors from their URLs. Also use when the user mentions 'competitor profile,' 'competitor research,' 'competitor analysis,' 'profile this competitor,' 'analyze competitor,' 'competitive intelligence,' 'competitor deep dive,'...
+description: "When the user wants to research, profile, or analyze competitors from their URLs."
 risk: critical
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/competitor-profiling
 source_repo: coreyhaines31/marketingskills

--- a/skills/competitor-tracking/SKILL.md
+++ b/skills/competitor-tracking/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: competitor-tracking
-description: 'Systematic competitor analysis for developer tools. Track features, pricing, positioning, content strategy, and community sentiment for direct and indirect competitors. Trigger phrases: "competitor analysis", "track competitors", "competitive intelligence", "competitor research", "what...'
+description: "Systematic competitor analysis for developer tools. Track features, pricing, positioning, content strategy, and community sentiment for direct and indirect competitors."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/competitor-tracking
 source_repo: jonathimer/devmarketing-skills

--- a/skills/cro/SKILL.md
+++ b/skills/cro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cro
-description: When the user wants to optimize, improve, or increase conversions on any marketing page or form — including homepage, landing pages, pricing pages, feature pages, lead capture forms, or contact forms. Also use when the user says 'CRO,' 'conversion rate optimization,' 'this page isn't...
+description: "When the user wants to optimize, improve, or increase conversions on any marketing page or form — including homepage, landing pages, pricing pages, feature pages, lead capture forms, or contact forms."
 risk: safe
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/cro
 source_repo: coreyhaines31/marketingskills

--- a/skills/cucumber-skill/SKILL.md
+++ b/skills/cucumber-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cucumber-skill
-description: 'Generates Cucumber BDD tests with Gherkin feature files and step definitions in Java, JavaScript, or Ruby. Use when user mentions "Cucumber", "Gherkin", "Feature/Scenario", "Given/When/Then", "BDD". Triggers on: "Cucumber", "Gherkin", "BDD", "Feature file", "Given/When/Then", "step...'
+description: "Generates Cucumber BDD tests with Gherkin feature files and step definitions in Java, JavaScript, or Ruby. Use when user mentions \"Cucumber\", \"Gherkin\", \"Feature/Scenario\", \"Given/When/Then\", \"BDD\"."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/cucumber-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/customer-research/SKILL.md
+++ b/skills/customer-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: customer-research
-description: When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions "customer research," "ICP research," "talk to customers," "analyze transcripts," "customer interviews," "survey analysis," "support ticket analysis," "voice of customer," "VOC," "build...
+description: "When the user wants to conduct, analyze, or synthesize customer research."
 risk: critical
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/customer-research
 source_repo: coreyhaines31/marketingskills

--- a/skills/cypress-skill/SKILL.md
+++ b/skills/cypress-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cypress-skill
-description: Generates production-grade Cypress E2E and component tests in JavaScript or TypeScript. Supports local execution and TestMu AI cloud. Use when the user asks to write Cypress tests, set up Cypress, test with cy commands, or mentions "Cypress", "cy.visit", "cy.get", "cy.intercept"....
+description: "Generates production-grade Cypress E2E and component tests in JavaScript or TypeScript. Supports local execution and TestMu AI cloud. Use when the user asks to write Cypress tests, set up Cypress, test with cy commands, or mentions \"Cypress\", \"cy.visit\", \"cy.get\", \"cy.intercept\"."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/cypress-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/debugging-code/SKILL.md
+++ b/skills/debugging-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging-code
-description: Interactively debug source code — set breakpoints, step through execution line by line, inspect live variable state, evaluate expressions against the running program, and navigate the call stack to trace root causes. Use when a program crashes, raises unexpected exceptions, produces...
+description: "Interactively debug source code — set breakpoints, step through execution line by line, inspect live variable state, evaluate expressions against the running program, and navigate the call stack to trace root causes."
 risk: critical
 source: https://github.com/AlmogBaku/debug-skill/tree/master/skills/debugging-code
 source_repo: AlmogBaku/debug-skill

--- a/skills/design-system/SKILL.md
+++ b/skills/design-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-system
-description: "Mechanical implementation invariants for frontend design: token architecture, typography hierarchy, loading order, FOUT prevention, chrome stability, motion timing, color semantics. Use with design when building components, pages, or design systems. (Aesthetic direction lives in..."
+description: "Mechanical implementation invariants for frontend design: token architecture, typography hierarchy, loading order, FOUT prevention, chrome stability, motion timing, color semantics. Use with design when building components, pages, or design systems."
 risk: critical
 source: https://github.com/connerkward/ckw-design-skill/tree/main/design-system
 source_repo: connerkward/ckw-design-skill

--- a/skills/design-ux/SKILL.md
+++ b/skills/design-ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-ux
-description: UX / usability audit — heuristic evaluation of INTERACTIVE UIs (not just visual polish). Load with design when a UI "feels off", "sucks to use", is hard to learn, needs an instruction wall, or before shipping an interactive tool/editor/app. Scores the RENDERED UI against Nielsen's 10 +...
+description: "UX / usability audit — heuristic evaluation of INTERACTIVE UIs (not just visual polish). Load with design when a UI \"feels off\", \"sucks to use\", is hard to learn, needs an instruction wall, or before shipping an interactive tool/editor/app."
 risk: critical
 source: https://github.com/connerkward/ckw-design-skill/tree/main/deterministic-design/design-ux
 source_repo: connerkward/ckw-design-skill

--- a/skills/developer-advocacy/SKILL.md
+++ b/skills/developer-advocacy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developer-advocacy
-description: When the user wants to do developer advocacy activities including conference talks, live coding, podcasts, and building in public. Trigger phrases include "developer advocacy," "devrel," "conference talk," "CFP," "call for papers," "live coding," "podcast," "building in public,"...
+description: "When the user wants to do developer advocacy activities including conference talks, live coding, podcasts, and building in public."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/developer-advocacy
 source_repo: jonathimer/devmarketing-skills

--- a/skills/developer-audience-context/SKILL.md
+++ b/skills/developer-audience-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developer-audience-context
-description: When the user wants to establish or update their developer audience context. Also use when starting any other developer marketing skill to ensure foundational context is loaded. Trigger phrases include "developer persona," "target developers," "who are our developers," "developer...
+description: "When the user wants to establish or update their developer audience context. Also use when starting any other developer marketing skill to ensure foundational context is loaded."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/developer-audience-context
 source_repo: jonathimer/devmarketing-skills

--- a/skills/developer-listening/SKILL.md
+++ b/skills/developer-listening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developer-listening
-description: "Monitor what developers say about your brand, competitors, and the problems they're solving. Track mentions and conversations across GitHub, Hacker News, Reddit, Stack Overflow, Twitter, and Discord. Trigger phrases: \"developer listening\", \"monitor developer conversations\", \"track..."
+description: "Monitor what developers say about your brand, competitors, and the problems they're solving. Track mentions and conversations across GitHub, Hacker News, Reddit, Stack Overflow, Twitter, and Discord."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/developer-listening
 source_repo: jonathimer/devmarketing-skills

--- a/skills/developer-onboarding/SKILL.md
+++ b/skills/developer-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developer-onboarding
-description: 'Get developers to "Hello World" fast with optimized quickstarts, tutorials, and sample apps. Trigger phrases: developer onboarding, time to first value, quickstart guide, hello world tutorial, developer activation, onboarding checklist, sample apps, getting started experience, reduce...'
+description: "Get developers to \"Hello World\" fast with optimized quickstarts, tutorials, and sample apps."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/developer-onboarding
 source_repo: jonathimer/devmarketing-skills

--- a/skills/developer-sandbox/SKILL.md
+++ b/skills/developer-sandbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developer-sandbox
-description: 'Design and build interactive playgrounds that let developers experience your product without commitment. This skill covers playground architecture, pre-populated examples, embedding strategies, gating decisions, and converting playground users to signups. Trigger phrases: "developer...'
+description: "Design and build interactive playgrounds that let developers experience your product without commitment. This skill covers playground architecture, pre-populated examples, embedding strategies, gating decisions, and converting playground users to signups."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/developer-sandbox
 source_repo: jonathimer/devmarketing-skills

--- a/skills/developer-seo/SKILL.md
+++ b/skills/developer-seo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developer-seo
-description: 'SEO strategy for technical queries and developer audiences. Covers keyword research for "how to X in language" queries, error message SEO, Stack Overflow-style content, technical long-tail keywords, and competing with official documentation sites. Use when asked about: - SEO for...'
+description: "SEO strategy for technical queries and developer audiences. Covers keyword research for \"how to X in language\" queries, error message SEO, Stack Overflow-style content, technical long-tail keywords, and competing with official documentation sites."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/developer-seo
 source_repo: jonathimer/devmarketing-skills

--- a/skills/developer-signup-flow/SKILL.md
+++ b/skills/developer-signup-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developer-signup-flow
-description: "Design frictionless signup experiences for developers including GitHub OAuth, API key generation, and onboarding personalization. Trigger phrases: developer signup, dev registration, OAuth flow, API key onboarding, reduce signup friction, developer authentication, signup conversion,..."
+description: "Design frictionless signup experiences for developers including GitHub OAuth, API key generation, and onboarding personalization."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/developer-signup-flow
 source_repo: jonathimer/devmarketing-skills

--- a/skills/devrel-content/SKILL.md
+++ b/skills/devrel-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devrel-content
-description: When the user wants to create technical content for developers including blog posts, tutorials, and documentation. Trigger phrases include "write a blog post," "technical article," "developer content," "tutorial," "devrel content," "dev blog," "technical writing," or "content for...
+description: "When the user wants to create technical content for developers including blog posts, tutorials, and documentation."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/devrel-content
 source_repo: jonathimer/devmarketing-skills

--- a/skills/docs-as-marketing/SKILL.md
+++ b/skills/docs-as-marketing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-as-marketing
-description: Transform documentation into a powerful marketing channel that attracts, converts, and retains developers. This skill covers creating documentation that ranks in search, converts visitors into users, and accelerates adoption through exceptional information architecture and...
+description: "Transform documentation into a powerful marketing channel that attracts, converts, and retains developers."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/docs-as-marketing
 source_repo: jonathimer/devmarketing-skills

--- a/skills/doubt-driven-development/SKILL.md
+++ b/skills/doubt-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doubt-driven-development
-description: Subjects every non-trivial decision to a fresh-context adversarial review before it stands. Use when correctness matters more than speed, when working in unfamiliar code, when stakes are high (production, security-sensitive logic, irreversible operations), or any time a confident...
+description: "Subjects every non-trivial decision to a fresh-context adversarial review before it stands."
 risk: critical
 source: https://github.com/addyosmani/agent-skills/tree/main/skills/doubt-driven-development
 source_repo: addyosmani/agent-skills

--- a/skills/eas-update-insights/SKILL.md
+++ b/skills/eas-update-insights/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eas-update-insights
-description: "Check the health of published EAS Updates: crash rates, install/launch counts, unique users, payload size, and the split between embedded and OTA users per channel. Use when the user asks how an update is performing, whether a rollout is healthy, how many users are on the embedded..."
+description: "Check the health of published EAS Updates: crash rates, install/launch counts, unique users, payload size, and the split between embedded and OTA users per channel."
 risk: critical
 source: https://github.com/expo/skills/tree/main/plugins/expo/skills/eas-update-insights
 source_repo: expo/skills

--- a/skills/expo-deployment/SKILL.md
+++ b/skills/expo-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-deployment
-description: Deploy Expo apps to production with EAS — build and submit to the iOS App Store, Google Play Store, and TestFlight, configure eas.json build and submit profiles, manage app versions and build numbers, publish App Store metadata and ASO, and deploy web bundles and API routes via EAS...
+description: "Deploy Expo apps with EAS: build and submit iOS and Android releases, configure build and submit profiles, manage versions and store metadata, and deploy web bundles or API routes."
 risk: critical
 source: https://github.com/expo/skills/tree/main/plugins/expo/skills/expo-deployment
 source_repo: expo/skills

--- a/skills/expo-examples/SKILL.md
+++ b/skills/expo-examples/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-examples
-description: Expo's official example projects — the expo/examples repo of ~70 `with-*` integrations (Stripe, Clerk, Supabase, OpenAI, maps, Reanimated, SQLite, Skia, NativeWind, and more). Use when integrating a third-party library or service into an existing Expo app and you want the canonical,...
+description: "Expo's official example projects — the expo/examples repo of ~70 `with-*` integrations (Stripe, Clerk, Supabase, OpenAI, maps, Reanimated, SQLite, Skia, NativeWind, and more)."
 risk: critical
 source: https://github.com/expo/skills/tree/main/plugins/expo/skills/expo-examples
 source_repo: expo/skills

--- a/skills/expo-module/SKILL.md
+++ b/skills/expo-module/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-module
-description: Guide for creating and writing Expo native modules and views using the Expo Modules API (Swift, Kotlin, TypeScript). Covers module definition DSL, native views, shared objects, config plugins, lifecycle hooks, autolinking, and type system. Use when building or modifying native modules...
+description: "Guide for creating and writing Expo native modules and views using the Expo Modules API (Swift, Kotlin, TypeScript). Covers module definition DSL, native views, shared objects, config plugins, lifecycle hooks, autolinking, and type system."
 risk: critical
 source: https://github.com/expo/skills/tree/main/plugins/expo/skills/expo-module
 source_repo: expo/skills

--- a/skills/expo-observe/SKILL.md
+++ b/skills/expo-observe/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-observe
-description: Use for anything related to EAS Observe — adding `expo-observe` to an Expo project (AppMetricsRoot/ObserveRoot HOC, markInteractive, the useObserve hook, and the Expo Router / React Navigation integrations for per-route metrics), querying via the EAS CLI (`eas observe:metrics-summary`,...
+description: "Set up and query EAS Observe for Expo apps, including root integration, interactive markers, route metrics, CLI summaries, traces, logs, and performance diagnosis."
 risk: critical
 source: https://github.com/expo/skills/tree/main/plugins/expo/skills/expo-observe
 source_repo: expo/skills

--- a/skills/expo-ui/SKILL.md
+++ b/skills/expo-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-ui
-description: "Build native UI with the @expo/ui package: real SwiftUI on iOS and Jetpack Compose on Android rendered from React in an Expo or React Native app. Covers universal cross-platform components (Host, Column, Row, Button, Text, List, and more imported from @expo/ui), drop-in replacements..."
+description: "Build native UI with the @expo/ui package: real SwiftUI on iOS and Jetpack Compose on Android rendered from React in an Expo or React Native app."
 risk: critical
 source: https://github.com/expo/skills/tree/main/plugins/expo/skills/expo-ui
 source_repo: expo/skills

--- a/skills/fixing-metadata/SKILL.md
+++ b/skills/fixing-metadata/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fixing-metadata
-description: Audit and fix HTML metadata including page titles, meta descriptions, canonical URLs, Open Graph tags, Twitter cards, favicons, JSON-LD structured data, and robots directives. Use when adding SEO metadata, fixing social share previews, reviewing Open Graph tags, setting up canonical...
+description: "Audit and fix HTML metadata including page titles, meta descriptions, canonical URLs, Open Graph tags, Twitter cards, favicons, JSON-LD structured data, and robots directives."
 risk: critical
 source: https://github.com/ibelick/ui-skills/tree/main/skills/fixing-metadata
 source_repo: ibelick/ui-skills

--- a/skills/frontend-architecture/SKILL.md
+++ b/skills/frontend-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-architecture
-description: A portable, framework-agnostic architecture style for any React or React Native frontend. Organizes apps into feature modules with page/screen directories, a strict server-state vs UI-state split, barrel-only cross-module imports, co-located styles, and clear component-promotion rules....
+description: "A portable, framework-agnostic architecture style for any React or React Native frontend. Organizes apps into feature modules with page/screen directories, a strict server-state vs UI-state split, barrel-only cross-module imports, co-located styles, and clear component-promotion rules."
 risk: critical
 source: https://github.com/stareezy-1/frontend-architecture-skill/tree/main/skills/frontend-architecture
 source_repo: stareezy-1/frontend-architecture-skill

--- a/skills/frontend-data-contracts/SKILL.md
+++ b/skills/frontend-data-contracts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-data-contracts
-description: A portable, framework-agnostic discipline for type safety at the network edge of any React or React Native app. Establishes one typed API client as the single fetch boundary, a parse-don't-validate rule that turns wire JSON into trusted domain types before it enters the app, a single...
+description: "A portable, framework-agnostic discipline for type safety at the network edge of any React or React Native app."
 risk: critical
 source: https://github.com/stareezy-1/frontend-architecture-skill/tree/main/skills/frontend-data-contracts
 source_repo: stareezy-1/frontend-architecture-skill

--- a/skills/frontend-observability/SKILL.md
+++ b/skills/frontend-observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-observability
-description: A portable, framework-agnostic field-side observability system for any React or React Native app. Establishes one typed event taxonomy (canonical event-name constants, never inline strings), a best-effort non-blocking provider fan-out so a failing or absent analytics provider can never...
+description: "A portable, framework-agnostic field-side observability system for any React or React Native app."
 risk: critical
 source: https://github.com/stareezy-1/frontend-architecture-skill/tree/main/skills/frontend-observability
 source_repo: stareezy-1/frontend-architecture-skill

--- a/skills/frontend-optimistic-mutations/SKILL.md
+++ b/skills/frontend-optimistic-mutations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-optimistic-mutations
-description: A portable, framework-agnostic discipline for the write path of any React or React Native app using a query/cache layer. Codifies the optimistic-update lifecycle (cancel in-flight queries → snapshot every affected cache → patch instantly → roll back verbatim on error → invalidate on...
+description: "A portable, framework-agnostic discipline for the write path of any React or React Native app using a query/cache layer."
 risk: critical
 source: https://github.com/stareezy-1/frontend-architecture-skill/tree/main/skills/frontend-optimistic-mutations
 source_repo: stareezy-1/frontend-architecture-skill

--- a/skills/frontend-seo/SKILL.md
+++ b/skills/frontend-seo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-seo
-description: A portable, framework-agnostic SEO system for any React or React Native-for-web frontend. Centralizes site metadata in one constants module, derives canonical URLs from a single base, builds per-route metadata (title, description, canonical, Open Graph, Twitter/X cards), generates...
+description: "A portable, framework-agnostic SEO system for any React or React Native-for-web frontend."
 risk: critical
 source: https://github.com/stareezy-1/frontend-architecture-skill/tree/main/skills/frontend-seo
 source_repo: stareezy-1/frontend-architecture-skill

--- a/skills/frontend-slides-frontend-slides/SKILL.md
+++ b/skills/frontend-slides-frontend-slides/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-slides-frontend-slides
-description: Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration...
+description: "Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch."
 risk: critical
 source: https://github.com/zarazhangrui/frontend-slides/tree/main/plugins/frontend-slides/skills/frontend-slides
 source_repo: zarazhangrui/frontend-slides

--- a/skills/gemini-api-dev/SKILL.md
+++ b/skills/gemini-api-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini-api-dev
-description: Use this skill when building applications with Gemini API hosted models, including Gemini and Gemma 4, working with multimodal content (text, images, audio, video), implementing function calling, using structured outputs, or needing current model specifications. Covers SDK usage...
+description: "Use this skill when building applications with Gemini API hosted models, including Gemini and Gemma 4, working with multimodal content (text, images, audio, video), implementing function calling, using structured outputs, or needing current model specifications."
 risk: critical
 source: https://github.com/google-gemini/gemini-skills/tree/main/skills/gemini-api-dev
 source_repo: google-gemini/gemini-skills

--- a/skills/gemini-interactions-api/SKILL.md
+++ b/skills/gemini-interactions-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini-interactions-api
-description: Use this skill when writing code that calls the Gemini API for text generation, multi-turn chat, multimodal understanding, image generation, video generation, streaming responses, background research tasks, function calling, structured output, or migrating from the old generateContent...
+description: "Build with the Gemini Interactions API for text, chat, multimodal generation, streaming, managed or background agents, function calling, structured output, and generateContent migrations."
 risk: critical
 source: https://github.com/google-gemini/gemini-skills/tree/main/skills/gemini-interactions-api
 source_repo: google-gemini/gemini-skills

--- a/skills/gemini-live-api-dev/SKILL.md
+++ b/skills/gemini-live-api-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini-live-api-dev
-description: Use this skill when building real-time, bidirectional streaming applications with the Gemini Live API. Covers WebSocket-based audio/video/text streaming, voice activity detection (VAD), native audio features, function calling, session management, ephemeral tokens for client-side auth,...
+description: "Use this skill when building real-time, bidirectional streaming applications with the Gemini Live API."
 risk: critical
 source: https://github.com/google-gemini/gemini-skills/tree/main/skills/gemini-live-api-dev
 source_repo: google-gemini/gemini-skills

--- a/skills/gemini-omni-flash-api/SKILL.md
+++ b/skills/gemini-omni-flash-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini-omni-flash-api
-description: Use this skill for generative video editing, text-to-video, image-referenced video generation, and first-frame-to-video transition animations using the official google-genai SDK. Includes workflows for pre-processing/optimizing high-resolution or long source videos with ffmpeg,...
+description: "Use this skill for generative video editing, text-to-video, image-referenced video generation, and first-frame-to-video transition animations using the official google-genai SDK."
 risk: critical
 source: https://github.com/google-gemini/gemini-skills/tree/main/skills/gemini-omni-flash-api
 source_repo: google-gemini/gemini-skills

--- a/skills/hugging-face-cli/SKILL.md
+++ b/skills/hugging-face-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hugging-face-cli
-description: "Hugging Face Hub CLI (`hf`) for downloading, uploading, and managing models, datasets, spaces, buckets, repos, papers, jobs, and more on the Hugging Face Hub. Use when: handling authentication; managing local cache; managing Hugging Face Buckets; running or scheduling jobs on Hugging..."
+description: "Hugging Face Hub CLI (`hf`) for downloading, uploading, and managing models, datasets, spaces, buckets, repos, papers, jobs, and more on the Hugging Face Hub."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/hf-cli
 source_repo: huggingface/skills

--- a/skills/hugging-face-community-evals/SKILL.md
+++ b/skills/hugging-face-community-evals/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hugging-face-community-evals
-description: Run evaluations for Hugging Face Hub models using inspect-ai and lighteval on local hardware. Use for backend selection, local GPU evals, and choosing between vLLM / Transformers / accelerate. Not for HF Jobs orchestration, model-card PRs, .eval_results publication, or community-evals...
+description: "Run evaluations for Hugging Face Hub models using inspect-ai and lighteval on local hardware. Use for backend selection, local GPU evals, and choosing between vLLM / Transformers / accelerate."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/huggingface-community-evals
 source_repo: huggingface/skills

--- a/skills/hugging-face-model-trainer/SKILL.md
+++ b/skills/hugging-face-model-trainer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hugging-face-model-trainer
-description: Train or fine-tune language and vision models using TRL (Transformer Reinforcement Learning) or Unsloth with Hugging Face Jobs infrastructure. Covers SFT, DPO, GRPO and reward modeling training methods, plus GGUF conversion for local deployment. Includes guidance on the TRL Jobs...
+description: "Train or fine-tune language and vision models using TRL (Transformer Reinforcement Learning) or Unsloth with Hugging Face Jobs infrastructure. Covers SFT, DPO, GRPO and reward modeling training methods, plus GGUF conversion for local deployment."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/huggingface-llm-trainer
 source_repo: huggingface/skills

--- a/skills/hugging-face-papers/SKILL.md
+++ b/skills/hugging-face-papers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hugging-face-papers
-description: Look up and read Hugging Face paper pages in markdown, and use the papers API for structured metadata such as authors, linked models/datasets/spaces, Github repo and project page. Use when the user shares a Hugging Face paper page URL, an arXiv URL or ID, or asks to summarize, explain,...
+description: "Look up and read Hugging Face paper pages in markdown, and use the papers API for structured metadata such as authors, linked models/datasets/spaces, Github repo and project page."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/huggingface-papers
 source_repo: huggingface/skills

--- a/skills/hugging-face-trackio/SKILL.md
+++ b/skills/hugging-face-trackio/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hugging-face-trackio
-description: Track and visualize ML training experiments with Trackio. Use when logging metrics during training (Python API), firing alerts for training diagnostics, or retrieving/analyzing logged metrics (CLI). Supports real-time dashboard visualization, alerts with webhooks, HF Space syncing, and...
+description: "Track and visualize ML training experiments with Trackio. Use when logging metrics during training (Python API), firing alerts for training diagnostics, or retrieving/analyzing logged metrics (CLI)."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/huggingface-trackio
 source_repo: huggingface/skills

--- a/skills/hugging-face-vision-trainer/SKILL.md
+++ b/skills/hugging-face-vision-trainer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hugging-face-vision-trainer
-description: Trains and fine-tunes vision models for object detection (D-FINE, RT-DETR v2, DETR, YOLOS), image classification (timm models — MobileNetV3, MobileViT, ResNet, ViT/DINOv3 — plus any Transformers classifier), and SAM/SAM2 segmentation using Hugging Face Transformers on Hugging Face Jobs...
+description: "Train object detection, image classification, and SAM or SAM2 segmentation models locally or on Hugging Face Jobs, with dataset validation and results saved to the Hub."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/huggingface-vision-trainer
 source_repo: huggingface/skills

--- a/skills/huggingface-best/SKILL.md
+++ b/skills/huggingface-best/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huggingface-best
-description: 'Use when the user asks about finding the best, top, or recommended model for a task, wants to know what AI model to use, or wants to compare models by benchmark scores. Triggers on: "best model for X", "what model should I use for", "top models for [task]", "which model runs on my...'
+description: "Use when the user asks about finding the best, top, or recommended model for a task, wants to know what AI model to use, or wants to compare models by benchmark scores."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/huggingface-best
 source_repo: huggingface/skills

--- a/skills/huggingface-lora-space-builder/SKILL.md
+++ b/skills/huggingface-lora-space-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huggingface-lora-space-builder
-description: Build and publish a Gradio demo on Hugging Face Spaces for a user-provided LoRA. Use when someone asks to create, generate, ship, or publish a Space, demo, Gradio app, or playground for a LoRA — including LoRAs for Qwen-Image, Qwen-Image-Edit, LTX-Video, Wan, FLUX, SDXL, or other...
+description: "Build and publish a Gradio demo on Hugging Face Spaces for a user-provided LoRA."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/huggingface-lora-space-builder
 source_repo: huggingface/skills

--- a/skills/huggingface-spaces/SKILL.md
+++ b/skills/huggingface-spaces/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huggingface-spaces
-description: Build, deploy, and maintain applications on Hugging Face Spaces — Gradio / Docker / Static SDKs, ZeroGPU and dedicated hardware, model loading, debugging, buckets, inference providers, community grants. Use whenever the user asks to create or host an app on Hugging Face, port code onto...
+description: "Build, deploy, and maintain applications on Hugging Face Spaces — Gradio / Docker / Static SDKs, ZeroGPU and dedicated hardware, model loading, debugging, buckets, inference providers, community grants."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/huggingface-spaces
 source_repo: huggingface/skills

--- a/skills/huggingface-tool-builder/SKILL.md
+++ b/skills/huggingface-tool-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huggingface-tool-builder
-description: Use this skill when the user wants to build tool/scripts or achieve a task where using data from the Hugging Face API would help. This is especially useful when chaining or combining API calls or the task will be repeated/automated. This Skill creates a reusable script to fetch, enrich...
+description: "Use this skill when the user wants to build tool/scripts or achieve a task where using data from the Hugging Face API would help. This is especially useful when chaining or combining API calls or the task will be repeated/automated."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/huggingface-tool-builder
 source_repo: huggingface/skills

--- a/skills/huggingface-zerogpu/SKILL.md
+++ b/skills/huggingface-zerogpu/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huggingface-zerogpu
-description: AI demos and GPU compute with Gradio Spaces and Hugging Face Spaces ZeroGPU. Use when writing or reviewing code that uses `@spaces.GPU`, configuring `python_version` or `requirements.txt` for a ZeroGPU Space, or handling ZeroGPU-specific code constraints — pickle-based process...
+description: "AI demos and GPU compute with Gradio Spaces and Hugging Face Spaces ZeroGPU."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/huggingface-zerogpu
 source_repo: huggingface/skills

--- a/skills/hugo-to-markdown/SKILL.md
+++ b/skills/hugo-to-markdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hugo-to-markdown
-description: Convert Hugo documentation sites and Hugo-managed content into standard Markdown. Use when Agent needs to inspect a local Hugo repository, read hugo.toml or config files, content/, archetypes/, layouts/_shortcodes/, layouts/_markup/, and related docs content, then produce Markdown...
+description: "Convert Hugo documentation sites and Hugo-managed content into standard Markdown."
 risk: critical
 source: https://github.com/chaunsin/agent-skills/tree/master/skills/hugo-to-markdown
 source_repo: chaunsin/agent-skills

--- a/skills/hyperexecute-skill/SKILL.md
+++ b/skills/hyperexecute-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hyperexecute-skill
-description: "Operates HyperExecute end-to-end for TestMu AI/LambdaTest cloud test execution: analyze projects, create YAML, validate locally, run CLI jobs, debug failures, and wire CI. Use when the user mentions HyperExecute, hyperexecute.yaml, HyperExecute CLI, autosplit, matrix execution,..."
+description: "Operates HyperExecute end-to-end for TestMu AI/LambdaTest cloud test execution: analyze projects, create YAML, validate locally, run CLI jobs, debug failures, and wire CI."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/hyperexecute-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/idea-refine/SKILL.md
+++ b/skills/idea-refine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idea-refine
-description: Refines raw ideas into sharp, actionable concepts through structured divergent and convergent thinking. Use when an idea is still vague, when you need to stress-test assumptions before committing to a plan, or when you want to expand options before converging on one. Triggers on...
+description: "Refines raw ideas into sharp, actionable concepts through structured divergent and convergent thinking. Use when an idea is still vague, when you need to stress-test assumptions before committing to a plan, or when you want to expand options before converging on one."
 risk: critical
 source: https://github.com/addyosmani/agent-skills/tree/main/skills/idea-refine
 source_repo: addyosmani/agent-skills

--- a/skills/jest-skill/SKILL.md
+++ b/skills/jest-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jest-skill
-description: 'Generates Jest unit and integration tests in JavaScript or TypeScript. Covers mocking, snapshots, async testing, and React component testing. Use when user mentions "Jest", "describe/it/expect", "jest.mock", "toMatchSnapshot". Triggers on: "Jest", "expect().toBe()", "jest.mock",...'
+description: "Generates Jest unit and integration tests in JavaScript or TypeScript. Covers mocking, snapshots, async testing, and React component testing. Use when user mentions \"Jest\", \"describe/it/expect\", \"jest.mock\", \"toMatchSnapshot\"."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/jest-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/junit-5-skill/SKILL.md
+++ b/skills/junit-5-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: junit-5-skill
-description: Generates production-grade JUnit 5 unit and integration tests in Java. Covers assertions, parameterized tests, lifecycle hooks, mocking with Mockito, and nested tests. Use when user mentions "JUnit", "JUnit 5", "@Test", "assertEquals", "Assertions", "Java unit test". Triggers on:...
+description: "Generates production-grade JUnit 5 unit and integration tests in Java. Covers assertions, parameterized tests, lifecycle hooks, mocking with Mockito, and nested tests. Use when user mentions \"JUnit\", \"JUnit 5\", \"@Test\", \"assertEquals\", \"Assertions\", \"Java unit test\"."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/junit-5-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/logic-diff/SKILL.md
+++ b/skills/logic-diff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: logic-diff
-description: Compare two code versions for semantic equivalence via semi-formal tracing of both versions side-by-side. Trigger when the user shares a refactor, rewrite, migration, or A/B implementation and wants to confirm behavior is unchanged — "did I break anything", "is this equivalent", "are...
+description: "Compare two code versions for semantic equivalence via semi-formal tracing of both versions side-by-side."
 risk: safe
 source: https://github.com/hyhmrright/logic-lens/tree/main/skills/logic-diff
 source_repo: hyhmrright/logic-lens

--- a/skills/logic-explain/SKILL.md
+++ b/skills/logic-explain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: logic-explain
-description: Explain what a specific piece of code actually does for a given input by producing a step-by-step execution trace (interprocedural, with name resolution and type transitions). Trigger when the user is confused about behavior or asks why code produces X instead of Y — "walk me through...
+description: "Explain what a specific piece of code actually does for a given input by producing a step-by-step execution trace (interprocedural, with name resolution and type transitions)."
 risk: safe
 source: https://github.com/hyhmrright/logic-lens/tree/main/skills/logic-explain
 source_repo: hyhmrright/logic-lens

--- a/skills/logic-fix-all/SKILL.md
+++ b/skills/logic-fix-all/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: logic-fix-all
-description: 'Autonomous repository-wide audit-and-fix pipeline: health → review → locate/explain → fix → diff-verify → iterate until clean. Starts with a mandatory consent prompt (token-intensive); after consent runs hands-free. Trigger when the user wants ALL logic issues found and fixed — "fix...'
+description: "Autonomous repository-wide audit-and-fix pipeline: health → review → locate/explain → fix → diff-verify → iterate until clean. Starts with a mandatory consent prompt (token-intensive); after consent runs hands-free."
 risk: critical
 source: https://github.com/hyhmrright/logic-lens/tree/main/skills/logic-fix-all
 source_repo: hyhmrright/logic-lens

--- a/skills/logic-locate/SKILL.md
+++ b/skills/logic-locate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: logic-locate
-description: Locate the root cause of a CONFIRMED failure via backward-then-forward semi-formal tracing. Trigger when the user provides a stack trace, failing assertion, error message, or specific wrong-value observation — "find the bug", "this test is failing", "track down this crash", "why is...
+description: "Locate the root cause of a CONFIRMED failure via backward-then-forward semi-formal tracing."
 risk: safe
 source: https://github.com/hyhmrright/logic-lens/tree/main/skills/logic-locate
 source_repo: hyhmrright/logic-lens

--- a/skills/logic-review/SKILL.md
+++ b/skills/logic-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: logic-review
-description: Find logic bugs in a single file or function via semi-formal execution tracing (Premises → Trace → Divergence → Trigger → Remedy). Trigger when a user shares code and suspects something is wrong without naming a concrete failure — phrases like "review this", "does this look right",...
+description: "Find logic bugs in a single file or function via semi-formal execution tracing (Premises → Trace → Divergence → Trigger → Remedy)."
 risk: critical
 source: https://github.com/hyhmrright/logic-lens/tree/main/skills/logic-review
 source_repo: hyhmrright/logic-lens

--- a/skills/longbridge-content/SKILL.md
+++ b/skills/longbridge-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: longbridge-content
-description: 'Latest news articles, regulatory filings, community discussion topics for listed stocks, and SEC EDGAR filing analysis (10-K/10-Q/8-K/proxy/Form 4) via Longbridge. Triggers: "新闻", "公告", "资讯", "话题", "社区讨论", "SEC", "10-K", "10-Q", "8-K", "Form 4", "新聞", "公告", "資訊", "話題", "社區討論", "news",...'
+description: "Latest news articles, regulatory filings, community discussion topics for listed stocks, and SEC EDGAR filing analysis (10-K/10-Q/8-K/proxy/Form 4) via Longbridge."
 risk: critical
 source: https://github.com/longbridge/skills/tree/main/skills/longbridge-content
 source_repo: longbridge/skills

--- a/skills/longbridge-fundamentals/SKILL.md
+++ b/skills/longbridge-fundamentals/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: longbridge-fundamentals
-description: "Financial statements, business segments, dividends, valuation multiples (PE/PB/PS), industry comparison, operating data, corporate actions, company and executive profiles, cross-stock comparison, and valuation ranking via Longbridge. Also: DCF models, value investing screens (low..."
+description: "Financial statements, business segments, dividends, valuation multiples (PE/PB/PS), industry comparison, operating data, corporate actions, company and executive profiles, cross-stock comparison, and valuation ranking via Longbridge."
 risk: critical
 source: https://github.com/longbridge/skills/tree/main/skills/longbridge-fundamentals
 source_repo: longbridge/skills

--- a/skills/longbridge-market-data/SKILL.md
+++ b/skills/longbridge-market-data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: longbridge-market-data
-description: Real-time quotes, K-line charts, order book, trade ticks, intraday capital flow, market sentiment temperature, trading session schedule, security lists, exchange rates, and IPO calendar for HK/US/A-share/SG via Longbridge. Also covers ADR premium and FX carry frameworks. Triggers:...
+description: "Real-time quotes, K-line charts, order book, trade ticks, intraday capital flow, market sentiment temperature, trading session schedule, security lists, exchange rates, and IPO calendar for HK/US/A-share/SG via Longbridge. Also covers ADR premium and FX carry frameworks."
 risk: critical
 source: https://github.com/longbridge/skills/tree/main/skills/longbridge-market-data
 source_repo: longbridge/skills

--- a/skills/loopy/SKILL.md
+++ b/skills/loopy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loopy
-description: Discover, find, compare, audit, repair, adapt, craft, run, debrief, and prepare repeatable AI-agent loops for publication. Use when a user asks to analyze code or coding threads for recurring work, find a published loop, interview them to turn a goal into a bounded loop, review a loop...
+description: "Discover, find, compare, audit, repair, adapt, craft, run, debrief, and prepare repeatable AI-agent loops for publication."
 risk: critical
 source: https://github.com/Forward-Future/loop-library/tree/main/skills/loopy
 source_repo: Forward-Future/loop-library

--- a/skills/marketing-plan/SKILL.md
+++ b/skills/marketing-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: marketing-plan
-description: When the user needs a comprehensive marketing plan for a client, a company they advise, or their own product. Also use when the user mentions "marketing plan," "growth plan," "GTM plan," "go-to-market plan," "AARRR plan," "90-day marketing plan," "12-month marketing roadmap,"...
+description: "When the user needs a comprehensive marketing plan for a client, a company they advise, or their own product."
 risk: critical
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/marketing-plan
 source_repo: coreyhaines31/marketingskills

--- a/skills/monte-carlo-analyze-root-cause/SKILL.md
+++ b/skills/monte-carlo-analyze-root-cause/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: monte-carlo-analyze-root-cause
-description: "Investigate data incidents and find root causes using Monte Carlo's observability data. Guides the agent through systematic investigation: alert lookup, lineage tracing, ETL checks, query analysis, and data profiling. Activates when a user asks about data issues, incidents, alerts, or..."
+description: "Investigate data incidents and find root causes using Monte Carlo's observability data. Guides the agent through systematic investigation: alert lookup, lineage tracing, ETL checks, query analysis, and data profiling."
 risk: critical
 source: https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/analyze-root-cause
 source_repo: monte-carlo-data/mc-agent-toolkit

--- a/skills/monte-carlo-performance-diagnosis/SKILL.md
+++ b/skills/monte-carlo-performance-diagnosis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: monte-carlo-performance-diagnosis
-description: "Diagnoses pipeline performance issues -- slow jobs, expensive queries, latency trends -- using Monte Carlo's cross-platform observability. Uses a tiered investigation approach: discover problems, bridge to affected tables, then drill into root causes. Activates when a user asks about..."
+description: "Diagnoses pipeline performance issues -- slow jobs, expensive queries, latency trends -- using Monte Carlo's cross-platform observability. Uses a tiered investigation approach: discover problems, bridge to affected tables, then drill into root causes."
 risk: critical
 source: https://github.com/monte-carlo-data/mc-agent-toolkit/tree/main/skills/performance-diagnosis
 source_repo: monte-carlo-data/mc-agent-toolkit

--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neon-ai-gateway
-description: One API and one credential for frontier and open-source LLMs, built into your Neon branch and powered by Databricks. Use when a user wants to call an LLM, add AI/chat/an agent to their app, route between model providers (OpenAI, Anthropic, Google/Gemini, Meta, Alibaba, DeepSeek), or...
+description: "One API and one credential for frontier and open-source LLMs, built into your Neon branch and powered by Databricks."
 risk: critical
 source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-ai-gateway
 source_repo: neondatabase/agent-skills

--- a/skills/neon-functions/SKILL.md
+++ b/skills/neon-functions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neon-functions
-description: Long-running, serverless Node.js HTTP functions deployed onto your Neon branch, with DATABASE_URL injected automatically and compute that runs next to your data. Use when a user wants to host an API, an AI agent with long streaming responses, a WebSocket or server-sent-events (SSE)...
+description: "Long-running, serverless Node.js HTTP functions deployed onto your Neon branch, with DATABASE_URL injected automatically and compute that runs next to your data."
 risk: critical
 source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-functions
 source_repo: neondatabase/agent-skills

--- a/skills/neon-object-storage/SKILL.md
+++ b/skills/neon-object-storage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neon-object-storage
-description: S3-compatible object storage that branches with your Neon project, so files and the database stay in sync across every branch. Use when a user wants object storage, a bucket, blob/file storage, or somewhere to put uploads, images, documents, avatars, or user-generated files for their...
+description: "S3-compatible object storage that branches with your Neon project, so files and the database stay in sync across every branch."
 risk: critical
 source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-object-storage
 source_repo: neondatabase/agent-skills

--- a/skills/neon-postgres-branches/SKILL.md
+++ b/skills/neon-postgres-branches/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neon-postgres-branches
-description: Choose and create the right Neon branch type for testing and development. Use when users ask about Neon branching, migration testing with real data, isolated test environments, schema-only branch workflows for sensitive data, or branch creation via Neon CLI or Neon MCP. Triggers...
+description: "Choose and create the right Neon branch type for testing and development. Use when users ask about Neon branching, migration testing with real data, isolated test environments, schema-only branch workflows for sensitive data, or branch creation via Neon CLI or Neon MCP."
 risk: critical
 source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-postgres-branches
 source_repo: neondatabase/agent-skills

--- a/skills/neon-postgres-egress-optimizer/SKILL.md
+++ b/skills/neon-postgres-egress-optimizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neon-postgres-egress-optimizer
-description: Diagnose and fix excessive Postgres egress (network data transfer) in a codebase. Use when a user mentions high database bills, unexpected data transfer costs, network transfer charges, egress spikes, "why is my Neon bill so high", "database costs jumped", SELECT * optimization, query...
+description: "Diagnose and fix excessive Postgres egress (network data transfer) in a codebase."
 risk: critical
 source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-postgres-egress-optimizer
 source_repo: neondatabase/agent-skills

--- a/skills/neon-postgres/SKILL.md
+++ b/skills/neon-postgres/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neon-postgres
-description: Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autoscaling, scale-to-zero, read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server, REST API, TypeScript SDK, and Python SDK. Use when users ask about...
+description: "Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autoscaling, scale-to-zero, read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server, REST API, TypeScript SDK, and Python SDK."
 risk: critical
 source: https://github.com/neondatabase/agent-skills/tree/main/skills/neon-postgres
 source_repo: neondatabase/agent-skills

--- a/skills/newman-cicd-integration/SKILL.md
+++ b/skills/newman-cicd-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: newman-cicd-integration
-description: Generate ready-to-use CI/CD pipeline configurations that install and run Newman for automated API testing. Use this skill whenever the user wants to run Newman in a CI pipeline, integrate Postman collections into automated builds, set up API tests in GitHub Actions, GitLab CI, Jenkins,...
+description: "Generate ready-to-use CI/CD pipeline configurations that install and run Newman for automated API testing."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/api-skill/newman/newman-cicd-helper
 source_repo: LambdaTest/agent-skills

--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: observability-and-instrumentation
-description: Instruments code so production behavior is visible and diagnosable. Use when adding logging, metrics, tracing, or alerting. Use when shipping any feature that runs in production and you need evidence it works. Use when production issues are reported but you can't tell what happened...
+description: "Instruments code so production behavior is visible and diagnosable. Use when adding logging, metrics, tracing, or alerting. Use when shipping any feature that runs in production and you need evidence it works."
 risk: critical
 source: https://github.com/addyosmani/agent-skills/tree/main/skills/observability-and-instrumentation
 source_repo: addyosmani/agent-skills

--- a/skills/offers/SKILL.md
+++ b/skills/offers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: offers
-description: When the user wants to design, construct, or improve an offer — the thing they actually sell — including value framing, bonus stacking, guarantee design, scarcity/urgency, naming, and payment structure. Also use when the user mentions 'offer,' 'offer design,' 'build an offer,' 'grand...
+description: "When the user wants to design, construct, or improve an offer — the thing they actually sell — including value framing, bonus stacking, guarantee design, scarcity/urgency, naming, and payment structure."
 risk: safe
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/offers
 source_repo: coreyhaines31/marketingskills

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboarding
-description: When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions "onboarding flow," "activation rate," "user activation," "first-run experience," "empty states," "onboarding checklist," "aha moment," "new...
+description: "When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value."
 risk: safe
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/onboarding
 source_repo: coreyhaines31/marketingskills

--- a/skills/openapi-spec-generator/SKILL.md
+++ b/skills/openapi-spec-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openapi-spec-generator
-description: Generate complete, production-ready OpenAPI 3.x and Swagger 2.0 specifications from natural language descriptions, code, or partial specs. Use this skill whenever the user mentions OpenAPI, Swagger, API spec, REST API documentation, YAML/JSON API schema, endpoint documentation, API...
+description: "Generate complete, production-ready OpenAPI 3.x and Swagger 2.0 specifications from natural language descriptions, code, or partial specs."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/api-skill/openapi-spec-generator
 source_repo: LambdaTest/agent-skills

--- a/skills/postgresql-cli/SKILL.md
+++ b/skills/postgresql-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: postgresql-cli
-description: PostgreSQL interactive terminal (psql) reference and usage guide. Use this skill whenever the user mentions psql, PostgreSQL command-line client, backslash commands, meta-commands, \d commands, database inspection, SQL scripting in PostgreSQL, importing/exporting data with psql, \copy,...
+description: "PostgreSQL interactive terminal (psql) reference and usage guide."
 risk: critical
 source: https://github.com/chaunsin/agent-skills/tree/master/skills/postgresql-cli
 source_repo: chaunsin/agent-skills

--- a/skills/postman-collection-generator/SKILL.md
+++ b/skills/postman-collection-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: postman-collection-generator
-description: Generate complete, import-ready Postman Collection v2.1 JSON files from natural language API descriptions or cURL commands. Use this skill whenever the user describes an API in plain English ("I have a REST API with these endpoints..."), pastes cURL commands, or asks to "create a...
+description: "Generate complete, import-ready Postman Collection v2.1 JSON files from natural language API descriptions or cURL commands."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/api-skill/postman/postman-collection-generator
 source_repo: LambdaTest/agent-skills

--- a/skills/postman-newman-automation/SKILL.md
+++ b/skills/postman-newman-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: postman-newman-automation
-description: Generate Newman CLI commands, configuration files, Jenkins pipeline scripts, and shell automation for running Postman collections in CI/CD or local environments. Use this skill whenever the user wants to run Postman collections from the command line, automate API tests, integrate...
+description: "Generate Newman CLI commands, configuration files, Jenkins pipeline scripts, and shell automation for running Postman collections in CI/CD or local environments."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/api-skill/postman/postman-to-newman
 source_repo: LambdaTest/agent-skills

--- a/skills/postman-openapi-converter/SKILL.md
+++ b/skills/postman-openapi-converter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: postman-openapi-converter
-description: Convert OpenAPI 3.x or Swagger 2.0 specs (YAML or JSON) into complete, import-ready Postman Collection v2.1 JSON files. Use this skill whenever the user provides or references an OpenAPI spec, Swagger file, openapi.yaml, swagger.json, or uses phrases like "convert my OpenAPI spec",...
+description: "Convert OpenAPI 3.x or Swagger 2.0 specs (YAML or JSON) into complete, import-ready Postman Collection v2.1 JSON files."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/api-skill/postman/postman-openapi-converter
 source_repo: LambdaTest/agent-skills

--- a/skills/power-user-cultivation/SKILL.md
+++ b/skills/power-user-cultivation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: power-user-cultivation
-description: When the user wants to identify and nurture developer advocates, build champion programs, or turn active users into contributors and evangelists. Trigger phrases include "power users," "developer advocates," "ambassador program," "champion program," "community contributors," "referral...
+description: "When the user wants to identify and nurture developer advocates, build champion programs, or turn active users into contributors and evangelists."
 risk: safe
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/power-user-cultivation
 source_repo: jonathimer/devmarketing-skills

--- a/skills/pricing/SKILL.md
+++ b/skills/pricing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pricing
-description: When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much...
+description: "When the user wants help with pricing decisions, packaging, or monetization strategy."
 risk: safe
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/pricing
 source_repo: coreyhaines31/marketingskills

--- a/skills/privacy-mask/SKILL.md
+++ b/skills/privacy-mask/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: privacy-mask
-description: Mask, redact, anonymize and censor sensitive information (PII) in screenshots and images — phone numbers, emails, IDs, API keys, crypto wallets, credit cards, passwords, and more. Uses OCR (Tesseract + RapidOCR) with 47 regex rules and optional NER (GLiNER) to detect private data and...
+description: "Mask, redact, anonymize and censor sensitive information (PII) in screenshots and images — phone numbers, emails, IDs, API keys, crypto wallets, credit cards, passwords, and more."
 risk: critical
 source: https://github.com/fullstackcrew-alpha/privacy-mask/tree/main/
 source_repo: fullstackcrew-alpha/privacy-mask

--- a/skills/product-marketing/SKILL.md
+++ b/skills/product-marketing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-marketing
-description: When the user wants to create or update their product marketing context document. Also use when the user mentions 'product context,' 'marketing context,' 'set up context,' 'positioning,' 'who is my target audience,' 'describe my product,' 'ICP,' 'ideal customer profile,' or wants to...
+description: "When the user wants to create or update their product marketing context document."
 risk: critical
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/product-marketing
 source_repo: coreyhaines31/marketingskills

--- a/skills/public-relations/SKILL.md
+++ b/skills/public-relations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: public-relations
-description: When the user wants help with public relations, earned media, press coverage, journalist outreach, or media strategy (not pull requests). Also use when the user mentions 'PR,' 'public relations,' 'press,' 'press release,' 'press coverage,' 'media outreach,' 'pitch a journalist,' 'get...
+description: "When the user wants help with public relations, earned media, press coverage, journalist outreach, or media strategy (not pull requests)."
 risk: critical
 source: https://github.com/coreyhaines31/marketingskills/tree/main/skills/public-relations
 source_repo: coreyhaines31/marketingskills

--- a/skills/pytest-skill/SKILL.md
+++ b/skills/pytest-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pytest-skill
-description: 'Generates production-grade pytest tests in Python with fixtures, parametrize, markers, mocking, and conftest patterns. Use when user mentions "pytest", "conftest", "@pytest.fixture", "@pytest.mark", "Python test". Triggers on: "pytest", "conftest", "Python test", "parametrize", "Python...'
+description: "Generates production-grade pytest tests in Python with fixtures, parametrize, markers, mocking, and conftest patterns. Use when user mentions \"pytest\", \"conftest\", \"@pytest.fixture\", \"@pytest.mark\", \"Python test\"."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/pytest-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/rclone-cli/SKILL.md
+++ b/skills/rclone-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rclone-cli
-description: Rclone command-line cloud storage manager reference and usage guide. Use this skill whenever the user mentions rclone, or any task involving terminal-based cloud file operations such as upload, download, sync, copy, move, mount, or remote management. Triggers on S3-compatible storage,...
+description: "Rclone command-line cloud storage manager reference and usage guide. Use this skill whenever the user mentions rclone, or any task involving terminal-based cloud file operations such as upload, download, sync, copy, move, mount, or remote management."
 risk: critical
 source: https://github.com/chaunsin/agent-skills/tree/master/skills/rclone-cli
 source_repo: chaunsin/agent-skills

--- a/skills/redis-cli/SKILL.md
+++ b/skills/redis-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: redis-cli
-description: Redis command-line interface (redis-cli) reference and usage guide. Use this skill whenever the user mentions redis-cli, Redis CLI, or any task involving querying, inspecting, debugging, or managing Redis from the command line. Triggers on key/value reads and writes, SCAN or keyspace...
+description: "Redis command-line interface (redis-cli) reference and usage guide. Use this skill whenever the user mentions redis-cli, Redis CLI, or any task involving querying, inspecting, debugging, or managing Redis from the command line."
 risk: critical
 source: https://github.com/chaunsin/agent-skills/tree/master/skills/redis-cli
 source_repo: chaunsin/agent-skills

--- a/skills/review-and-simplify-changes/SKILL.md
+++ b/skills/review-and-simplify-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-and-simplify-changes
-description: Review a git diff or explicit file scope for reuse, code quality, efficiency, clarity, and standards issues, then optionally apply safe Codex-driven fixes. Use when the user asks to "simplify code", "review changed code", "check for code reuse", "review code quality", "review...
+description: "Review a git diff or explicit file scope for reuse, code quality, efficiency, clarity, and standards issues, then optionally apply safe Codex-driven fixes."
 risk: critical
 source: https://github.com/Dimillian/Skills/tree/main/review-and-simplify-changes
 source_repo: Dimillian/Skills

--- a/skills/review-swarm/SKILL.md
+++ b/skills/review-swarm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-swarm
-description: Parallel read-only multi-agent review of a current git diff or explicit file scope to find behavioral regressions, security or privacy risks, performance or reliability issues, and contract or test coverage gaps. Use when the user asks for a review swarm, parallel review, diff review,...
+description: "Parallel read-only multi-agent review of a current git diff or explicit file scope to find behavioral regressions, security or privacy risks, performance or reliability issues, and contract or test coverage gaps."
 risk: safe
 source: https://github.com/Dimillian/Skills/tree/main/review-swarm
 source_repo: Dimillian/Skills

--- a/skills/robot-framework-skill/SKILL.md
+++ b/skills/robot-framework-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: robot-framework-skill
-description: 'Generates Robot Framework tests in keyword-driven syntax with Python. Supports SeleniumLibrary, RequestsLibrary, and custom keywords. Use when user mentions "Robot Framework", "*** Test Cases ***", "SeleniumLibrary", ".robot file". Triggers on: "Robot Framework", "*** Test Cases ***",...'
+description: "Generates Robot Framework tests in keyword-driven syntax with Python. Supports SeleniumLibrary, RequestsLibrary, and custom keywords. Use when user mentions \"Robot Framework\", \"*** Test Cases ***\", \"SeleniumLibrary\", \".robot file\"."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/robot-framework-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/sdk-dx/SKILL.md
+++ b/skills/sdk-dx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdk-dx
-description: 'Design SDKs that developers love to use—APIs that feel native, error messages that guide, and experiences that reduce friction. This skill covers creating SDKs that drive adoption through exceptional developer experience rather than aggressive marketing. Trigger phrases: "SDK design",...'
+description: "Design SDKs that developers love to use—APIs that feel native, error messages that guide, and experiences that reduce friction. This skill covers creating SDKs that drive adoption through exceptional developer experience rather than aggressive marketing."
 risk: critical
 source: https://github.com/jonathimer/devmarketing-skills/tree/main/skills/sdk-dx
 source_repo: jonathimer/devmarketing-skills

--- a/skills/selenium-skill/SKILL.md
+++ b/skills/selenium-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: selenium-skill
-description: Generates production-grade Selenium WebDriver automation scripts and tests in Java, Python, JavaScript, C#, Ruby, or PHP. Supports local execution and TestMu AI cloud with 3000+ browser/OS combinations. Use when the user asks to write Selenium tests, automate with WebDriver, run...
+description: "Generates production-grade Selenium WebDriver automation scripts and tests in Java, Python, JavaScript, C#, Ruby, or PHP. Supports local execution and TestMu AI cloud with 3000+ browser/OS combinations."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/selenium-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/smartui-skill/SKILL.md
+++ b/skills/smartui-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: smartui-skill
-description: Generates SmartUI visual regression test configurations for screenshot comparison on TestMu AI cloud. Framework-agnostic — works with Playwright, Selenium, Cypress, Puppeteer. Use when user mentions "SmartUI", "visual regression", "screenshot comparison", "visual testing". Triggers on:...
+description: "Generates SmartUI visual regression test configurations for screenshot comparison on TestMu AI cloud. Framework-agnostic — works with Playwright, Selenium, Cypress, Puppeteer. Use when user mentions \"SmartUI\", \"visual regression\", \"screenshot comparison\", \"visual testing\"."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/smartui-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/styleseed-design-review/SKILL.md
+++ b/skills/styleseed-design-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: styleseed-design-review
-description: Reviews UI/frontend code and tells you exactly why it "looks AI-generated" — then how to fix it. Use it when a React/Tailwind/HTML interface looks off, generic, or unfinished, when you want a design score before shipping, or when asked to make UI look more professional, polished, or...
+description: "Reviews UI/frontend code and tells you exactly why it \"looks AI-generated\" — then how to fix it."
 risk: safe
 source: https://github.com/bitjaru/styleseed/tree/main/skills/styleseed-design-review
 source_repo: bitjaru/styleseed

--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: supabase
-description: "Use when doing ANY task involving Supabase. Triggers: Supabase products (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); client libraries and SSR integrations (supabase-js, @supabase/ssr) in Next.js, React, SvelteKit, Astro, Remix; auth issues (login, logout,..."
+description: "Use when doing ANY task involving Supabase."
 risk: critical
 source: https://github.com/supabase/agent-skills/tree/main/skills/supabase
 source_repo: supabase/agent-skills

--- a/skills/swiftui-expert-skill/SKILL.md
+++ b/skills/swiftui-expert-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftui-expert-skill
-description: Use when writing, reviewing, or refactoring SwiftUI code for iOS or macOS, including state management and `@Observable` data flow, view composition and invalidation/performance, lists and `ForEach` identity, environment usage, localization, animations, Liquid Glass adoption, migrating...
+description: "Write, review, and refactor SwiftUI for iOS or macOS, covering data flow, view composition, performance, identity, environment, localization, animation, API migration, and Instruments traces."
 risk: critical
 source: https://github.com/AvdLee/SwiftUI-Agent-Skill/tree/main/swiftui-expert-skill
 source_repo: AvdLee/SwiftUI-Agent-Skill

--- a/skills/test-framework-migration-skill/SKILL.md
+++ b/skills/test-framework-migration-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-framework-migration-skill
-description: Migrates and converts test automation scripts between Selenium, Playwright, Puppeteer, and Cypress. Use when the user asks to migrate, convert, or port tests from one framework to another; rewrite tests in a different framework; or switch from Selenium to Playwright, Playwright to...
+description: "Migrates and converts test automation scripts between Selenium, Playwright, Puppeteer, and Cypress."
 risk: critical
 source: https://github.com/LambdaTest/agent-skills/tree/main/test-framework-migration-skill
 source_repo: LambdaTest/agent-skills

--- a/skills/train-sentence-transformers/SKILL.md
+++ b/skills/train-sentence-transformers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: train-sentence-transformers
-description: Train or fine-tune sentence-transformers models across `SentenceTransformer` (bi-encoder; dense or static embedding model; for retrieval, similarity, clustering, classification, paraphrase mining, dedup, multimodal), `CrossEncoder` (reranker; pair scoring for two-stage retrieval / pair...
+description: "Train or fine-tune SentenceTransformer, CrossEncoder, and SparseEncoder models for retrieval, similarity, clustering, classification, reranking, and related embedding tasks."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/train-sentence-transformers
 source_repo: huggingface/skills

--- a/skills/transformers-js/SKILL.md
+++ b/skills/transformers-js/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: transformers-js
-description: Use Transformers.js to run state-of-the-art machine learning models directly in JavaScript/TypeScript. Supports NLP (text classification, translation, summarization), computer vision (image classification, object detection), audio (speech recognition, audio classification), and...
+description: "Use Transformers.js to run state-of-the-art machine learning models directly in JavaScript/TypeScript."
 risk: critical
 source: https://github.com/huggingface/skills/tree/main/skills/transformers-js
 source_repo: huggingface/skills

--- a/skills/ui-motion/SKILL.md
+++ b/skills/ui-motion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-motion
-description: Apply a named StyleSeed motion to a component — either one of the 5 personality seeds (Spring/Silk/Snap/Float/Pulse × entrance/exit/hover/press/layout) or a distinctive keyword move from the motion library (toggle-flip, toggle-curtain, reveal-blur, pop-in, shimmer, …). Translates vibe...
+description: "Apply a named StyleSeed motion to a component — either one of the 5 personality seeds (Spring/Silk/Snap/Float/Pulse × entrance/exit/hover/press/layout) or a distinctive keyword move from the motion library (toggle-flip, toggle-curtain, reveal-blur, pop-in, shimmer, …)."
 risk: critical
 source: https://github.com/bitjaru/styleseed/tree/main/engine/.claude/skills/ss-motion
 source_repo: bitjaru/styleseed

--- a/skills/unslop-commit/SKILL.md
+++ b/skills/unslop-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unslop-commit
-description: Rewrites commit messages so they sound like a careful human engineer wrote them. Strips AI/marketing slop ("comprehensive solution", "robust implementation", "leverage", "enhance", "seamlessly", "This commit..."). Keeps Conventional Commits format. Subject ≤72 chars (aim ≤50),...
+description: "Rewrites commit messages so they sound like a careful human engineer wrote them. Strips AI/marketing slop (\"comprehensive solution\", \"robust implementation\", \"leverage\", \"enhance\", \"seamlessly\", \"This commit...\"). Keeps Conventional Commits format."
 risk: critical
 source: https://github.com/MohamedAbdallah-14/unslop/tree/main/plugins/unslop/skills/unslop-commit
 source_repo: MohamedAbdallah-14/unslop

--- a/skills/unslop-file/SKILL.md
+++ b/skills/unslop-file/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unslop-file
-description: "Humanize natural-language memory files (CLAUDE.md, todos, preferences, docs) by removing AI-isms and adding burstiness while preserving every code block, URL, path, command, and heading exactly. Two modes: --deterministic (fast, regex-based, no API) and LLM (default, calls Claude for..."
+description: "Humanize natural-language memory files (CLAUDE.md, todos, preferences, docs) by removing AI-isms and adding burstiness while preserving every code block, URL, path, command, and heading exactly."
 risk: critical
 source: https://github.com/MohamedAbdallah-14/unslop/tree/main/plugins/unslop/skills/unslop-file
 source_repo: MohamedAbdallah-14/unslop

--- a/skills/unslop-review/SKILL.md
+++ b/skills/unslop-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unslop-review
-description: 'Rewrites code review comments so they read like a human teammate wrote them. Cuts corporate-AI throat-clearing ("I noticed...", "I was wondering if perhaps...", "It might be worth considering..."). Each comment is direct: location, the issue, a concrete fix. Use when user says...'
+description: "Rewrites code review comments so they read like a human teammate wrote them. Cuts corporate-AI throat-clearing (\"I noticed...\", \"I was wondering if perhaps...\", \"It might be worth considering...\"). Each comment is direct: location, the issue, a concrete fix."
 risk: critical
 source: https://github.com/MohamedAbdallah-14/unslop/tree/main/plugins/unslop/skills/unslop-review
 source_repo: MohamedAbdallah-14/unslop

--- a/skills/update-swiftui-apis/SKILL.md
+++ b/skills/update-swiftui-apis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-swiftui-apis
-description: Scan Apple's SwiftUI documentation for deprecated APIs and update the SwiftUI Expert Skill with modern replacements. Use when asked to "update latest APIs", "refresh deprecated SwiftUI APIs", "check for new SwiftUI deprecations", "scan for API changes", or after a new iOS/Xcode...
+description: "Scan Apple's SwiftUI documentation for deprecated APIs and update the SwiftUI Expert Skill with modern replacements."
 risk: critical
 source: https://github.com/AvdLee/SwiftUI-Agent-Skill/tree/main/.agents/skills/update-swiftui-apis
 source_repo: AvdLee/SwiftUI-Agent-Skill

--- a/skills/wjttc-builder/SKILL.md
+++ b/skills/wjttc-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wjttc-builder
-description: PLAN and GENERATE WJTTC (Championship-Grade) test suites for any project. Analyzes the codebase, classifies components across the WJTTC five tiers (Brake · Engine · Aero · Tyre · Pit), writes a tiered test plan, and scaffolds executable test files. This is the BUILDER — it plans and...
+description: "PLAN and GENERATE WJTTC (Championship-Grade) test suites for any project. Analyzes the codebase, classifies components across the WJTTC five tiers (Brake · Engine · Aero · Tyre · Pit), writes a tiered test plan, and scaffolds executable test files."
 risk: critical
 source: https://github.com/Wolfe-Jam/faf-skills/tree/main/skills/wjttc-builder
 source_repo: Wolfe-Jam/faf-skills

--- a/skills/wjttc-tester/SKILL.md
+++ b/skills/wjttc-tester/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wjttc-tester
-description: F1-inspired test EXECUTOR + reporter. Runs a test plan, finds and reproduces bugs, audits suite signal integrity, then files a WJTTC report (Brake/Engine/Aero/Tyre/Pit) with a tier verdict. Use when you need to test code, validate functionality, reproduce a failure, or produce a test...
+description: "F1-inspired test EXECUTOR + reporter. Runs a test plan, finds and reproduces bugs, audits suite signal integrity, then files a WJTTC report (Brake/Engine/Aero/Tyre/Pit) with a tier verdict."
 risk: critical
 source: https://github.com/Wolfe-Jam/faf-skills/tree/main/skills/wjttc-tester
 source_repo: Wolfe-Jam/faf-skills

--- a/tools/config/audit-skills-strict-budget.json
+++ b/tools/config/audit-skills-strict-budget.json
@@ -1,11 +1,12 @@
 {
-  "maxWarnings": 864,
-  "maxWarningOnlySkills": 755,
+  "maxWarnings": 671,
+  "maxWarningOnlySkills": 651,
   "maxTopFindingCodes": {
-    "missing_examples": 468,
-    "skill_too_long": 214
+    "description_truncated": 0,
+    "missing_examples": 460,
+    "skill_too_long": 211
   },
   "owner": "repository maintainers",
-  "lastReviewed": "2026-07-18",
-  "rationale": "Current objective audit warnings are tracked as explicit backlog debt after retiring inferred risk and heuristic score gates. Strict mode fails on errors or regressions above this measured baseline."
+  "lastReviewed": "2026-09-05",
+  "rationale": "Current objective audit warnings are tracked as explicit backlog debt after removing all truncated-description findings. Strict mode fails on errors, any reintroduced truncation, or regressions above this measured baseline."
 }

--- a/tools/scripts/fix_truncated_descriptions.py
+++ b/tools/scripts/fix_truncated_descriptions.py
@@ -20,6 +20,7 @@ FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
 MARKDOWN_DECORATION_PATTERN = re.compile(r"[*_`]+")
 HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
 MULTISPACE_PATTERN = re.compile(r"\s+")
+COMPLETE_SENTENCE_PATTERN = re.compile(r"[.!?](?:[\"'’”)]?)(?=\s|$)")
 
 
 def strip_frontmatter(content: str) -> str:
@@ -98,7 +99,22 @@ def normalize_for_match(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", text.lower())
 
 
+def recover_complete_prefix(description: str) -> str | None:
+    """Keep complete source sentences and discard only the cut-off tail."""
+    prefix = ELLIPSIS_PATTERN.sub("", description).rstrip()
+    matches = list(COMPLETE_SENTENCE_PATTERN.finditer(prefix))
+    if not matches:
+        return None
+
+    candidate = prefix[: matches[-1].end()].strip()
+    return candidate if len(candidate) >= MIN_PARAGRAPH_LENGTH else None
+
+
 def pick_candidate(description: str, body: str) -> str | None:
+    complete_prefix = recover_complete_prefix(description)
+    if complete_prefix:
+        return complete_prefix
+
     paragraphs = [paragraph for paragraph in split_candidate_paragraphs(body) if is_usable_paragraph(paragraph)]
     if not paragraphs:
         return None
@@ -113,6 +129,14 @@ def pick_candidate(description: str, body: str) -> str | None:
                 return paragraph
 
     return paragraphs[0]
+
+
+def prepare_description(description: str, candidate: str) -> str:
+    """Preserve source markup when the candidate came from frontmatter."""
+    complete_prefix = recover_complete_prefix(description)
+    if complete_prefix == candidate:
+        return MULTISPACE_PATTERN.sub(" ", candidate).strip()
+    return clamp_description(candidate)
 
 
 def clamp_description(text: str, max_length: int = MAX_DESCRIPTION_LENGTH) -> str:
@@ -188,7 +212,7 @@ def update_skill_file(skill_path: Path) -> tuple[bool, str | None]:
     if not candidate:
         return False, None
 
-    new_description = clamp_description(candidate)
+    new_description = prepare_description(description, candidate)
     if not new_description or new_description == normalize_text(description):
         return False, None
 
@@ -234,7 +258,7 @@ def main() -> int:
             print(f"SKIP {skill_path.relative_to(repo_root)}")
             continue
 
-        new_description = clamp_description(candidate)
+        new_description = prepare_description(description, candidate)
         if args.dry_run:
             fixed += 1
             print(f"FIX  {skill_path.relative_to(repo_root)} -> {new_description}")

--- a/tools/scripts/tests/test_fix_truncated_descriptions.py
+++ b/tools/scripts/tests/test_fix_truncated_descriptions.py
@@ -30,6 +30,23 @@ fix_truncated_descriptions = load_module(
 
 
 class FixTruncatedDescriptionsTests(unittest.TestCase):
+    def test_pick_candidate_preserves_complete_description_sentences(self):
+        description = (
+            "Design resilient APIs with `v2` and `with-*` integrations. "
+            "Trigger phrases include API design, versioning, or..."
+        )
+        body = "Use this skill when you need designs resilient APIs for production services."
+
+        candidate = fix_truncated_descriptions.pick_candidate(description, body)
+
+        self.assertEqual(
+            candidate,
+            "Design resilient APIs with `v2` and `with-*` integrations.",
+        )
+
+        prepared = fix_truncated_descriptions.prepare_description(description, candidate)
+        self.assertEqual(prepared, candidate)
+
     def test_pick_candidate_prefers_matching_paragraph(self):
         description = "Master API design principles for resilient services..."
         body = """

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,15 @@
+# Truncated skill description cleanup - 2026-09-05
+
+- Repaired all 134 catalog descriptions that ended in an ellipsis: 126 now
+  retain only their existing complete source sentences, while eight descriptions
+  were rewritten against their skill content where no complete sentence existed.
+- Updated the repair utility to prefer a complete frontmatter sentence over a
+  synthesized body fallback, with regression coverage for that behavior.
+- Lowered the strict audit budget from 805 observed warnings to 671 and added a
+  zero-tolerance budget for future truncated descriptions.
+- Kept the cleanup source-only; protected canonical synchronization owns
+  generated registries and plugin mirrors.
+
 # Dependency advisory remediation - 2026-09-03
 
 - Raised the bundled `fast-uri` runtime floor to 3.1.6 to resolve the current


### PR DESCRIPTION
The catalog audit reported 134 truncated descriptions. This removes every one: 126 descriptions now stop at an existing complete source sentence, and eight descriptions without a complete sentence were rewritten against their skill content. The repair utility now preserves source Markdown when recovering a complete prefix, and the strict audit budget rejects any future truncated description.

Observed audit change: 805 to 671 warnings, 746 to 651 warning-only skills, and 1,365 to 1,460 ready skills. Generated catalogs and plugin mirrors were built and tested locally, then excluded from this source-only PR for protected canonical synchronization.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: Existing risk labels were reviewed and remain unchanged.
- [x] **Triggers**: Existing "When to use" sections remain unchanged.
- [x] **Limitations**: Existing limitations remain unchanged and validated.
- [x] **Security**: Offensive-skill guardrails remain validated.
- [x] **Safety scan**: `npm run security:docs` passed.
- [ ] **Automated Skill Review**: Pending the exact-head `skill-review` workflow result.
- [x] **Manual Logic Review**: Reviewed all 134 description changes; 126 are exact source prefixes and eight are content-grounded editorial rewrites.
- [x] **Local Test**: Full 121-test suite passed after temporary canonical generation.
- [x] **Repo Checks**: `npm run validate:references` and `npm run audit:skills:strict` passed.
- [x] **Source-Only PR**: Generated registries and plugin mirrors are excluded.
- [x] **Credits**: No source or ownership changes were made.
- [x] **License provenance**: Existing provenance is unchanged and changed-skill evidence is non-blocking.
- [x] **Maintainer Edits**: Enabled for this same-repository branch.

Validation:

- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run audit:skills:strict`
- `npm run build`
- `npm run test` (121 tests)
- changed-skill evidence: 134 changes, zero blockers, exact head `a340741703017ec071db3a193f13861cb190b050`
