### PR TITLE
fix: recognize bundled skill examples

### DIFF
--- a/tools/config/audit-skills-strict-budget.json
+++ b/tools/config/audit-skills-strict-budget.json
@@ -1,12 +1,12 @@
 {
-  "maxWarnings": 671,
-  "maxWarningOnlySkills": 651,
+  "maxWarnings": 507,
+  "maxWarningOnlySkills": 491,
   "maxTopFindingCodes": {
     "description_truncated": 0,
-    "missing_examples": 460,
+    "missing_examples": 296,
     "skill_too_long": 211
   },
   "owner": "repository maintainers",
   "lastReviewed": "2026-09-05",
-  "rationale": "Current objective audit warnings are tracked as explicit backlog debt after removing all truncated-description findings. Strict mode fails on errors, any reintroduced truncation, or regressions above this measured baseline."
+  "rationale": "Current objective audit warnings are tracked as explicit backlog debt after removing truncated descriptions and recognizing real nested or bundled examples. Strict mode fails on errors, any reintroduced truncation, or regressions above this measured baseline."
 }

--- a/tools/scripts/audit_skills.py
+++ b/tools/scripts/audit_skills.py
@@ -29,7 +29,7 @@ from validate_skills import configure_utf8_output, has_when_to_use_section, pars
 ELLIPSIS_PATTERN = re.compile(r"(?:\.\.\.|…)\s*$")
 FENCED_CODE_BLOCK_PATTERN = re.compile(r"^```", re.MULTILINE)
 EXAMPLES_HEADING_PATTERNS = [
-    re.compile(r"^##\s+Example(s)?\b", re.MULTILINE | re.IGNORECASE),
+    re.compile(r"^#{2,4}\s+.*\bExample(s)?\b", re.MULTILINE | re.IGNORECASE),
     re.compile(r"^##\s+Usage\b", re.MULTILINE | re.IGNORECASE),
 ]
 LIMITATIONS_HEADING_PATTERNS = [
@@ -71,10 +71,49 @@ class Finding:
             "code": self.code,
             "message": self.message,
         }
-def has_examples(content: str) -> bool:
-    return bool(FENCED_CODE_BLOCK_PATTERN.search(content)) or any(
+def safe_bundled_files(directory: Path, *, skip_nested_skills: bool = False):
+    if directory.is_symlink() or not directory.is_dir():
+        return
+
+    for root, dirs, files in os.walk(directory, followlinks=False):
+        root_path = Path(root)
+        if skip_nested_skills and root_path != directory and (root_path / "SKILL.md").exists():
+            dirs[:] = []
+            continue
+        dirs[:] = [name for name in dirs if not (root_path / name).is_symlink()]
+        for filename in files:
+            path = root_path / filename
+            try:
+                if not path.is_symlink() and path.is_file() and path.stat().st_size > 0:
+                    yield path
+            except OSError:
+                continue
+
+
+def has_bundled_examples(skill_root: Path) -> bool:
+    examples_root = skill_root / "examples"
+    if next(safe_bundled_files(examples_root), None) is not None:
+        return True
+
+    for support_path in safe_bundled_files(skill_root, skip_nested_skills=True):
+        if support_path == skill_root / "SKILL.md":
+            continue
+        if support_path.suffix.lower() not in {".md", ".rst", ".txt"}:
+            continue
+        try:
+            support_content = support_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if has_examples(support_content):
+            return True
+    return False
+
+
+def has_examples(content: str, skill_root: Path | None = None) -> bool:
+    inline_examples = bool(FENCED_CODE_BLOCK_PATTERN.search(content)) or any(
         pattern.search(content) for pattern in EXAMPLES_HEADING_PATTERNS
     )
+    return inline_examples or (skill_root is not None and has_bundled_examples(skill_root))
 
 
 def has_limitations(content: str) -> bool:
@@ -222,7 +261,7 @@ def build_skill_report(
     if not has_when_to_use_section(content):
         findings.append(Finding("warning", "missing_when_to_use", "Missing a recognized 'When to Use' section."))
 
-    if not has_examples(content):
+    if not has_examples(content, skill_root):
         findings.append(Finding("warning", "missing_examples", "Missing an example section or fenced example block."))
 
     if not has_limitations(content):

--- a/tools/scripts/tests/test_audit_skills.py
+++ b/tools/scripts/tests/test_audit_skills.py
@@ -108,6 +108,58 @@ echo "hello"
             self.assertEqual(report["summary"]["errors"], 0)
             self.assertEqual(report["skills"][0]["status"], "ok")
 
+    def test_examples_heading_at_nested_level_counts_as_real_example(self):
+        content = "# Skill\n\n### Worked Example\n\nA concrete input and expected output.\n"
+
+        self.assertTrue(audit_skills.has_examples(content))
+
+    def test_nonempty_bundled_example_counts_without_following_symlinks(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_root = Path(temp_dir) / "skill"
+            examples_dir = skill_root / "examples"
+            examples_dir.mkdir(parents=True)
+            (examples_dir / "request.md").write_text("# Example request\n", encoding="utf-8")
+
+            self.assertTrue(audit_skills.has_examples("# Skill\n", skill_root))
+
+            (examples_dir / "request.md").unlink()
+            outside = Path(temp_dir) / "outside.md"
+            outside.write_text("# Outside\n", encoding="utf-8")
+            try:
+                (examples_dir / "linked.md").symlink_to(outside)
+            except (OSError, NotImplementedError):
+                self.skipTest("Symlinks are unavailable on this platform")
+
+            self.assertFalse(audit_skills.has_examples("# Skill\n", skill_root))
+
+    def test_example_in_bundled_support_document_counts(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_root = Path(temp_dir) / "skill"
+            resources_dir = skill_root / "resources"
+            resources_dir.mkdir(parents=True)
+            support_path = resources_dir / "guide.md"
+            support_path.write_text(
+                "# Guide\n\n## Worked Example\n\nA concrete input and expected output.\n",
+                encoding="utf-8",
+            )
+
+            self.assertTrue(audit_skills.has_examples("# Skill\n", skill_root))
+
+            support_path.write_text("# Guide\n\nConceptual background only.\n", encoding="utf-8")
+            self.assertFalse(audit_skills.has_examples("# Skill\n", skill_root))
+
+    def test_nested_skill_examples_do_not_satisfy_parent(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_root = Path(temp_dir) / "parent"
+            child_root = skill_root / "child"
+            child_root.mkdir(parents=True)
+            (child_root / "SKILL.md").write_text(
+                "# Child\n\n## Examples\n\nA child-only example.\n",
+                encoding="utf-8",
+            )
+
+            self.assertFalse(audit_skills.has_examples("# Parent\n", skill_root))
+
     def test_audit_flags_truncated_description_and_missing_sections(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,12 @@
+# Real skill example recognition - 2026-09-05
+
+- Updated the structural audit to recognize example headings nested below level
+  two, non-empty files in a bundled `examples/` directory, and concrete examples
+  inside bundled Markdown, reStructuredText, or text support documents.
+- Kept symlinked and empty example files from satisfying the audit so external
+  paths and placeholder bundles cannot hide missing documentation.
+- Reclassified existing examples without changing canonical skill content.
+
 # Truncated skill description cleanup - 2026-09-05
 
 - Repaired all 134 catalog descriptions that ended in an ellipsis: 126 now


### PR DESCRIPTION
The structural audit was reporting 164 skills as missing examples even though they already expose concrete examples through nested Markdown headings, non-empty bundled `examples/` files, or bundled support documents. This teaches the audit to recognize those forms while refusing empty files, symlinks, and examples owned by nested child skills.

Observed audit change: 671 to 507 warnings, 651 to 491 warning-only skills, and 1,460 to 1,620 ready skills. The strict budget is lowered to preserve the improvement.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Repository quality and security guidance reviewed.
- [x] **Metadata**: `npm run validate` passed.
- [x] **Safety scan**: `npm run security:docs` passed.
- [x] **Local Test**: Full 121-test suite passed.
- [x] **Repo Checks**: `npm run validate:references` and `npm run audit:skills:strict` passed.
- [x] **Source-Only PR**: No generated registry artifact is included.
- [x] **Maintainer Edits**: Enabled for this same-repository branch.

Validation:

- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run audit:skills:strict`
- `npm run test` (121 tests)
