### PR TITLE
fix: classify copies into existing skills

### DIFF
--- a/tools/scripts/changed_skill_evidence.py
+++ b/tools/scripts/changed_skill_evidence.py
@@ -144,7 +144,13 @@ def skill_pairs(
             affected.add(old_id)
         if new_id:
             affected.add(new_id)
-        if record.status in {"R", "C"} and old_id and new_id and old_id != new_id:
+        if (
+            record.status in {"R", "C"}
+            and old_id
+            and new_id
+            and old_id != new_id
+            and new_id not in old_roots
+        ):
             rename_pairs[(old_id, new_id)].append(record)
 
     result: list[tuple[str | None, str | None, list[ChangeRecord]]] = []

--- a/tools/scripts/tests/test_changed_skill_evidence.py
+++ b/tools/scripts/tests/test_changed_skill_evidence.py
@@ -113,6 +113,26 @@ class ChangedSkillEvidenceTests(unittest.TestCase):
             changed_skill_evidence.canonical_skill_id("docs/example.md", roots)
         )
 
+    def test_copy_into_existing_skill_is_a_modification(self):
+        record = changed_skill_evidence.ChangeRecord(
+            status="C",
+            old_path="skills/source/SKILL.md",
+            new_path="skills/target/references/detailed-guide.md",
+            old_mode="100644",
+            new_mode="100644",
+            old_oid="a" * 40,
+            new_oid="b" * 40,
+            similarity=90,
+        )
+
+        pairs = changed_skill_evidence.skill_pairs(
+            [record],
+            {"source", "target"},
+            {"source", "target"},
+        )
+
+        self.assertEqual(pairs, [("target", "target", [record])])
+
     def test_mixed_copy_and_rename_keep_distinct_change_types(self):
         root, base = init_repo()
         original = root / "skills/example/SKILL.md"


### PR DESCRIPTION
# Pull Request Description

Changed-skill evidence treated a Git copy record into an already existing skill directory as a newly copied skill. That caused false provenance blockers when a new reference file resembled another skill. The classifier now creates cross-skill copy/rename pairs only when the destination canonical skill did not exist on the protected base; a regression test covers copies into existing skills.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: Read the repository quality and security guidance.
- [x] **Metadata**: Not applicable; no skill metadata changes.
- [x] **Risk Label**: Not applicable.
- [x] **Triggers**: Not applicable.
- [x] **Limitations**: Not applicable.
- [x] **Security**: Not applicable.
- [x] **Safety scan**: No command guidance changed.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` changes.
- [x] **Manual Logic Review**: Reviewed copy, rename, and existing-destination behavior.
- [x] **Local Test**: `python3 tools/scripts/tests/test_changed_skill_evidence.py` passes all 26 tests.
- [x] **Repo Checks**: `git diff --check` passes.
- [x] **Source-Only PR**: No generated artifacts included.
- [x] **Credits**: Not applicable.
- [x] **License provenance**: Not applicable.
- [x] **Maintainer Edits**: Enabled.

## Screenshots (if applicable)

N/A
