### PR TITLE
chore: migrate web typechecking to TypeScript 6

### DIFF
--- a/apps/web-app/package-lock.json
+++ b/apps/web-app/package-lock.json
@@ -45,7 +45,7 @@
         "jsdom": "^30.0.1",
         "postcss": "8.5.25",
         "tailwindcss": "^4.2.0",
-        "typescript": "^5.4.0",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.65.0",
         "vite": "^8.0.16",
         "vitest": "^5.0.0"
@@ -6678,9 +6678,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -9,11 +9,12 @@
     "prerender:seo": "node scripts/prerender-routes.js",
     "prebuild": "npm run generate:sitemap",
     "verify:seo": "node scripts/verify-seo-assets.js --require-hosted-url",
-    "build": "tsc && vite build && npm run prerender:seo",
+    "build": "npm run typecheck && vite build && npm run prerender:seo",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit"
   },
   "dependencies": {
     "@fontsource/jetbrains-mono": "^5.3.0",
@@ -53,7 +54,7 @@
     "jsdom": "^30.0.1",
     "postcss": "8.5.25",
     "tailwindcss": "^4.2.0",
-    "typescript": "^5.4.0",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.65.0",
     "vite": "^8.0.16",
     "vitest": "^5.0.0"

--- a/apps/web-app/refresh-skills-plugin.d.ts
+++ b/apps/web-app/refresh-skills-plugin.d.ts
@@ -1,0 +1,3 @@
+import type { Plugin } from 'vite';
+
+export default function refreshSkillsPlugin(): Plugin;

--- a/apps/web-app/tsconfig.json
+++ b/apps/web-app/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["node"],
     "module": "ESNext",
     "skipLibCheck": true,
 
@@ -21,9 +22,8 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Path mapping */
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"],

--- a/apps/web-app/tsconfig.node.json
+++ b/apps/web-app/tsconfig.node.json
@@ -1,10 +1,14 @@
 {
   "compilerOptions": {
+    "target": "ES2020",
+    "types": ["node"],
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsconfig.node.tsbuildinfo",
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "refresh-skills-plugin.d.ts"]
 }

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,10 @@
+# TypeScript 6 migration and configuration checks - 2026-09-05
+
+- Upgraded the compiler to TypeScript 6.0.3, within typescript-eslint's supported range; TypeScript 7 remains outside that range.
+- Removed deprecated `baseUrl` and made the `@/` alias relative to the configuration file. Explicitly loaded Node types required by the existing tests and build configuration.
+- Added `npm run typecheck` to production builds so Vite and Vitest configuration are checked alongside application sources. Declared the JavaScript refresh plugin's default Vite plugin contract and kept incremental compiler state under ignored node_modules.
+- Preserved strict checks, test assertions, timeouts, and coverage thresholds.
+
 # Web test toolchain migration - 2026-09-05
 
 - Upgraded Vitest and its V8 coverage provider to 5, jsdom to 30, jest-dom to 7, and ESLint globals to 17.


### PR DESCRIPTION
# Pull Request Description

Migrate the web compiler to TypeScript 6.0.3, which remains supported by typescript-eslint. Replace deprecated baseUrl with an explicit relative alias and load the Node globals used by the existing tests.

Production builds now run an explicit typecheck for application code and both Vite/Vitest configurations. Add the JavaScript refresh plugin's default export declaration and store incremental compiler state under node_modules. Strict checks, assertions, timeouts and coverage thresholds remain unchanged.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Read quality-bar.md and security-guardrails.md.
- [x] **Metadata**: Repository validation passes; no canonical skill changes.
- [x] **Source-Only PR**: No generated registry artifacts.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

Risk labels, triggers, limitations, skill review, source credits and license provenance are not applicable: no skill content changes.

## Validation

- Repository validate, validate:references, security:docs and all 121 test files pass.
- Production build/prerender and lint pass; application and configuration typecheck also passes on Node 22.23.1.
- All 201 web tests pass with unchanged coverage (86.89% statements, 91.34% lines). A first run overlapped with build/root tests and one Workbench case timed out; the complete run without competing build passed, and all 13 Workbench tests also passed on Node 22 in 1.59 seconds. No timeout or assertion was changed.
- npm audit: zero vulnerabilities.

- [x] **Local Test**: Web tests, coverage, lint and build pass.
- [x] **Repo Checks**: All repository checks above pass.
