### PR TITLE
feat: add outcome discovery and clear selection evidence

### DIFF
--- a/apps/web-app/src/components/OutcomeExplorer.tsx
+++ b/apps/web-app/src/components/OutcomeExplorer.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router';
+import type { Skill } from '../types';
+import { useSkillShortlist } from '../hooks/useSkillShortlist';
+import { evidenceSignals, isDiscoveryCatalog, OUTCOME_PRESETS, rankForOutcome } from '../utils/outcomeDiscovery';
+import { getSkillsIndexCandidateUrls } from '../utils/publicAssetUrls';
+import { ShortlistReview } from './ShortlistReview';
+
+interface Props { catalog?: Skill[]; onGoalChange?: (goal: string) => void }
+
+function DiscoverySession({ catalog, onGoalChange }: Props): React.ReactElement {
+  const [loaded, setLoaded] = useState<Skill[]>([]);
+  const [loading, setLoading] = useState(!catalog);
+  const [retry, setRetry] = useState(0);
+  const [error, setError] = useState('');
+  const [goal, setGoal] = useState('');
+  const [query, setQuery] = useState('');
+  const [limit, setLimit] = useState(6);
+  const { ids, toggle, clear } = useSkillShortlist();
+  const skills = catalog || loaded;
+  const results = useMemo(() => rankForOutcome(skills, query), [skills, query]);
+
+  useEffect(() => {
+    if (catalog) return;
+    const controller = new AbortController();
+    async function load() {
+      setLoading(true); setError('');
+      try {
+        const urls = getSkillsIndexCandidateUrls({ baseUrl: import.meta.env.BASE_URL, origin: location.origin, pathname: location.pathname, documentBaseUrl: document.baseURI });
+        let found: Skill[] | undefined;
+        for (const url of urls) {
+          try {
+            const response = await fetch(url, { signal: controller.signal });
+            if (!response.ok) continue;
+            const text = await response.text();
+            if (text.length > 15_000_000) continue;
+            const parsed: unknown = JSON.parse(text);
+            if (isDiscoveryCatalog(parsed)) { found = parsed; break; }
+          } catch { if (controller.signal.aborted) return; }
+        }
+        if (!found) throw new Error('The catalog could not be loaded. Your imported artifacts have not changed.');
+        if (!controller.signal.aborted) setLoaded(found);
+      } catch (cause) { if (!controller.signal.aborted) setError((cause as Error).message); }
+      finally { if (!controller.signal.aborted) setLoading(false); }
+    }
+    void Promise.resolve().then(load);
+    return () => controller.abort();
+  }, [catalog, retry]);
+
+  function search(value: string) { setQuery(value); setLimit(6); onGoalChange?.(value); }
+
+  return <div className="outcome-content">
+      {!catalog ? <p className="outcome-note">Discovery downloads the public catalog. Your goal and imported artifacts stay in this browser.</p> : null}
+      {loading ? <p role="status">Loading public catalog…</p> : null}
+      {error ? <div role="alert">{error} <button type="button" onClick={() => setRetry((value) => value + 1)}>Retry catalog download</button></div> : null}
+      {skills.length ? <>
+        <div className="outcome-presets" aria-label="Example outcomes">{OUTCOME_PRESETS.map((preset) => <button type="button" key={preset.label} onClick={() => { setGoal(preset.goal); search(preset.goal); }}>{preset.label}</button>)}</div>
+        <form className="outcome-form" onSubmit={(event) => { event.preventDefault(); search(goal); }}>
+          <label htmlFor="outcome-goal">Describe your goal<textarea id="outcome-goal" value={goal} onChange={(event) => setGoal(event.target.value)} maxLength={1000} rows={3} placeholder="For example: debug a React authentication error and add regression tests" /></label>
+          <button type="submit" disabled={!goal.trim()}>Find relevant skills</button>
+        </form>
+        {query ? <div aria-live="polite"><h3>{results.length ? `Showing ${Math.min(limit, results.length)} of ${results.length} matching skills` : 'No clear matches for this goal'}</h3><p>Start with these candidates, then read their instructions to check they fit your task.</p><details className="outcome-method"><summary>How suggestions work</summary><p>Matches in skill names and tags weigh more than descriptions; distinctive terms weigh more than common ones. Suggestions match words, not complex constraints or proven effectiveness.</p></details>{!results.length ? <p>Try a specific tool, task or technique, or browse the full catalog below.</p> : null}</div> : <p>Choose an example or describe your goal. Nothing is selected automatically.</p>}
+        <div className="outcome-results">{results.slice(0, limit).map(({ skill, matched, totalTerms }, index) => <article className="outcome-card" key={skill.id}>
+          <p className="outcome-eyebrow">Candidate {index + 1} · matches {matched.length} of {totalTerms} goal terms</p><h3><Link to={`/skill/${encodeURIComponent(skill.id)}/`}>{skill.name}</Link></h3><p>{skill.description}</p>
+          <p className="outcome-reason"><strong>Why it appears:</strong> {matched.join(', ')}</p>
+          <details><summary>Evidence and gaps</summary><dl>{evidenceSignals(skill).map((signal) => <div key={signal.label}><dt>{signal.label}</dt><dd>{signal.value}</dd></div>)}</dl><p>These fields describe the author’s claims and setup requirements. They do not certify effectiveness. Read the complete skill before choosing it.</p></details>
+          <button type="button" aria-label={`${ids.includes(skill.id) ? 'Remove from shortlist' : 'Add to shortlist'} ${skill.name}`} aria-pressed={ids.includes(skill.id)} onClick={() => toggle(skill.id)}>{ids.includes(skill.id) ? 'Remove from shortlist' : 'Add to shortlist'}</button>
+        </article>)}</div>
+        {results.length > limit ? <button type="button" onClick={() => setLimit((current) => current + 12)}>Show more candidates</button> : null}
+        <p><Link to="/">Browse the complete catalog</Link> · All {skills.length.toLocaleString('en-US')} skills remain available regardless of metadata or this ranking.</p>
+        {!catalog ? <ShortlistReview suggestedGoal={query} skills={skills.filter((skill) => ids.includes(skill.id))} onRemove={toggle} onClear={clear} /> : null}
+      </> : null}
+    </div>;
+}
+
+export default function OutcomeExplorer(props: Props): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  return <section className="outcome-explorer" aria-labelledby="outcome-title">
+    <div className="outcome-heading"><div><p className="outcome-eyebrow">Start with an outcome</p><h2 id="outcome-title">What do you want to get done?</h2><p>Find a starting point, compare requirements, and give your agent a focused brief.</p></div>
+      <button type="button" aria-expanded={open} onClick={() => setOpen((value) => !value)}>{open ? 'Close discovery' : 'Explore skills by outcome'}</button></div>
+    {open ? <DiscoverySession {...props} /> : null}
+  </section>;
+}

--- a/apps/web-app/src/components/ShortlistReview.tsx
+++ b/apps/web-app/src/components/ShortlistReview.tsx
@@ -9,9 +9,10 @@ interface Props {
   skills: Skill[];
   onRemove: (id: string) => void;
   onClear: () => void;
+  suggestedGoal?: string;
 }
 
-export function ShortlistReview({ skills, onRemove, onClear }: Props): React.ReactElement {
+export function ShortlistReview({ skills, onRemove, onClear, suggestedGoal }: Props): React.ReactElement {
   const [goal, setGoal] = useState('');
   const [target, setTarget] = useState<BriefTarget>('codex:project');
   const [message, setMessage] = useState('');
@@ -69,6 +70,7 @@ export function ShortlistReview({ skills, onRemove, onClear }: Props): React.Rea
             <label htmlFor="shortlist-goal">What do you want to accomplish?
               <textarea id="shortlist-goal" rows={3} value={goal} placeholder="Describe the outcome and constraints for your project" onChange={(event) => { setGoal(event.target.value); setMessage(''); }} />
             </label>
+            {suggestedGoal && suggestedGoal !== goal ? <button type="button" onClick={() => { setGoal(suggestedGoal); setMessage('Discovery goal added to the brief.'); }}>Use discovery goal in brief</button> : null}
             <label htmlFor="shortlist-target">Target
               <select id="shortlist-target" value={target} onChange={(event) => { setTarget(event.target.value as BriefTarget); setMessage(''); }}>
                 <option value="codex:project">Codex · this project</option>

--- a/apps/web-app/src/components/__tests__/OutcomeExplorer.test.tsx
+++ b/apps/web-app/src/components/__tests__/OutcomeExplorer.test.tsx
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { render } from '@testing-library/react';
+import OutcomeExplorer from '../OutcomeExplorer';
+import { createMockSkill } from '../../factories/skill';
+
+const skill = createMockSkill({ id: 'react-auth', name: 'React authentication', description: 'Handle authentication in React', tags: ['react'], category: 'frontend' });
+function mount(catalog?: typeof skill[]) { return render(<MemoryRouter><OutcomeExplorer catalog={catalog} /></MemoryRouter>); }
+
+describe('optional outcome discovery', () => {
+  beforeEach(() => { localStorage.clear(); vi.clearAllMocks(); vi.mocked(fetch).mockReset(); });
+
+  it('does not fetch, persist or inspect anything until opened, and never transmits the goal', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(JSON.stringify([skill])));
+    mount();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Explore skills by outcome' }));
+    await screen.findByLabelText('Describe your goal');
+    const calls = vi.mocked(fetch).mock.calls.length;
+    fireEvent.change(screen.getByLabelText('Describe your goal'), { target: { value: 'React authentication private-project' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Find relevant skills' }));
+    expect(await screen.findByRole('link', { name: 'React authentication' })).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledTimes(calls);
+    expect(JSON.stringify(vi.mocked(fetch).mock.calls)).not.toContain('private-project');
+    expect(JSON.stringify(vi.mocked(localStorage.setItem).mock.calls)).not.toContain('private-project');
+    const add = screen.getByRole('button', { name: 'Add to shortlist React authentication' });
+    expect(add).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(add);
+    fireEvent.click(screen.getByText(/Compare 1 selected skill and prepare/));
+    fireEvent.click(screen.getByRole('button', { name: 'Use discovery goal in brief' }));
+    expect((screen.getByLabelText('Agent brief preview') as HTMLTextAreaElement).value).toContain('private-project');
+  });
+
+  it('reuses the catalog supplied by the home page and exposes evidence gaps and no-match recovery', async () => {
+    mount([skill]);
+    fireEvent.click(screen.getByRole('button', { name: 'Explore skills by outcome' }));
+    fireEvent.change(screen.getByLabelText('Describe your goal'), { target: { value: 'React authentication' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Find relevant skills' }));
+    const card = screen.getByRole('article');
+    expect(within(card).getByText(/Why it appears/)).toBeInTheDocument();
+    fireEvent.click(within(card).getByText('Evidence and gaps'));
+    expect(within(card).getByText(/do not certify effectiveness/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Describe your goal'), { target: { value: 'unmatchable' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Find relevant skills' }));
+    expect(screen.getByText('No clear matches for this goal')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Browse the complete catalog' })).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(screen.queryByText(/usage history/i)).not.toBeInTheDocument();
+  });
+
+  it('recovers from invalid catalog responses without accepting malformed records', async () => {
+    vi.mocked(fetch).mockImplementation(async () => new Response(JSON.stringify([{ ...skill, plugin: {} }])));
+    mount(); fireEvent.click(screen.getByRole('button', { name: 'Explore skills by outcome' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('catalog could not be loaded');
+    expect(screen.queryByLabelText('Describe your goal')).not.toBeInTheDocument();
+    vi.mocked(fetch).mockImplementation(async () => new Response(JSON.stringify([skill])));
+    fireEvent.click(screen.getByRole('button', { name: 'Retry catalog download' }));
+    await waitFor(() => expect(screen.getByLabelText('Describe your goal')).toBeInTheDocument());
+  });
+});

--- a/apps/web-app/src/index.css
+++ b/apps/web-app/src/index.css
@@ -2799,3 +2799,36 @@ samp {
     color: #a7f3d0 !important;
   }
 }
+
+/* Optional outcome discovery: shares the catalog's visual language. */
+.outcome-explorer { margin: 1.5rem 0; padding: clamp(1rem, 3vw, 1.75rem); border: 1px solid var(--stroke-subtle); border-radius: var(--radius-xl); background: var(--surface-card); }
+.outcome-heading { display: flex; align-items: center; justify-content: space-between; gap: 1.25rem; }
+.outcome-heading h2 { font-size: clamp(1.4rem, 2.7vw, 1.9rem); line-height: 1.2; margin: .35rem 0 .65rem; }
+.outcome-heading p:not(.outcome-eyebrow), .outcome-content p { color: var(--text-secondary); line-height: 1.6; }
+.outcome-eyebrow { color: var(--text-muted); font: 500 .75rem/1.5 var(--font-mono); }
+.outcome-explorer button { border: 1px solid var(--stroke-strong); border-radius: var(--radius-sm); padding: .65rem .9rem; background: var(--surface-elevated); color: var(--text-primary); cursor: pointer; }
+.outcome-explorer button:hover { border-color: var(--accent-border); }
+.outcome-explorer button[aria-pressed='true'] { border-color: var(--accent-border); background: var(--accent-soft); }
+.outcome-explorer button:disabled { opacity: .55; cursor: not-allowed; }
+.outcome-content { margin-top: 1.5rem; border-top: 1px solid var(--stroke-subtle); padding-top: 1.5rem; }
+.outcome-presets { display: flex; flex-wrap: wrap; gap: .5rem; margin: 1rem 0; }
+.outcome-presets button { border-radius: 2rem; font-size: .9rem; }
+.outcome-form { display: grid; gap: .75rem; margin: 1rem 0 1.5rem; }
+.outcome-form label { display: grid; gap: .5rem; font-weight: 500; }
+.outcome-form textarea { width: 100%; resize: vertical; padding: .8rem; border: 1px solid var(--stroke-strong); border-radius: var(--radius-sm); background: var(--surface-canvas); color: var(--text-primary); font: inherit; }
+.outcome-form button { justify-self: start; }
+.outcome-results { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; margin: 1.25rem 0; }
+.outcome-card { min-width: 0; display: flex; flex-direction: column; gap: .75rem; border: 1px solid var(--stroke-subtle); border-radius: var(--radius-lg); padding: 1rem; overflow-wrap: anywhere; }
+.outcome-card h3 { font-size: 1.15rem; font-weight: 600; }
+.outcome-card h3 a { text-decoration: underline; text-underline-offset: .2em; }
+.outcome-card > button { margin-top: auto; align-self: start; }
+.outcome-card summary { cursor: pointer; font-weight: 500; }
+.outcome-card dl { display: grid; gap: .6rem; padding: .75rem 0; }
+.outcome-card dt { color: var(--text-muted); font-size: .8rem; }
+.outcome-card dd { margin: .2rem 0 0; }
+.outcome-reason { font-size: .85rem; }
+.outcome-note { font-size: .9rem; }
+@media (max-width: 680px) {
+  .outcome-heading { flex-direction: column; align-items: flex-start; }
+  .outcome-results { grid-template-columns: 1fr; }
+}

--- a/apps/web-app/src/pages/Home.tsx
+++ b/apps/web-app/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import { VirtuosoGrid } from 'react-virtuoso';
 import { categoryFacet, matchCatalogSkill, searchMode, type SearchMode } from '../utils/catalogSearch';
 import { SkillCard } from '../components/SkillCard';
 import { ShortlistReview } from '../components/ShortlistReview';
+import OutcomeExplorer from '../components/OutcomeExplorer';
 import { Icon } from '../components/ui/Icon';
 import { useSkills } from '../context/SkillContext';
 import { seoLandingPages } from '../data/seoLandingPages';
@@ -71,6 +72,7 @@ export function Home(): React.ReactElement {
   const [sourceFilter, setSourceFilter] = useState(() => getInitialFilter(searchParams, 'source', 'all'));
   const [scopeFilter, setScopeFilter] = useState(() => getInitialFilter(searchParams, 'scope', 'all'));
   const [sortBy, setSortBy] = useState(() => getInitialFilter(searchParams, 'sort', 'default'));
+  const [discoveryGoal, setDiscoveryGoal] = useState('');
   const [syncing, setSyncing] = useState(false);
   const [syncMsg, setSyncMsg] = useState<SyncMessage | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -338,7 +340,8 @@ export function Home(): React.ReactElement {
           </div>
         </section>
 
-        <ShortlistReview skills={shortlistSkills} onRemove={toggleShortlist} onClear={clearShortlist} />
+        <OutcomeExplorer catalog={skills} onGoalChange={setDiscoveryGoal} />
+        <ShortlistReview suggestedGoal={discoveryGoal} skills={shortlistSkills} onRemove={toggleShortlist} onClear={clearShortlist} />
 
         <section className="catalog-results" aria-labelledby="catalog-results-title">
           <header>

--- a/apps/web-app/src/pages/Workbench.tsx
+++ b/apps/web-app/src/pages/Workbench.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { usePageMeta } from '../hooks/usePageMeta';
 import { SelectionFeedback } from '../components/SelectionFeedback';
+import OutcomeExplorer from '../components/OutcomeExplorer';
 import { Link } from 'react-router';
 import { releaseFileUrl } from '../utils/catalogRelease';
 import exampleStack from '../../../../docs/examples/workflows/mcp-contract/aas-stack.json';
@@ -430,12 +431,14 @@ export function Workbench(): React.ReactElement {
             <p>Review the exact skills, project profile and proposed changes saved by your agent. Import <code>aas-stack.json</code>, an immutable CLI plan, and optional selection evidence, or explore the recorded example below.</p>
           </div>
           <dl>
-            <div><dt>Privacy</dt><dd>In-memory only</dd></div>
+            <div><dt>Imported artifacts</dt><dd>In-memory only</dd></div>
             <div><dt>Target changes</dt><dd>None</dd></div>
-            <div><dt>Network</dt><dd>Not used</dd></div>
+            <div><dt>Artifact review</dt><dd>No network</dd></div>
           </dl>
         </div>
       </header>
+
+      <OutcomeExplorer />
 
       <section className="workbench-boundary" aria-labelledby="workbench-start-title">
         <h2 id="workbench-start-title">Need a stack to review?</h2>

--- a/apps/web-app/src/utils/__tests__/outcomeDiscovery.test.ts
+++ b/apps/web-app/src/utils/__tests__/outcomeDiscovery.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { createMockSkill } from '../../factories/skill';
+import { evidenceSignals, isDiscoveryCatalog, outcomeTerms, rankForOutcome } from '../outcomeDiscovery';
+
+describe('goal discovery relevance and evidence boundaries', () => {
+  const specific = createMockSkill({ id: 'react-auth', name: 'React authentication', description: 'Handle authentication in React', tags: [], category: 'frontend', risk: 'unknown' });
+  const general = createMockSkill({ id: 'generic', name: 'General review', description: 'Review code', tags: [], category: 'general', source: 'official' });
+  it('ranks matching task and technology above unrelated popularity or provenance without mutating the catalog', () => {
+    const catalog = [general, specific];
+    const before = JSON.stringify(catalog);
+    const result = rankForOutcome(catalog, 'React authentication review');
+    expect(result[0].skill.id).toBe('react-auth');
+    expect(result[0].matched).toEqual(['react', 'auth']);
+    expect(JSON.stringify(catalog)).toBe(before);
+    expect(rankForOutcome(catalog, 'nonexistent-task')).toEqual([]);
+  });
+  it('does not let risk, source, missing license or packaging determine rank or eligibility', () => {
+    const first = createMockSkill({ ...specific, id: 'a', source: 'self', risk: 'unknown', license: undefined });
+    const second = createMockSkill({ ...specific, id: 'b', source: 'official', risk: 'safe', license: 'MIT' });
+    const result = rankForOutcome([second, first], 'react auth');
+    expect(result.map((item) => item.skill.id)).toEqual(['a', 'b']);
+    expect(result[0].score).toBe(result[1].score);
+  });
+  it('handles blank, punctuation-only, multilingual and bounded goals without fabricating matches', () => {
+    expect(rankForOutcome([specific], 'the and')).toEqual([]);
+    expect(rankForOutcome([specific], '!!!')).toEqual([]);
+    expect(outcomeTerms('autenticazione React')).toEqual(['auth', 'react']);
+    expect(outcomeTerms('x '.repeat(1000))).toEqual([]);
+    expect(outcomeTerms('constructor __proto__')).toEqual(['constructor', 'proto']);
+  });
+  it('labels missing evidence without awarding a reliability badge', () => {
+    const signals = evidenceSignals(createMockSkill({ source: undefined, license: undefined, risk: 'unknown', plugin: undefined }));
+    expect(signals.map((entry) => entry.value)).toEqual(['Source not recorded', 'Not recorded in catalog', 'Not assessed in catalog', 'Not recorded in catalog']);
+  });
+  it('rejects duplicate IDs and malformed data before it reaches comparison', () => {
+    expect(isDiscoveryCatalog([specific])).toBe(true);
+    expect(isDiscoveryCatalog([specific, specific])).toBe(false);
+    expect(isDiscoveryCatalog([{ ...specific, tags: [{}] }])).toBe(false);
+    expect(isDiscoveryCatalog([{ ...specific, plugin: { targets: {}, setup: {}, reasons: [] } }])).toBe(false);
+    expect(isDiscoveryCatalog([{ ...specific, source: {} }])).toBe(false);
+    expect(isDiscoveryCatalog([{ ...specific, id: '../escape' }])).toBe(false);
+    expect(isDiscoveryCatalog([])).toBe(false);
+  });
+});

--- a/apps/web-app/src/utils/outcomeDiscovery.ts
+++ b/apps/web-app/src/utils/outcomeDiscovery.ts
@@ -1,0 +1,82 @@
+import type { Skill } from '../types';
+
+export const OUTCOME_PRESETS = [
+  { label: 'Fix a bug', goal: 'Systematic debugging and regression testing' },
+  { label: 'Ship a web feature', goal: 'Build an accessible React interface with tests' },
+  { label: 'Review security', goal: 'Review application security and authentication vulnerabilities' },
+  { label: 'Understand my data', goal: 'Data analysis, data quality and dashboard design' },
+  { label: 'Improve conversion', goal: 'Improve landing page conversion with copywriting and experiments' },
+  { label: 'Prepare a release', goal: 'Release review and deployment checklist' },
+] as const;
+
+const STOP_WORDS = new Set('a an and are as at be by for from how i in is it me my of on or our the this to want with without un una e di del della per con che il la le lo gli da come mio voglio'.split(' '));
+const ALIASES: Record<string, string> = {
+  debugging: 'debug', debuggen: 'debug', bug: 'debug', bugs: 'debug', fix: 'debug', failing: 'debug',
+  tests: 'test', testing: 'test', tested: 'test',
+  sicurezza: 'security', vulnerabilities: 'security', vulnerability: 'security',
+  dati: 'data', analisi: 'analysis', analyze: 'analysis', analytics: 'analysis',
+  accessibile: 'accessibility', accessible: 'accessibility',
+  conversione: 'conversion', conversioni: 'conversion',
+  authentication: 'auth', autenticazione: 'auth',
+  deploy: 'deployment', deploys: 'deployment',
+};
+
+export function outcomeTerms(text: string): string[] {
+  return [...new Set(text.slice(0, 1000).normalize('NFKC').toLowerCase()
+    .split(/[^\p{L}\p{N}+#]+/u).filter((word) => word.length > 1 && !STOP_WORDS.has(word))
+    .map((word) => Object.prototype.hasOwnProperty.call(ALIASES, word) ? ALIASES[word] : word))].slice(0, 32);
+}
+
+export interface OutcomeMatch { skill: Skill; score: number; matched: string[]; totalTerms: number }
+
+/** Browser-only discovery: descriptive relevance, never quality or Core eligibility. */
+export function rankForOutcome(skills: Skill[], goal: string): OutcomeMatch[] {
+  const terms = outcomeTerms(goal);
+  if (!terms.length) return [];
+  const indexed = skills.map((skill) => {
+    const identity = new Set(outcomeTerms(`${skill.id} ${skill.name} ${(skill.tags || []).join(' ')}`));
+    const description = new Set(outcomeTerms(skill.description));
+    const category = new Set(outcomeTerms(skill.category));
+    return { skill, identity, description, category };
+  });
+  const frequency = new Map(terms.map((term) => [term, indexed.filter(({ identity, description, category }) => identity.has(term) || description.has(term) || category.has(term)).length]));
+  return indexed.map(({ skill, identity, description, category }) => {
+    const matched = terms.filter((term) => identity.has(term) || description.has(term) || category.has(term));
+    const score = matched.reduce((sum, term) => sum + (identity.has(term) ? 3 : description.has(term) ? 2 : 1) * Math.log(1 + skills.length / (1 + (frequency.get(term) || 0))), 0);
+    return { skill, score, matched, totalTerms: terms.length };
+  }).filter((result) => result.score > 0)
+    .sort((a, b) => b.score - a.score || b.matched.length - a.matched.length || a.skill.id.localeCompare(b.skill.id, 'en'));
+}
+
+export function evidenceSignals(skill: Skill): Array<{ label: string; value: string }> {
+  return [
+    { label: 'Provenance', value: skill.source_repo ? `Declared source: ${skill.source_repo}` : skill.source === 'self' ? 'Author declares original work' : skill.source ? `Declared source: ${skill.source}` : 'Source not recorded' },
+    { label: 'License', value: skill.license || 'Not recorded in catalog' },
+    { label: 'Risk', value: !skill.risk || skill.risk === 'unknown' ? 'Not assessed in catalog' : `Author-declared: ${skill.risk}` },
+    { label: 'Setup', value: skill.plugin?.setup.type === 'manual' ? skill.plugin.setup.summary || 'Manual setup required' : skill.plugin ? 'No extra setup declared' : 'Not recorded in catalog' },
+  ];
+}
+
+/** Reject malformed optional fields too: shortlist comparison consumes these records. */
+export function isDiscoveryCatalog(value: unknown): value is Skill[] {
+  if (!Array.isArray(value) || !value.length || value.length > 10000) return false;
+  const seen = new Set<string>();
+  return value.every((skill: unknown) => {
+    if (!skill || typeof skill !== 'object' || Array.isArray(skill)) return false;
+    const row = skill as Record<string, unknown>;
+    if (!['id', 'name', 'description', 'category', 'path'].every((key) => typeof row[key] === 'string' && (row[key] as string).length <= 2000)) return false;
+    if (!/^[a-z0-9][a-z0-9._-]{0,199}$/.test(row.id as string) || seen.has(row.id as string)) return false;
+    seen.add(row.id as string);
+    for (const key of ['source', 'source_repo', 'license', 'license_source', 'date_added']) if (row[key] !== undefined && typeof row[key] !== 'string') return false;
+    if (row.risk !== undefined && !['none', 'safe', 'critical', 'offensive', 'unknown'].includes(String(row.risk))) return false;
+    if (row.tags !== undefined && (!Array.isArray(row.tags) || !row.tags.every((tag) => typeof tag === 'string'))) return false;
+    if (row.plugin !== undefined) {
+      const plugin = row.plugin as Skill['plugin'];
+      if (!plugin || typeof plugin !== 'object' || !plugin.targets || !plugin.setup ||
+        !['supported', 'blocked'].includes(plugin.targets.codex) || !['supported', 'blocked'].includes(plugin.targets.claude) ||
+        !['none', 'manual'].includes(plugin.setup.type) || typeof plugin.setup.summary !== 'string' ||
+        (plugin.setup.docs !== null && typeof plugin.setup.docs !== 'string') || !Array.isArray(plugin.reasons) || !plugin.reasons.every((reason) => typeof reason === 'string')) return false;
+    }
+    return true;
+  });
+}

--- a/docs/users/aas-core.md
+++ b/docs/users/aas-core.md
@@ -65,6 +65,12 @@ During preview, AAS checks the ownership of the configuration parent directory (
 
 ### Start from a catalog shortlist
 
+Use **Explore skills by outcome** in the catalog or Workbench to describe a task or choose a starting example. The browser suggests candidates from the public catalog and explains which terms match. Names and tags weigh more than descriptions; distinctive terms weigh more than common terms. This is descriptive relevance, not a quality score, semantic assessment, or effectiveness benchmark. Inspect the complete instructions and constraints before selecting anything. Core/MCP retrieval remains neutral and every canonical ID remains available.
+
+Each candidate exposes provenance, license, declared risk and setup information, including missing fields. These are author-supplied metadata, not reliability badges. Add candidates explicitly to the shared shortlist, compare them, and choose **Use discovery goal in brief** to carry the goal into the existing agent handoff. Nothing is selected automatically.
+
+Workbench downloads the public catalog only after you open discovery. Artifact review does not need that download and never sends imported artifacts or goals. The goal remains in page memory; only explicitly shortlisted IDs use the existing browser-local shortlist. There is no usage measurement, installation diary, or centralized collection.
+
 In the [hosted catalog](https://sickn33.github.io/agentic-awesome-skills/), add candidate skills to your shortlist. Open the comparison above the search results to inspect descriptions, declared risk, manual setup, plugin packaging, source, and license metadata. Missing metadata is shown explicitly; it does not make a skill unavailable to Core.
 
 Enter the project outcome and select Codex or Claude as the project target, preview the brief, then copy it into your coding agent with the local AAS MCP configured. The brief includes exact candidate IDs and the catalog version. It asks the agent to inspect the complete catalog and explain its final selection, including any additions or omissions. A shortlist is input to that review, not an approved stack.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,11 @@
+# Outcome discovery and clearer selection evidence - 2026-09-05
+
+- Added optional goal-based candidate discovery to catalog and Workbench, with explained term relevance and full-catalog access.
+- Exposed provenance, license, author-declared risk and setup gaps without assigning reliability scores or hiding canonical skill IDs.
+- Connected candidates to the existing comparison and agent-brief workflow, including an explicit action to reuse the discovery goal.
+- Kept Workbench artifact review independent of catalog downloads; discovery downloads public data only when opened. Goals and imported artifacts are never sent.
+- Removed the unshipped usage-history experiment at the user's request. No installation/reuse measurement or collection was added.
+
 # TypeScript 6 migration and configuration checks - 2026-09-05
 
 - Upgraded the compiler to TypeScript 6.0.3, within typescript-eslint's supported range; TypeScript 7 remains outside that range.


### PR DESCRIPTION
# Pull Request Description

Users can start from a task instead of guessing a skill name. Add optional outcome discovery to the catalog and Workbench, with six task examples, explained matches, explicit shortlist selection, evidence gaps, and an action to reuse the goal in the existing agent brief.

Suggestions use descriptive term relevance, not quality scores or effectiveness claims. All canonical IDs stay available and Core/MCP selection remains unchanged. Workbench fetches the public catalog only when discovery is opened; goals and imported artifacts are never transmitted. No usage measurement, installation history, or collection backend is added.

## Change Classification

- [x] Docs PR
- [x] Infra PR (catalog application)

## Quality Bar Checklist ✅

- [x] **Standards**: Read the quality bar and security guardrails.
- [x] **Safety scan**: `npm run security:docs` passed.
- [x] **Manual Logic Review**: Reviewed explicit activation, catalog validation, metadata semantics, failure recovery, selection and goal boundaries.
- [x] **Local Test**: Web tests, typecheck, lint, build and browser checks passed.
- [x] **Repo Checks**: Validation and reference checks passed.
- [x] **Source-Only PR**: No generated registry artifacts or mirrors included.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

Skill metadata, skill review, source credits and license provenance checklist items are not applicable: no canonical skills or bundled skill files changed.

## Validation

- Web: 209 tests across 29 files; 87.17% statements, 76.96% branches, 90.21% functions, 91.80% lines.
- Targeted tests rerun after final copy changes; typecheck, lint and production build passed.
- Headless Edge on actual local catalog: desktop and 390px mobile, no page errors or horizontal overflow, explicit shortlist and goal handoff, no default Workbench catalog request, no goal persistence/transmission.
- Repository validation, references, docs security, all 121 script test groups, all 169 focused Core tests and offline catalog integrity passed. Strict audit and warning budget remain at zero.

## Screenshots (if applicable)

Desktop and mobile rendering were inspected locally. The discovery panel follows the existing catalog theme and remains collapsed until opened.
