### PR TITLE
fix: preserve discovery constraints and prepare exact install previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ Use direct installation when your host does not yet have a native AAS Core adapt
 For example, after reviewing `brainstorming` and `systematic-debugging` for a Codex project, run from that project directory:
 
 ```bash
-npm exec --yes --ignore-scripts --package=agentic-awesome-skills@16.7.0 -- \
-  agentic-awesome-skills --release 16.7.0 --path .agents/skills \
+npm exec --yes --ignore-scripts --package=agentic-awesome-skills@16.8.0 -- \
+  agentic-awesome-skills --release 16.8.0 --path .agents/skills \
   --skills brainstorming,systematic-debugging --dry-run
 ```
 

--- a/apps/web-app/src/components/InstallationHandoff.tsx
+++ b/apps/web-app/src/components/InstallationHandoff.tsx
@@ -1,0 +1,27 @@
+import { useId, useState } from 'react';
+import { buildInstallationPreview, type CommandShell } from '../utils/installationHandoff';
+
+interface Props { ids: string[]; version: string; packageName?: string }
+
+export function InstallationHandoff({ ids, version, packageName }: Props): React.ReactElement {
+  const id = useId();
+  const [open, setOpen] = useState(false);
+  const [destination, setDestination] = useState('');
+  const [shell, setShell] = useState<CommandShell>('posix');
+  const [message, setMessage] = useState('');
+  let command = '';
+  let error = '';
+  try { command = buildInstallationPreview(ids, version, destination, shell, packageName); }
+  catch (cause) { error = (cause as Error).message; }
+  return <section className="installation-handoff">
+    <button type="button" aria-expanded={open} onClick={() => setOpen(!open)}>Prepare installation preview</button>
+    {open ? <div>
+      <p>Use these {ids.length} exact IDs from AAS {version}. Run the preview in your project, inspect the changes, and remove <code>--dry-run</code> only when you approve installation.</p>
+      <p>The direct installer produces its own preview; it does not apply a Core plan. Confirm the directory your agent uses and any prerequisites before proceeding.</p>
+      <label htmlFor={`${id}-directory`}>Skill directory<input id={`${id}-directory`} value={destination} placeholder="For example: .agents/skills or .claude/skills" onChange={(event) => { setDestination(event.target.value); setMessage(''); }} /></label>
+      <label htmlFor={`${id}-shell`}>Terminal<select id={`${id}-shell`} value={shell} onChange={(event) => { setShell(event.target.value as CommandShell); setMessage(''); }}><option value="posix">macOS / Linux · bash or zsh</option><option value="powershell">Windows · PowerShell</option></select></label>
+      {command ? <><textarea aria-label="Installation preview command" readOnly value={command} rows={5} /><button type="button" onClick={() => { void navigator.clipboard.writeText(command).then(() => setMessage('Preview command copied.'), () => setMessage('Clipboard unavailable. Select and copy the command above.')); }}>Copy preview command</button></> : <p>{error}</p>}
+      {message ? <p role="status">{message}</p> : null}
+    </div> : null}
+  </section>;
+}

--- a/apps/web-app/src/components/OutcomeExplorer.tsx
+++ b/apps/web-app/src/components/OutcomeExplorer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import type { Skill } from '../types';
 import { useSkillShortlist } from '../hooks/useSkillShortlist';
-import { evidenceSignals, isDiscoveryCatalog, OUTCOME_PRESETS, rankForOutcome } from '../utils/outcomeDiscovery';
+import { evidenceSignals, groupOutcomeMatches, isDiscoveryCatalog, OUTCOME_PRESETS, parseOutcomeGoal, rankForOutcome } from '../utils/outcomeDiscovery';
 import { getSkillsIndexCandidateUrls } from '../utils/publicAssetUrls';
 import { ShortlistReview } from './ShortlistReview';
 
@@ -18,7 +18,8 @@ function DiscoverySession({ catalog, onGoalChange }: Props): React.ReactElement 
   const [limit, setLimit] = useState(6);
   const { ids, toggle, clear } = useSkillShortlist();
   const skills = catalog || loaded;
-  const results = useMemo(() => rankForOutcome(skills, query), [skills, query]);
+  const results = useMemo(() => groupOutcomeMatches(rankForOutcome(skills, query)), [skills, query]);
+  const excluded = parseOutcomeGoal(query).excluded;
 
   useEffect(() => {
     if (catalog) return;
@@ -59,10 +60,13 @@ function DiscoverySession({ catalog, onGoalChange }: Props): React.ReactElement 
           <label htmlFor="outcome-goal">Describe your goal<textarea id="outcome-goal" value={goal} onChange={(event) => setGoal(event.target.value)} maxLength={1000} rows={3} placeholder="For example: debug a React authentication error and add regression tests" /></label>
           <button type="submit" disabled={!goal.trim()}>Find relevant skills</button>
         </form>
-        {query ? <div aria-live="polite"><h3>{results.length ? `Showing ${Math.min(limit, results.length)} of ${results.length} matching skills` : 'No clear matches for this goal'}</h3><p>Start with these candidates, then read their instructions to check they fit your task.</p><details className="outcome-method"><summary>How suggestions work</summary><p>Matches in skill names and tags weigh more than descriptions; distinctive terms weigh more than common ones. Suggestions match words, not complex constraints or proven effectiveness.</p></details>{!results.length ? <p>Try a specific tool, task or technique, or browse the full catalog below.</p> : null}</div> : <p>Choose an example or describe your goal. Nothing is selected automatically.</p>}
-        <div className="outcome-results">{results.slice(0, limit).map(({ skill, matched, totalTerms }, index) => <article className="outcome-card" key={skill.id}>
+        {query ? <div aria-live="polite"><h3>{results.length ? `Showing ${Math.min(limit, results.length)} of ${results.length} matching procedures` : 'No clear matches for this goal'}</h3><p>Start with these candidates, then read their instructions to check they fit your task.</p><details className="outcome-method"><summary>How suggestions work</summary><p>Matches in skill names and tags weigh more than descriptions; distinctive terms weigh more than common ones. Suggestions match words, not complex constraints or proven effectiveness.</p></details>{!results.length ? <p>Try a specific tool, task or technique, or browse the full catalog below.</p> : null}</div> : <p>Choose an example or describe your goal. Nothing is selected automatically.</p>}
+        <p className="outcome-note">Exclude a term with “without Supabase” or “senza Supabase”. Repeat for additional terms; complex constraints still need review.</p>
+        {excluded.length ? <p role="status">Excluded terms: {excluded.join(", ")}</p> : null}
+        <div className="outcome-results">{results.slice(0, limit).map(({ skill, matched, totalTerms, alternatives }, index) => <article className="outcome-card" key={skill.id}>
           <p className="outcome-eyebrow">Candidate {index + 1} · matches {matched.length} of {totalTerms} goal terms</p><h3><Link to={`/skill/${encodeURIComponent(skill.id)}/`}>{skill.name}</Link></h3><p>{skill.description}</p>
           <p className="outcome-reason"><strong>Why it appears:</strong> {matched.join(', ')}</p>
+          {alternatives.length ? <details><summary>Same procedure · {alternatives.length} alternative {alternatives.length === 1 ? 'ID' : 'IDs'}</summary><p>These IDs share the procedure. Choose the ID you need; none is selected automatically.</p><ul>{alternatives.map((alias) => <li key={alias.id}><Link to={`/skill/${encodeURIComponent(alias.id)}/`}>{alias.id}</Link> <button type="button" aria-pressed={ids.includes(alias.id)} onClick={() => toggle(alias.id)}>{ids.includes(alias.id) ? 'Remove' : 'Select'} {alias.id}</button></li>)}</ul></details> : null}
           <details><summary>Evidence and gaps</summary><dl>{evidenceSignals(skill).map((signal) => <div key={signal.label}><dt>{signal.label}</dt><dd>{signal.value}</dd></div>)}</dl><p>These fields describe the author’s claims and setup requirements. They do not certify effectiveness. Read the complete skill before choosing it.</p></details>
           <button type="button" aria-label={`${ids.includes(skill.id) ? 'Remove from shortlist' : 'Add to shortlist'} ${skill.name}`} aria-pressed={ids.includes(skill.id)} onClick={() => toggle(skill.id)}>{ids.includes(skill.id) ? 'Remove from shortlist' : 'Add to shortlist'}</button>
         </article>)}</div>

--- a/apps/web-app/src/components/ShortlistReview.tsx
+++ b/apps/web-app/src/components/ShortlistReview.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { InstallationHandoff } from './InstallationHandoff';
 import { Link } from 'react-router';
 import type { Skill } from '../types';
 import { SkillRequirements } from './SkillRequirements';
@@ -66,6 +67,7 @@ export function ShortlistReview({ skills, onRemove, onClear, suggestedGoal }: Pr
             </table>
           </div>
           <p className="shortlist-review__note">Metadata describes the catalog record. Plugin packaging does not determine whether an agent can select a skill; inspect its full instructions before use.</p>
+          <InstallationHandoff ids={ids} version={catalogVersion} />
           <div className="shortlist-review__brief">
             <label htmlFor="shortlist-goal">What do you want to accomplish?
               <textarea id="shortlist-goal" rows={3} value={goal} placeholder="Describe the outcome and constraints for your project" onChange={(event) => { setGoal(event.target.value); setMessage(''); }} />

--- a/apps/web-app/src/components/__tests__/InstallationHandoff.test.tsx
+++ b/apps/web-app/src/components/__tests__/InstallationHandoff.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { InstallationHandoff } from '../InstallationHandoff';
+
+describe('installation handoff', () => {
+  it('requires a destination and updates exact IDs without persisting or running the command', () => {
+    vi.clearAllMocks();
+    const { rerender } = render(<InstallationHandoff ids={['react']} version="16.8.0" />);
+    expect(screen.queryByLabelText('Installation preview command')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Prepare installation preview'));
+    fireEvent.change(screen.getByLabelText('Skill directory'), { target: { value: '.agents/skills' } });
+    expect((screen.getByLabelText('Installation preview command') as HTMLTextAreaElement).value).toContain("--skills 'react'");
+    rerender(<InstallationHandoff ids={['other']} version="16.7.0" />);
+    expect((screen.getByLabelText('Installation preview command') as HTMLTextAreaElement).value).toContain("--release 16.7.0");
+    expect((screen.getByLabelText('Installation preview command') as HTMLTextAreaElement).value).not.toContain("--skills 'react'");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+  });
+  it('offers manual copying when clipboard fails', async () => {
+    vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValueOnce(new Error('blocked'));
+    render(<InstallationHandoff ids={['react']} version="16.8.0" />);
+    fireEvent.click(screen.getByText('Prepare installation preview'));
+    fireEvent.change(screen.getByLabelText('Skill directory'), { target: { value: '.agents/skills' } });
+    fireEvent.click(screen.getByText('Copy preview command'));
+    expect(await screen.findByRole('status')).toHaveTextContent('Clipboard unavailable');
+  });
+});

--- a/apps/web-app/src/index.css
+++ b/apps/web-app/src/index.css
@@ -2832,3 +2832,10 @@ samp {
   .outcome-heading { flex-direction: column; align-items: flex-start; }
   .outcome-results { grid-template-columns: 1fr; }
 }
+
+.installation-handoff { margin: 1rem 0; padding: 1rem; border: 1px solid var(--stroke-subtle); border-radius: var(--radius-sm); }
+.installation-handoff p { margin: .75rem 0; line-height: 1.6; }
+.installation-handoff label { display: grid; gap: .4rem; margin: .75rem 0; }
+.installation-handoff input, .installation-handoff select, .installation-handoff textarea { width: 100%; padding: .65rem; border: 1px solid var(--stroke-strong); border-radius: var(--radius-sm); background: var(--surface-canvas); color: var(--text-primary); }
+.installation-handoff textarea { font-family: var(--font-mono); font-size: .85rem; }
+.installation-handoff button { padding: .65rem .9rem; border: 1px solid var(--stroke-strong); border-radius: var(--radius-sm); background: var(--surface-elevated); color: var(--text-primary); }

--- a/apps/web-app/src/pages/Workbench.tsx
+++ b/apps/web-app/src/pages/Workbench.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { usePageMeta } from '../hooks/usePageMeta';
 import { SelectionFeedback } from '../components/SelectionFeedback';
+import { InstallationHandoff } from '../components/InstallationHandoff';
 import OutcomeExplorer from '../components/OutcomeExplorer';
 import { Link } from 'react-router';
 import { releaseFileUrl } from '../utils/catalogRelease';
@@ -219,7 +220,7 @@ function PlanReviewView({ plan }: { plan: PlanReview }): React.ReactElement {
   );
 }
 
-function PairReview({ stack, plan, evidence }: { stack: StackManifestReview; plan: PlanReview | null; evidence: SelectionEvidenceReview | null }): React.ReactElement {
+function PairReview({ stack, plan, evidence, allowInstallation }: { allowInstallation: boolean; stack: StackManifestReview; plan: PlanReview | null; evidence: SelectionEvidenceReview | null }): React.ReactElement {
   const [checked, setChecked] = useState<{ stack: StackManifestReview; plan: PlanReview | null; evidence: SelectionEvidenceReview | null; review?: ReturnType<typeof reviewWorkbenchPair>; error?: string } | null>(null);
   useEffect(() => {
     let active = true;
@@ -247,6 +248,7 @@ function PairReview({ stack, plan, evidence }: { stack: StackManifestReview; pla
         </div>
         <span>{consistent ? 'Ready to compare' : `${review.checks.filter((check) => check.status === 'mismatch').length} mismatches`}</span>
       </header>
+      {consistent && allowInstallation ? <InstallationHandoff key={JSON.stringify(stack)} ids={stack.skills.map((skill) => skill.id)} version={stack.catalog.version} packageName={stack.catalog.package} /> : null}
       <ul aria-label="Artifact consistency checks">
         {review.checks.map((check) => (
           <li key={check.id}>
@@ -482,7 +484,8 @@ export function Workbench(): React.ReactElement {
       </div>}
 
       <section className="workbench-review-area" aria-label="Imported artifact review">
-        {stack.value && (plan.value || evidence.value) ? <PairReview stack={stack.value} plan={plan.value} evidence={evidence.value} /> : null}
+        {stack.value && (plan.value || evidence.value) ? <PairReview allowInstallation={!plan.error && !evidence.error} stack={stack.value} plan={plan.value} evidence={evidence.value} /> : null}
+        {stack.value && !plan.value && !plan.error && !evidence.value && !evidence.error ? <InstallationHandoff key={JSON.stringify(stack.value)} ids={stack.value.skills.map((skill) => skill.id)} version={stack.value.catalog.version} packageName={stack.value.catalog.package} /> : null}
         {stack.value ? <StackReview stack={stack.value} /> : null}
         {plan.value ? <PlanReviewView plan={plan.value} /> : null}
         {evidence.value ? <EvidenceReview evidence={evidence.value} /> : null}

--- a/apps/web-app/src/pages/__tests__/Workbench.test.tsx
+++ b/apps/web-app/src/pages/__tests__/Workbench.test.tsx
@@ -132,7 +132,7 @@ describe('Workbench review UI', () => {
   });
   beforeEach(() => vi.clearAllMocks());
 
-  it('reviews a valid stack without offering install, apply, or share actions', () => {
+  it('reviews a valid stack with text-only installation preparation and no execution actions', () => {
     renderWithRouter(<Workbench />, { route: '/workbench', path: '/workbench', useProvider: false });
 
     expect(screen.getByRole('heading', { level: 1, name: 'Review what your agent selected.' })).toBeInTheDocument();
@@ -147,7 +147,7 @@ describe('Workbench review UI', () => {
     expect(screen.getByText('react-best-practices')).toBeInTheDocument();
     expect(screen.getByText('playwright-skill')).toBeInTheDocument();
     expect(screen.getByText('Declared identity only.', { exact: false })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /install|apply|share/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^(install|apply|share)( |$)/i })).not.toBeInTheDocument();
     expect(window.location.search).toBe('');
   });
 
@@ -273,4 +273,18 @@ describe('Workbench review UI', () => {
     expect(screen.queryByText('reviewed-web-stack')).not.toBeInTheDocument();
     expect(screen.getByText('No artifact loaded')).toBeInTheDocument();
   });
+});
+
+it('hides installation preparation when imported artifacts disagree or fail validation', async () => {
+  renderWithRouter(<Workbench />, { useProvider: false });
+  paste('Paste JSON', stackFixture());
+  fireEvent.click(screen.getByRole('button', { name: 'Review pasted stack' }));
+  expect(screen.getByText('Prepare installation preview')).toBeInTheDocument();
+  paste('Paste JSON', planFixture(), 1);
+  fireEvent.click(screen.getByRole('button', { name: 'Review pasted plan' }));
+  await screen.findByText('Bindings need attention');
+  expect(screen.queryByText('Prepare installation preview')).not.toBeInTheDocument();
+  paste('Paste JSON', { invalid: true }, 1);
+  fireEvent.click(screen.getByRole('button', { name: 'Review pasted plan' }));
+  expect(screen.queryByText('Prepare installation preview')).not.toBeInTheDocument();
 });

--- a/apps/web-app/src/utils/__tests__/installationHandoff.test.ts
+++ b/apps/web-app/src/utils/__tests__/installationHandoff.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { buildInstallationPreview } from '../installationHandoff';
+
+describe('installation preview text', () => {
+  it('pins selection and release and always previews', () => {
+    const result = buildInstallationPreview(['react', 'game-development/2d-games'], '16.8.0', '.agents/skills', 'posix');
+    expect(result).toContain('--package=agentic-awesome-skills@16.8.0');
+    expect(result).toContain('--release 16.8.0');
+    expect(result).toContain("--skills 'react,game-development/2d-games'");
+    expect(result).toMatch(/--dry-run$/);
+  });
+  it('quotes paths for each terminal without evaluating shell text', () => {
+    const path = "/tmp/Nicco's $(touch nope) `oops`";
+    expect(buildInstallationPreview(['react'], '16.8.0', path, 'posix')).toContain("--path '/tmp/Nicco'\\''s $(touch nope) `oops`'");
+    expect(() => buildInstallationPreview(['react'], '16.8.0', path, 'powershell')).toThrow();
+    expect(buildInstallationPreview(['react'], '16.8.0', "C:\\Users\\Nicco's Skills", 'powershell')).toContain("--path 'C:\\Users\\Nicco''s Skills'");
+  });
+  it('rejects substituted packages, unsafe inputs and ambiguous versions', () => {
+    for (const version of ['latest', '16.8.0;echo', 'v16.8.0']) expect(() => buildInstallationPreview(['react'], version, '.agents/skills', 'posix')).toThrow();
+    for (const ids of [[], ['../x'], ['x','x'], ['x;echo']]) expect(() => buildInstallationPreview(ids, '16.8.0', '.agents/skills', 'posix')).toThrow();
+    for (const path of ['', '~/.codex/skills', '/tmp/a\nb']) expect(() => buildInstallationPreview(['react'], '16.8.0', path, 'posix')).toThrow();
+    expect(() => buildInstallationPreview(['react'], '16.8.0', '.agents/skills', 'posix', 'other-package')).toThrow();
+  });
+});

--- a/apps/web-app/src/utils/__tests__/outcomeDiscovery.test.ts
+++ b/apps/web-app/src/utils/__tests__/outcomeDiscovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createMockSkill } from '../../factories/skill';
-import { evidenceSignals, isDiscoveryCatalog, outcomeTerms, rankForOutcome } from '../outcomeDiscovery';
+import { evidenceSignals, groupOutcomeMatches, isDiscoveryCatalog, outcomeTerms, rankForOutcome } from '../outcomeDiscovery';
 
 describe('goal discovery relevance and evidence boundaries', () => {
   const specific = createMockSkill({ id: 'react-auth', name: 'React authentication', description: 'Handle authentication in React', tags: [], category: 'frontend', risk: 'unknown' });
@@ -41,4 +41,24 @@ describe('goal discovery relevance and evidence boundaries', () => {
     expect(isDiscoveryCatalog([{ ...specific, id: '../escape' }])).toBe(false);
     expect(isDiscoveryCatalog([])).toBe(false);
   });
+});
+
+describe('explicit exclusions and retained aliases', () => {
+  it('does not recommend the technology explicitly excluded in English or Italian', () => {
+    const plain = createMockSkill({ id: 'react', name: 'React', description: 'Build React interfaces', tags: [], category: 'web' });
+    const supabase = createMockSkill({ ...plain, id: 'react-supabase', name: 'React Supabase' });
+    for (const goal of ['React without Supabase', 'React senza Supabase', 'React WITHOUT SUPABASE']) {
+      expect(rankForOutcome([plain, supabase], goal).map((item) => item.skill.id)).toEqual(['react']);
+    }
+    expect(rankForOutcome([plain, supabase], 'without Supabase')).toEqual([]);
+  });
+});
+
+it('groups explicit aliases without deleting their selectable IDs or reintroducing excluded candidates', () => {
+  const skills = ['internal-comms', 'internal-comms-community', 'internal-comms-anthropic'].map((id) => createMockSkill({ id, name: id, description: 'Internal communications', tags: [] }));
+  const grouped = groupOutcomeMatches(rankForOutcome(skills, 'internal comms'));
+  expect(grouped).toHaveLength(1);
+  expect(new Set([grouped[0].skill.id, ...grouped[0].alternatives.map((skill) => skill.id)])).toEqual(new Set(skills.map((skill) => skill.id)));
+  const excluded = groupOutcomeMatches(rankForOutcome(skills, 'internal without community'));
+  expect(excluded[0].alternatives.some((skill) => skill.id === 'internal-comms-community')).toBe(false);
 });

--- a/apps/web-app/src/utils/installationHandoff.ts
+++ b/apps/web-app/src/utils/installationHandoff.ts
@@ -1,0 +1,13 @@
+export type CommandShell = 'posix' | 'powershell';
+const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const ID = /^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)*$/;
+
+/** Prepare text only. Never executes, downloads, or treats a Core plan as installer state. */
+export function buildInstallationPreview(ids: string[], version: string, destination: string, shell: CommandShell, packageName = 'agentic-awesome-skills'): string {
+  if (packageName !== 'agentic-awesome-skills' || !VERSION.test(version)) throw new Error('An exact AAS release version is required.');
+  if (!ids.length || ids.length > 128 || ids.some((id) => !ID.test(id) || id.length > 200 || id.split('/').some((part) => part === '.' || part === '..')) || new Set(ids).size !== ids.length) throw new Error('Choose between 1 and 128 distinct skill IDs.');
+  if (!destination.trim() || destination.length > 1000 || /^[~-]/.test(destination) || Array.from(destination).some((character) => character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127)) throw new Error('Enter a skill directory using a full path or a project-relative path; expand ~ yourself.');
+  if (shell === 'powershell' && /["&|<>^%!`$()]/.test(destination)) throw new Error('For npm.cmd, use a directory without shell metacharacters.');
+  const quote = (value: string) => shell === 'powershell' ? `'${value.split("'").join( "''")}'` : `'${value.split("'").join( "'\\''")}'`;
+  return `${shell === 'powershell' ? 'npm.cmd' : 'npm'} exec --yes --ignore-scripts --package=agentic-awesome-skills@${version} -- agentic-awesome-skills --release ${version} --path ${quote(destination)} --skills ${quote(ids.join(','))} --dry-run`;
+}

--- a/apps/web-app/src/utils/outcomeDiscovery.ts
+++ b/apps/web-app/src/utils/outcomeDiscovery.ts
@@ -1,4 +1,5 @@
 import type { Skill } from '../types';
+import compatibilityAliases from '../../../../docs/contributors/content-aliases.json';
 
 export const OUTCOME_PRESETS = [
   { label: 'Fix a bug', goal: 'Systematic debugging and regression testing' },
@@ -27,11 +28,36 @@ export function outcomeTerms(text: string): string[] {
     .map((word) => Object.prototype.hasOwnProperty.call(ALIASES, word) ? ALIASES[word] : word))].slice(0, 32);
 }
 
+/** Recognize explicit single-term exclusions; show them so the caller can inspect interpretation. */
+export function parseOutcomeGoal(goal: string): { positive: string; excluded: string[] } {
+  const excluded: string[] = [];
+  const positive = goal.slice(0, 1000).replace(/\b(?:without|senza|excluding)\s+([\p{L}\p{N}+#._-]+)/giu, (_, term: string) => {
+    excluded.push(...outcomeTerms(term));
+    return ' ';
+  });
+  return { positive, excluded: [...new Set(excluded)] };
+}
+
+export function outcomeAliases(id: string): string[] {
+  return compatibilityAliases.groups.find((group) => group.ids.includes(id))?.ids.filter((alias) => alias !== id) || [];
+}
+
+export function groupOutcomeMatches(matches: OutcomeMatch[]): Array<OutcomeMatch & { alternatives: Skill[] }> {
+  const seen = new Set<string>();
+  return matches.flatMap((match) => {
+    if (seen.has(match.skill.id)) return [];
+    const aliases = outcomeAliases(match.skill.id);
+    [match.skill.id, ...aliases].forEach((id) => seen.add(id));
+    return [{ ...match, alternatives: matches.map((item) => item.skill).filter((skill) => aliases.includes(skill.id)) }];
+  });
+}
+
 export interface OutcomeMatch { skill: Skill; score: number; matched: string[]; totalTerms: number }
 
 /** Browser-only discovery: descriptive relevance, never quality or Core eligibility. */
 export function rankForOutcome(skills: Skill[], goal: string): OutcomeMatch[] {
-  const terms = outcomeTerms(goal);
+  const { positive, excluded } = parseOutcomeGoal(goal);
+  const terms = outcomeTerms(positive);
   if (!terms.length) return [];
   const indexed = skills.map((skill) => {
     const identity = new Set(outcomeTerms(`${skill.id} ${skill.name} ${(skill.tags || []).join(' ')}`));
@@ -39,8 +65,9 @@ export function rankForOutcome(skills: Skill[], goal: string): OutcomeMatch[] {
     const category = new Set(outcomeTerms(skill.category));
     return { skill, identity, description, category };
   });
+  const eligible = indexed.filter(({ identity, description, category }) => !excluded.some((term) => identity.has(term) || description.has(term) || category.has(term)));
   const frequency = new Map(terms.map((term) => [term, indexed.filter(({ identity, description, category }) => identity.has(term) || description.has(term) || category.has(term)).length]));
-  return indexed.map(({ skill, identity, description, category }) => {
+  return eligible.map(({ skill, identity, description, category }) => {
     const matched = terms.filter((term) => identity.has(term) || description.has(term) || category.has(term));
     const score = matched.reduce((sum, term) => sum + (identity.has(term) ? 3 : description.has(term) ? 2 : 1) * Math.log(1 + skills.length / (1 + (frequency.get(term) || 0))), 0);
     return { skill, score, matched, totalTerms: terms.length };

--- a/docs/contributors/content-review-followup-2026-09-05.md
+++ b/docs/contributors/content-review-followup-2026-09-05.md
@@ -1,0 +1,33 @@
+# Scoped worked-example review — 2026-09-05 follow-up
+
+This second, deliberately bounded cohort covers the complete `lint-and-validate` and `sql-optimization-patterns` trees. They were selected because they offer executable validation/SQL examples central to everyday maintenance. No popularity or usage data was collected. This is not a whole-catalog certification.
+
+## Repairs and observed evidence
+
+- **Lint runner:** no configured checks previously returned `passed: true` and exit 0. It now reports `not-checked` and exit 2. Invalid package metadata is an explicit failure. Node fallback checkers resolve installed local binaries instead of allowing `npx` to download a checker. A real subprocess test exercises empty and malformed projects; a temporary project confirms a missing local checker fails without fetching it.
+- **Annotation inventory:** the Python regex counted a function with parameter and return annotations twice; source sampling could claim all discovered files were analyzed. AST counting now counts each function once; deterministic samples report the actual successful file count, truncation and parse errors. TypeScript observations are explicitly lexical; removed unsupported type-safety scores and acceptance thresholds. A 31-file fixture verifies the 30-file bound and one-function/one-count behavior.
+- **SQL:** replaced driver-ambiguous `IN (?)` list binding with a complete bounded SQLite function that binds each value and handles empty input. Tests execute the published code against an in-memory database, including multiple rows and an injection-like string treated as data.
+- **SQL result preservation:** executed the published composite cursor against tied timestamps and compared the correlated-count and LEFT JOIN aggregation examples for parents with zero, one and multiple children. Clarified that filtering completed orders changes the question, JOIN spelling alone does not guarantee a new plan, and approximate counts are not exact counts.
+- **PostgreSQL guidance:** corrected statement-statistics column names, index statistics naming, and the unique-index prerequisite for concurrent materialized-view refresh. Corrected the half-open timestamp interval and removed nonexistent bundled-reference links. Declared mutation risk and EXPLAIN ANALYZE execution explicitly.
+
+Run the six observed cases from the repository root:
+
+```sh
+python3 tools/scripts/tests/test_skill_worked_examples.py
+```
+
+The tests use Python's standard library and SQLite; they do not connect to a live database, run an external linter or establish query speed. PostgreSQL-specific corrections were checked against the official PostgreSQL 18 documentation linked from the playbook. No PostgreSQL server, extension setup, DDL locking behavior or production-provider integration was exercised. Python and Node project detection remains heuristic; inspect commands and use the repository's own check contract.
+
+## Content and provenance
+
+Both original skills declare community provenance; no new upstream identity, license or endorsement is inferred. All five tracked files were read, including both Python helpers and the SQL playbook; none is a symlink, binary or executable-mode file. Exact content fingerprints follow below. Later edits invalidate these byte-specific fingerprints. The protected merge's full-head review attestation remains separate.
+
+The earlier `content-review-2026-09-05.md` is a historical snapshot from before warning cleanup, not a statement of the current warning count.
+
+| File | SHA-256 |
+| --- | --- |
+| `skills/lint-and-validate/SKILL.md` | `6756e4dd35b4b62cab9ebe4bcd3d9b3839ebe1ea87030ea0a8d758c828240483` |
+| `skills/lint-and-validate/scripts/lint_runner.py` | `fe1230c95c7a38c11fd330b8b2ba57ab4e2744dc423e84637d3ca31c4562a20d` |
+| `skills/lint-and-validate/scripts/type_coverage.py` | `b61ed59396a30f0da730f7686971d6697e4caf62785f3da78e70335a7f44c348` |
+| `skills/sql-optimization-patterns/SKILL.md` | `e5e212280c58e04ed35df715b093f6e95ef0c382235104e3b4477fd9920bbd03` |
+| `skills/sql-optimization-patterns/resources/implementation-playbook.md` | `a42a1614aafa56f50dac45735a87b982a1c437ca57d876b570dcbd072d09c648` |

--- a/docs/users/aas-core.md
+++ b/docs/users/aas-core.md
@@ -67,6 +67,8 @@ During preview, AAS checks the ownership of the configuration parent directory (
 
 Use **Explore skills by outcome** in the catalog or Workbench to describe a task or choose a starting example. The browser suggests candidates from the public catalog and explains which terms match. Names and tags weigh more than descriptions; distinctive terms weigh more than common terms. This is descriptive relevance, not a quality score, semantic assessment, or effectiveness benchmark. Inspect the complete instructions and constraints before selecting anything. Core/MCP retrieval remains neutral and every canonical ID remains available.
 
+Use `without Supabase` or `senza Supabase` for an explicit single-term exclusion; repeat the phrase for additional terms. The interpreted exclusions are displayed. Other natural-language constraints still need agent review. Explicit compatibility aliases share one result card, with individually selectable matching alternative IDs.
+
 Each candidate exposes provenance, license, declared risk and setup information, including missing fields. These are author-supplied metadata, not reliability badges. Add candidates explicitly to the shared shortlist, compare them, and choose **Use discovery goal in brief** to carry the goal into the existing agent handoff. Nothing is selected automatically.
 
 Workbench downloads the public catalog only after you open discovery. Artifact review does not need that download and never sends imported artifacts or goals. The goal remains in page memory; only explicitly shortlisted IDs use the existing browser-local shortlist. There is no usage measurement, installation diary, or centralized collection.
@@ -261,20 +263,21 @@ aas stack audit \
 Use an existing target directory. On `main`, missing paths, wrong file/directory
 types and denied access return bounded `AAS_CLI_*` filesystem errors; correct the
 path or its permissions and retry. Native exception messages and private paths are
-not copied into the result. This error-handling refinement is unreleased.
+not copied into the result. This error-handling refinement is available from 16.8.0.
 
 On `main`, `--target` is inferred only when the validated manifest has one target;
 otherwise supply, for example, `--target codex:project`. The runtime version comes
 from the manifest, and its verified catalog must match the manifest's catalog.
 The npm SRI is the `runtime.integrity` returned by the approved MCP configuration;
-cache location and target directory remain explicit. These refinements are unreleased:
-the published 16.7.0 CLI still requires the explicit `--target` shown above.
+cache location and target directory remain explicit. These refinements are available from 16.8.0. Older clients still require the explicit `--target` shown above.
 
 `stack audit` is also read-only. It validates all three artifacts independently, resolves the manifest's pinned verified catalog, and reports whether their manifest digests, catalog identities, target, and selected skill IDs remain consistent. A structurally invalid or unverifiable artifact fails closed; a valid but differently bound artifact returns `status: "inconsistent"` with stable reason codes.
 
 Stop after reviewing the plan unless you are deliberately participating in controlled preview development. `stack apply` and `stack recover` remain experimental and require explicit opt-in.
 
 ## Use the reviewed selection
+
+**Prepare installation preview** in shortlist comparison or Workbench generates a copyable direct-installer command. Enter the actual skill directory and choose bash/zsh or PowerShell. The command preserves the selected IDs and exact catalog release and always includes `--dry-run`. It stays in page memory and is never executed by the browser. Workbench hides preparation while supplied artifacts are invalid or inconsistent; browser checks still do not prove semantic suitability or catalog integrity.
 
 For supported installation, use the direct installer with the same exact IDs,
 release version and intended skill directory. Follow [From selection to use](../../README.md#from-selection-to-use):

--- a/skills/lint-and-validate/SKILL.md
+++ b/skills/lint-and-validate/SKILL.md
@@ -1,62 +1,34 @@
 ---
 name: lint-and-validate
-description: "MANDATORY: Run appropriate validation tools after EVERY code change. Do not finish a task until the code is error-free."
+description: "Run configured lint and type checks, distinguish failures from checks that did not run, and report concrete validation results."
 risk: critical
 source: community
 date_added: "2026-02-27"
 ---
 
-# Lint and Validate Skill
-
-> **MANDATORY:** Run appropriate validation tools after EVERY code change. Do not finish a task until the code is error-free.
-
-### Procedures by Ecosystem
-
-#### Node.js / TypeScript
-1. **Lint/Fix:** `npm run lint` or `npx eslint "path" --fix`
-2. **Types:** `npx tsc --noEmit`
-3. **Security:** `npm audit --audit-level=high`
-
-#### Python
-1. **Linter (Ruff):** `ruff check "path" --fix` (Fast & Modern)
-2. **Security (Bandit):** `bandit -r "path" -ll`
-3. **Types (MyPy):** `mypy "path"`
-
-## The Quality Loop
-1. **Write/Edit Code**
-2. **Run Audit** for the project's ecosystem:
-   - **Node.js / TypeScript:** `npm run lint && npx tsc --noEmit`
-   - **Python:** `ruff check . --fix && mypy . && bandit -r . -ll`
-3. **Analyze Report:** Check the "FINAL AUDIT REPORT" section.
-4. **Fix & Repeat:** Submitting code with "FINAL AUDIT" failures is NOT allowed.
-
-## Error Handling
-- If `lint` fails: Fix the style or syntax issues immediately.
-- If `tsc` fails: Correct type mismatches before proceeding.
-- If no tool is configured: Check the project root for `.eslintrc`, `tsconfig.json`, `pyproject.toml` and suggest creating one.
-
----
-**Strict Rule:** No code should be committed or reported as "done" without passing these checks.
-
----
-
-## Scripts
-
-| Script | Purpose | Command |
-|--------|---------|---------|
-| `scripts/lint_runner.py` | Unified lint check | `python scripts/lint_runner.py <project_path>` |
-| `scripts/type_coverage.py` | Type coverage analysis | `python scripts/type_coverage.py <project_path>` |
+# Lint and Validate
 
 ## When to Use
-This skill is applicable to execute the workflow or actions described in the overview.
+
+Use after behavior or configuration changes when a repository has relevant lint or type checks. Read the repository's instructions and package scripts first. Run focused checks during development and the required checks before completion.
+
+## Procedure
+
+1. Identify the changed languages, configured commands, and installed tools. Inspect package scripts before executing them: a script named `lint` can modify files or run arbitrary project code.
+2. Run the project's read-only lint/type-check commands. For Node projects, prefer declared scripts such as `npm run lint` and `npm run typecheck`. Do not use `npx` to silently fetch an absent checker.
+3. For Python, use configured, already installed tools such as `ruff check .` or `mypy .`. Do not assume every `pyproject.toml` configures both. Never add `--fix` without inspecting the proposed changes and the task's authorization.
+4. Fix relevant failures without deleting user work, weakening rules, or raising timeouts just to pass. If a required tool is unavailable, report the exact check that did not run.
+5. Report commands, exit results, scope and remaining limitations. Passing lint does not prove the absence of runtime or security defects.
 
 ## Example
 
-**User request:**
+After correcting a TypeScript behavior, inspect `package.json`, run the configured focused regression test, then `npm run lint` and `npm run typecheck` if those scripts exist. If TypeScript is declared but not installed, report the missing local checker; do not substitute a downloaded package or call the result a pass.
 
-> Use @lint-and-validate for this task: MANDATORY: Run appropriate validation tools after EVERY code change.
+## Bundled helpers
+
+- `python scripts/lint_runner.py /absolute/project`: runs a conservative set of candidate checks. Node fallback checkers must exist in local `node_modules/.bin`; Python candidates must be installed. Inspect the project scripts first. A missing command or failing check exits 1; no configured checks or invalid project metadata exits 2. Exit 0 means the invoked checks passed, not that every needed check was discovered. Python detection is heuristic and may suggest unconfigured Ruff/MyPy commands.
+- `python scripts/type_coverage.py /absolute/project`: read-only annotation inventory, despite its retained compatibility filename. Samples at most 30 files per language, skips links and build/dependency directories, and bounds file reads. Python uses AST nodes to avoid double-counting functions. TypeScript reports lexical `: any` occurrences, including possible comments and strings. No quality percentage or pass/fail threshold is inferred. Exit 2 means no applicable files; parse/read errors exit 1.
 
 ## Limitations
-- Use this skill only when the task clearly matches the scope described above.
-- Do not treat the output as a substitute for environment-specific validation, testing, or expert review.
-- Stop and ask for clarification if required inputs, permissions, safety boundaries, or success criteria are missing.
+
+The runner executes trusted project commands, which may mutate files or access the network. It does not install dependencies, detect every monorepo configuration, or replace the project's CI contract. The inventory is a bounded source sample, not semantic type coverage; inferred types, generics, decorator behavior and correctness require the actual type checker. Do not label unrun checks as successful.

--- a/skills/lint-and-validate/scripts/lint_runner.py
+++ b/skills/lint-and-validate/scripts/lint_runner.py
@@ -7,13 +7,14 @@ Usage:
     python lint_runner.py <project_path>
 
 Supports:
-    - Node.js: npm run lint, npx tsc --noEmit
+    - Node.js: npm run lint, installed local tsc --noEmit
     - Python: ruff check, mypy
 """
 
 import subprocess
 import sys
 import json
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -44,14 +45,14 @@ def detect_project_type(project_path: Path) -> dict:
             if "lint" in scripts:
                 result["linters"].append({"name": "npm lint", "cmd": ["npm", "run", "lint"]})
             elif "eslint" in deps:
-                result["linters"].append({"name": "eslint", "cmd": ["npx", "eslint", "."]})
+                result["linters"].append({"name": "eslint", "cmd": [str(project_path / "node_modules" / ".bin" / ("eslint.cmd" if os.name == "nt" else "eslint")), "."]})
 
             # Check for TypeScript
             if "typescript" in deps or (project_path / "tsconfig.json").exists():
-                result["linters"].append({"name": "tsc", "cmd": ["npx", "tsc", "--noEmit"]})
+                result["linters"].append({"name": "tsc", "cmd": [str(project_path / "node_modules" / ".bin" / ("tsc.cmd" if os.name == "nt" else "tsc")), "--noEmit"]})
 
-        except:
-            pass
+        except (OSError, ValueError, TypeError, AttributeError) as error:
+            raise ValueError(f"Cannot inspect package.json: {error}") from error
 
     # Python project
     if (project_path / "pyproject.toml").exists() or (project_path / "requirements.txt").exists():
@@ -111,7 +112,14 @@ def main():
     print(f"Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
 
     # Detect project type
-    project_info = detect_project_type(project_path)
+    if not project_path.is_dir():
+        print("Project directory does not exist.", file=sys.stderr)
+        sys.exit(2)
+    try:
+        project_info = detect_project_type(project_path)
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        sys.exit(2)
     print(f"Type: {project_info['type']}")
     print(f"Linters: {len(project_info['linters'])}")
     print("-"*60)
@@ -123,11 +131,12 @@ def main():
             "project": str(project_path),
             "type": project_info["type"],
             "checks": [],
-            "passed": True,
+            "passed": False,
+            "status": "not-checked",
             "message": "No linters configured"
         }
         print(json.dumps(output, indent=2))
-        sys.exit(0)
+        sys.exit(2)
 
     # Run each linter
     results = []

--- a/skills/lint-and-validate/scripts/type_coverage.py
+++ b/skills/lint-and-validate/scripts/type_coverage.py
@@ -1,173 +1,78 @@
 #!/usr/bin/env python3
-"""
-Type Coverage Checker - Measures TypeScript/Python type coverage.
-Identifies untyped functions, any usage, and type safety issues.
-"""
-import sys
-import re
-import subprocess
+"""Bounded annotation inventory, not type coverage or a type-safety verdict."""
+import ast
+import json
+import os
 from pathlib import Path
+import re
+import sys
 
-# Fix Windows console encoding for Unicode output
-try:
-    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
-    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
-except AttributeError:
-    pass  # Python < 3.7
+MAX_FILES = 30
+MAX_BYTES = 1_000_000
+SKIP = {'.git', 'node_modules', 'venv', '.venv', '__pycache__', 'dist', 'build'}
 
-def check_typescript_coverage(project_path: Path) -> dict:
-    """Check TypeScript type coverage."""
-    issues = []
-    passed = []
-    stats = {'any_count': 0, 'untyped_functions': 0, 'total_functions': 0}
 
-    ts_files = list(project_path.rglob("*.ts")) + list(project_path.rglob("*.tsx"))
-    ts_files = [f for f in ts_files if 'node_modules' not in str(f) and '.d.ts' not in str(f)]
+def source_files(root, suffixes):
+    """Yield a deterministic sample without following directory or file links."""
+    for directory, dirs, files in os.walk(root, followlinks=False):
+        dirs[:] = sorted(name for name in dirs if name not in SKIP and not (Path(directory) / name).is_symlink())
+        for name in sorted(files):
+            path = Path(directory) / name
+            if path.suffix in suffixes and not path.name.endswith('.d.ts') and not path.is_symlink():
+                yield path
 
-    if not ts_files:
-        return {'type': 'typescript', 'files': 0, 'passed': [], 'issues': ["[!] No TypeScript files found"], 'stats': stats}
 
-    for file_path in ts_files[:30]:  # Limit
+def inventory(project_path, language):
+    result = {'type': language, 'files': 0, 'sample_limit': MAX_FILES, 'truncated': False, 'errors': [], 'stats': {}}
+    stats = result['stats']
+    stats.update({'functions': 0, 'fully_annotated_functions': 0} if language == 'python' else {'explicit_any_text_matches': 0})
+    for index, path in enumerate(source_files(project_path, {'.py'} if language == 'python' else {'.ts', '.tsx'})):
+        if index == MAX_FILES:
+            result['truncated'] = True
+            break
         try:
-            content = file_path.read_text(encoding='utf-8', errors='ignore')
+            with path.open('rb') as handle:
+                raw = handle.read(MAX_BYTES + 1)
+            if len(raw) > MAX_BYTES:
+                raise ValueError('source exceeds byte limit')
+            text = raw.decode('utf-8')
+            if language == 'python':
+                tree = ast.parse(text)
+                for node in ast.walk(tree):
+                    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        stats['functions'] += 1
+                        args = node.args.posonlyargs + node.args.args + node.args.kwonlyargs
+                        args += [arg for arg in (node.args.vararg, node.args.kwarg) if arg]
+                        annotated = node.returns is not None and all(arg.annotation is not None for arg in args)
+                        stats['fully_annotated_functions'] += int(annotated)
+            else:
+                # This includes comments/string literals and misses inferred/aliased any.
+                stats['explicit_any_text_matches'] += len(re.findall(r':\s*any\b', text))
+            result['files'] += 1
+        except (OSError, UnicodeError, ValueError, SyntaxError) as error:
+            result['errors'].append({'file': str(path.relative_to(project_path)), 'error': str(error)})
+    return result
 
-            # Count 'any' usage
-            any_matches = re.findall(r':\s*any\b', content)
-            stats['any_count'] += len(any_matches)
 
-            # Find functions without return types
-            # function name(params) { - no return type
-            untyped = re.findall(r'function\s+\w+\s*\([^)]*\)\s*{', content)
-            # Arrow functions without types: const fn = (x) => or (x) =>
-            untyped += re.findall(r'=\s*\([^:)]*\)\s*=>', content)
-            stats['untyped_functions'] += len(untyped)
+def check_python_coverage(project_path):
+    return inventory(project_path, 'python')
 
-            # Count typed functions
-            typed = re.findall(r'function\s+\w+\s*\([^)]*\)\s*:\s*\w+', content)
-            typed += re.findall(r':\s*\([^)]*\)\s*=>\s*\w+', content)
-            stats['total_functions'] += len(typed) + len(untyped)
 
-        except Exception:
-            continue
+def check_typescript_coverage(project_path):
+    return inventory(project_path, 'typescript')
 
-    # Analyze results
-    if stats['any_count'] == 0:
-        passed.append("[OK] No 'any' types found")
-    elif stats['any_count'] <= 5:
-        issues.append(f"[!] {stats['any_count']} 'any' types found (acceptable)")
-    else:
-        issues.append(f"[X] {stats['any_count']} 'any' types found (too many)")
-
-    if stats['total_functions'] > 0:
-        typed_ratio = (stats['total_functions'] - stats['untyped_functions']) / stats['total_functions'] * 100
-        if typed_ratio >= 80:
-            passed.append(f"[OK] Type coverage: {typed_ratio:.0f}%")
-        elif typed_ratio >= 50:
-            issues.append(f"[!] Type coverage: {typed_ratio:.0f}% (improve)")
-        else:
-            issues.append(f"[X] Type coverage: {typed_ratio:.0f}% (too low)")
-
-    passed.append(f"[OK] Analyzed {len(ts_files)} TypeScript files")
-
-    return {'type': 'typescript', 'files': len(ts_files), 'passed': passed, 'issues': issues, 'stats': stats}
-
-def check_python_coverage(project_path: Path) -> dict:
-    """Check Python type hints coverage."""
-    issues = []
-    passed = []
-    stats = {'untyped_functions': 0, 'typed_functions': 0, 'any_count': 0}
-
-    py_files = list(project_path.rglob("*.py"))
-    py_files = [f for f in py_files if not any(x in str(f) for x in ['venv', '__pycache__', '.git', 'node_modules'])]
-
-    if not py_files:
-        return {'type': 'python', 'files': 0, 'passed': [], 'issues': ["[!] No Python files found"], 'stats': stats}
-
-    for file_path in py_files[:30]:  # Limit
-        try:
-            content = file_path.read_text(encoding='utf-8', errors='ignore')
-
-            # Count Any usage
-            any_matches = re.findall(r':\s*Any\b', content)
-            stats['any_count'] += len(any_matches)
-
-            # Find functions with type hints
-            typed_funcs = re.findall(r'def\s+\w+\s*\([^)]*:[^)]+\)', content)
-            typed_funcs += re.findall(r'def\s+\w+\s*\([^)]*\)\s*->', content)
-            stats['typed_functions'] += len(typed_funcs)
-
-            # Find functions without type hints
-            all_funcs = re.findall(r'def\s+\w+\s*\(', content)
-            stats['untyped_functions'] += len(all_funcs) - len(typed_funcs)
-
-        except Exception:
-            continue
-
-    total = stats['typed_functions'] + stats['untyped_functions']
-
-    if total > 0:
-        typed_ratio = stats['typed_functions'] / total * 100
-        if typed_ratio >= 70:
-            passed.append(f"[OK] Type hints coverage: {typed_ratio:.0f}%")
-        elif typed_ratio >= 40:
-            issues.append(f"[!] Type hints coverage: {typed_ratio:.0f}%")
-        else:
-            issues.append(f"[X] Type hints coverage: {typed_ratio:.0f}% (add type hints)")
-
-    if stats['any_count'] == 0:
-        passed.append("[OK] No 'Any' types found")
-    elif stats['any_count'] <= 3:
-        issues.append(f"[!] {stats['any_count']} 'Any' types found")
-    else:
-        issues.append(f"[X] {stats['any_count']} 'Any' types found")
-
-    passed.append(f"[OK] Analyzed {len(py_files)} Python files")
-
-    return {'type': 'python', 'files': len(py_files), 'passed': passed, 'issues': issues, 'stats': stats}
 
 def main():
-    target = sys.argv[1] if len(sys.argv) > 1 else "."
-    project_path = Path(target)
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else '.').resolve()
+    if not root.is_dir():
+        print('Project directory does not exist.', file=sys.stderr)
+        return 2
+    results = [inventory(root, language) for language in ('python', 'typescript')]
+    print(json.dumps({'kind': 'annotation-inventory', 'limitation': 'Not type coverage. Annotations do not establish correctness; TypeScript counts are lexical. Run the configured type checker.', 'results': results}, indent=2))
+    if any(result['errors'] for result in results):
+        return 1
+    return 0 if any(result['files'] for result in results) else 2
 
-    print("\n" + "=" * 60)
-    print("  TYPE COVERAGE CHECKER")
-    print("=" * 60 + "\n")
 
-    results = []
-
-    # Check TypeScript
-    ts_result = check_typescript_coverage(project_path)
-    if ts_result['files'] > 0:
-        results.append(ts_result)
-
-    # Check Python
-    py_result = check_python_coverage(project_path)
-    if py_result['files'] > 0:
-        results.append(py_result)
-
-    if not results:
-        print("[!] No TypeScript or Python files found.")
-        sys.exit(0)
-
-    # Print results
-    critical_issues = 0
-    for result in results:
-        print(f"\n[{result['type'].upper()}]")
-        print("-" * 40)
-        for item in result['passed']:
-            print(f"  {item}")
-        for item in result['issues']:
-            print(f"  {item}")
-            if item.startswith("[X]"):
-                critical_issues += 1
-
-    print("\n" + "=" * 60)
-    if critical_issues == 0:
-        print("[OK] TYPE COVERAGE: ACCEPTABLE")
-        sys.exit(0)
-    else:
-        print(f"[X] TYPE COVERAGE: {critical_issues} critical issues")
-        sys.exit(1)
-
-if __name__ == "__main__":
-    main()
+if __name__ == '__main__':
+    sys.exit(main())

--- a/skills/sql-optimization-patterns/SKILL.md
+++ b/skills/sql-optimization-patterns/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: sql-optimization-patterns
-description: "Transform slow database queries into lightning-fast operations through systematic optimization, proper indexing, and query plan analysis."
-risk: safe
+description: "Diagnose slow SQL with query plans, preserve query results, and verify indexing or query changes against representative data."
+risk: critical
 source: community
 date_added: "2026-02-27"
 ---
 
 # SQL Optimization Patterns
 
-Transform slow database queries into lightning-fast operations through systematic optimization, proper indexing, and query plan analysis.
+Diagnose slow SQL with query plans, preserve query results, and verify indexing or query changes against representative data.
 
 ## Use this skill when
 
@@ -28,9 +28,9 @@ Transform slow database queries into lightning-fast operations through systemati
 
 ## Instructions
 
-- Clarify goals, constraints, and required inputs.
-- Apply relevant best practices and validate outcomes.
-- Provide actionable steps and verification.
+- Confirm database engine/version, query parameters, expected rows, data distribution and the permitted environment. Start read-only; obtain authorization before DDL, data changes, configuration changes or maintenance.
+- Compare result sets before comparing performance. EXPLAIN ANALYZE executes the statement: use approved representative data, account for functions and triggers, and do not assume a transaction rollback undoes every side effect.
+- Record the observed plan, timing conditions and correctness checks. Indexes and query rewrites are hypotheses, not universal speed improvements.
 - If detailed examples are required, open `resources/implementation-playbook.md`.
 
 ## Resources
@@ -41,3 +41,7 @@ Transform slow database queries into lightning-fast operations through systemati
 - Use this skill only when the task clearly matches the scope described above.
 - Do not treat the output as a substitute for environment-specific validation, testing, or expert review.
 - Stop and ask for clarification if required inputs, permissions, safety boundaries, or success criteria are missing.
+
+## Worked example
+
+The playbook includes an executable SQLite batch-loading example with bound values and an empty-input case. The repository test exercises it alongside pagination ties and aggregation equivalence. SQLite correctness checks do not establish PostgreSQL performance or production safety.

--- a/skills/sql-optimization-patterns/resources/implementation-playbook.md
+++ b/skills/sql-optimization-patterns/resources/implementation-playbook.md
@@ -4,7 +4,7 @@ This file contains detailed patterns, checklists, and code samples referenced by
 
 # SQL Optimization Patterns
 
-Transform slow database queries into lightning-fast operations through systematic optimization, proper indexing, and query plan analysis.
+Preserve the query result before assessing performance. PostgreSQL-specific examples target PostgreSQL 18 unless marked otherwise; use an authorized test database with matching tables. DDL, configuration and maintenance examples require explicit authorization. EXPLAIN ANALYZE executes the statement, including possible function side effects.
 
 ## Do not use this skill when
 
@@ -53,9 +53,9 @@ WHERE u.created_at > NOW() - INTERVAL '30 days';
 ```
 
 **Key Metrics to Watch:**
-- **Seq Scan**: Full table scan (usually slow for large tables)
-- **Index Scan**: Using index (good)
-- **Index Only Scan**: Using index without touching table (best)
+- **Seq Scan**: May be appropriate for small tables or queries returning much of a table
+- **Index Scan**: Assess selectivity and heap reads, not just the node name
+- **Index Only Scan**: Check heap fetches and visibility; not automatically fastest
 - **Nested Loop**: Join method (okay for small datasets)
 - **Hash Join**: Join method (good for larger datasets)
 - **Merge Join**: Join method (good for sorted data)
@@ -127,18 +127,18 @@ SELECT * FROM users WHERE email = 'user@example.com';
 
 **Optimize JOINs:**
 ```sql
--- Bad: Cartesian product then filter
+-- Equivalent inner-join spelling; the optimizer may produce the same plan
 SELECT u.name, o.total
 FROM users u, orders o
 WHERE u.id = o.user_id AND u.created_at > '2024-01-01';
 
--- Good: Filter before join
+-- Explicit JOIN improves readability, not necessarily execution
 SELECT u.name, o.total
 FROM users u
 JOIN orders o ON u.id = o.user_id
 WHERE u.created_at > '2024-01-01';
 
--- Better: Filter both tables
+-- Equivalent subquery form; only users are filtered here
 SELECT u.name, o.total
 FROM (SELECT * FROM users WHERE created_at > '2024-01-01') u
 JOIN orders o ON u.id = o.user_id;
@@ -172,28 +172,24 @@ SELECT * FROM orders
 WHERE user_id IN (1, 2, 3, 4, 5);
 ```
 
-```python
-# Good: Single query with JOIN or batch load
-# Using JOIN
-results = db.query("""
-    SELECT u.id, u.name, o.id as order_id, o.total
-    FROM users u
-    LEFT JOIN orders o ON u.id = o.user_id
-    WHERE u.id IN (1, 2, 3, 4, 5)
-""")
+**Executable SQLite batch loading** (an existing connection and table are required):
 
-# Or batch load
-users = db.query("SELECT * FROM users LIMIT 10")
-user_ids = [u.id for u in users]
-orders = db.query(
-    "SELECT * FROM orders WHERE user_id IN (?)",
-    user_ids
-)
-# Group orders by user_id
-orders_by_user = {}
-for order in orders:
-    orders_by_user.setdefault(order.user_id, []).append(order)
+```python
+# batch-loading-example
+
+def load_orders(connection, user_ids):
+    if not user_ids:
+        return []
+    if len(user_ids) > 500:
+        raise ValueError("Batch limit is 500 IDs; split larger inputs")
+    placeholders = ",".join("?" for _ in user_ids)
+    return connection.execute(
+        f"SELECT id, user_id, total FROM orders WHERE user_id IN ({placeholders}) ORDER BY id",
+        tuple(user_ids),
+    ).fetchall()
 ```
+
+Values are bound, never interpolated. A single `IN (?)` parameter does not expand a Python list. Other drivers use different placeholders. Preserve parents with no orders when reconstructing parent/child results; a JOIN duplicates parent rows when multiple children match.
 
 ### Pattern 2: Optimize Pagination
 
@@ -207,13 +203,13 @@ LIMIT 20 OFFSET 100000;  -- Very slow!
 
 **Good: Cursor-Based Pagination**
 ```sql
--- Much faster: Use cursor (last seen ID)
+-- Single-column cursor is valid only when created_at is unique and non-null
 SELECT * FROM users
 WHERE created_at < '2024-01-15 10:30:00'  -- Last cursor
 ORDER BY created_at DESC
 LIMIT 20;
 
--- With composite sorting
+-- For timestamp ties, use both non-null created_at and unique id from the last row
 SELECT * FROM users
 WHERE (created_at, id) < ('2024-01-15 10:30:00', 12345)
 ORDER BY created_at DESC, id DESC
@@ -230,10 +226,10 @@ CREATE INDEX idx_users_cursor ON users(created_at DESC, id DESC);
 -- Bad: Counts all rows
 SELECT COUNT(*) FROM orders;  -- Slow on large tables
 
--- Good: Use estimates for approximate counts
+-- Approximate count only; not equivalent to exact COUNT(*)
 SELECT reltuples::bigint AS estimate
 FROM pg_class
-WHERE relname = 'orders';
+WHERE oid = 'public.orders'::regclass;
 
 -- Good: Filter before counting
 SELECT COUNT(*) FROM orders
@@ -253,14 +249,14 @@ FROM orders
 GROUP BY user_id
 HAVING COUNT(*) > 10;
 
--- Better: Filter first, then group (if possible)
+-- DIFFERENT REQUIREMENT: count only completed orders; not an equivalent rewrite
 SELECT user_id, COUNT(*) as order_count
 FROM orders
 WHERE status = 'completed'
 GROUP BY user_id
 HAVING COUNT(*) > 10;
 
--- Best: Use covering index
+-- Candidate index; compare the actual plan and write overhead
 CREATE INDEX idx_orders_user_status ON orders(user_id, status);
 ```
 
@@ -279,7 +275,7 @@ FROM users u
 LEFT JOIN orders o ON o.user_id = u.id
 GROUP BY u.id, u.name, u.email;
 
--- Better: Use window functions
+-- Alternative window form; may process more rows, measure before choosing
 SELECT DISTINCT ON (u.id)
     u.name, u.email,
     COUNT(o.id) OVER (PARTITION BY u.id) as order_count
@@ -335,11 +331,11 @@ UPDATE users SET status = 'active' WHERE id = 2;
 -- Good: Single UPDATE with IN clause
 UPDATE users
 SET status = 'active'
-WHERE id IN (1, 2, 3, 4, 5, ...);
+WHERE id IN (1, 2, 3, 4, 5);
 
 -- Better: Use temporary table for large batches
 CREATE TEMP TABLE temp_user_updates (id INT, new_status VARCHAR);
-INSERT INTO temp_user_updates VALUES (1, 'active'), (2, 'active'), ...;
+INSERT INTO temp_user_updates VALUES (1, 'active'), (2, 'active');
 
 UPDATE users u
 SET status = t.new_status
@@ -372,7 +368,8 @@ CREATE INDEX idx_user_summary_spent ON user_order_summary(total_spent DESC);
 -- Refresh materialized view
 REFRESH MATERIALIZED VIEW user_order_summary;
 
--- Concurrent refresh (PostgreSQL)
+-- Concurrent refresh requires a populated view and a non-partial UNIQUE index on plain columns.
+CREATE UNIQUE INDEX idx_user_summary_id ON user_order_summary(id);
 REFRESH MATERIALIZED VIEW CONCURRENTLY user_order_summary;
 
 -- Query materialized view (very fast)
@@ -403,24 +400,24 @@ CREATE TABLE orders_2024_q2 PARTITION OF orders
 
 -- Queries automatically use appropriate partition
 SELECT * FROM orders
-WHERE created_at BETWEEN '2024-02-01' AND '2024-02-28';
+WHERE created_at >= '2024-02-01' AND created_at < '2024-03-01';
 -- Only scans orders_2024_q1 partition
 ```
 
 ### Query Hints and Optimization
 
 ```sql
--- Force index usage (MySQL)
+-- Restrict candidate indexes (MySQL); USE INDEX does not force an index scan
 SELECT * FROM users
 USE INDEX (idx_users_email)
 WHERE email = 'user@example.com';
 
 -- Parallel query (PostgreSQL)
 SET max_parallel_workers_per_gather = 4;
-SELECT * FROM large_table WHERE condition;
+SELECT * FROM large_table WHERE id = 123;
 
 -- Join hints (PostgreSQL)
-SET enable_nestloop = OFF;  -- Force hash or merge join
+SET enable_nestloop = OFF;  -- Discourage nested loops for diagnosis; not an absolute prohibition
 ```
 
 ## Best Practices
@@ -454,17 +451,18 @@ REINDEX TABLE users;
 - **Unused Indexes**: Waste space and slow writes
 - **Missing Indexes**: Slow queries, full table scans
 - **Implicit Type Conversion**: Prevents index usage
-- **OR Conditions**: Can't use indexes efficiently
-- **LIKE with Leading Wildcard**: `LIKE '%abc'` can't use index
+- **OR Conditions**: May combine indexes; inspect the plan
+- **LIKE with Leading Wildcard**: Ordinary B-tree indexes often do not help; specialized indexes may
 - **Function in WHERE**: Prevents index usage unless functional index exists
 
 ## Monitoring Queries
 
 ```sql
--- Find slow queries (PostgreSQL)
-SELECT query, calls, total_time, mean_time
+-- Requires an already configured pg_stat_statements extension and suitable privileges.
+-- Query text can contain sensitive values; do not export it without permission.
+SELECT query, calls, total_exec_time, mean_exec_time
 FROM pg_stat_statements
-ORDER BY mean_time DESC
+ORDER BY mean_exec_time DESC
 LIMIT 10;
 
 -- Find missing indexes (PostgreSQL)
@@ -480,11 +478,11 @@ WHERE seq_scan > 0
 ORDER BY seq_tup_read DESC
 LIMIT 10;
 
--- Find unused indexes (PostgreSQL)
+-- Zero scans are observations since statistics reset, not permission to drop an index.
 SELECT
     schemaname,
     tablename,
-    indexname,
+    indexrelname,
     idx_scan,
     idx_tup_read,
     idx_tup_fetch
@@ -493,12 +491,10 @@ WHERE idx_scan = 0
 ORDER BY pg_relation_size(indexrelid) DESC;
 ```
 
-## Resources
+## Verified reference material
 
-- **references/postgres-optimization-guide.md**: PostgreSQL-specific optimization
-- **references/mysql-optimization-guide.md**: MySQL/MariaDB optimization
-- **references/query-plan-analysis.md**: Deep dive into EXPLAIN plans
-- **assets/index-strategy-checklist.md**: When and how to create indexes
-- **assets/query-optimization-checklist.md**: Step-by-step optimization guide
-- **scripts/analyze-slow-queries.sql**: Identify slow queries in your database
-- **scripts/index-recommendations.sql**: Generate index recommendations
+- [PostgreSQL 18 EXPLAIN](https://www.postgresql.org/docs/18/using-explain.html): execution, estimates and observed plans.
+- [PostgreSQL 18 materialized-view refresh](https://www.postgresql.org/docs/18/sql-refreshmaterializedview.html): populated view and unique-index requirements.
+- [PostgreSQL 18 statement statistics](https://www.postgresql.org/docs/18/pgstatstatements.html): extension prerequisites and current time columns.
+
+The former references to unbundled local guides and scripts have been removed. Examples above assume application tables and permissions; they are not one migration script. Performance, locks, concurrent changes, extension setup and production-provider behavior require separate environment-specific verification.

--- a/tools/scripts/tests/test_skill_worked_examples.py
+++ b/tools/scripts/tests/test_skill_worked_examples.py
@@ -1,0 +1,86 @@
+import importlib.util
+import json
+from pathlib import Path
+import re
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[3]
+LINT = ROOT / 'skills/lint-and-validate/scripts'
+PLAYBOOK = ROOT / 'skills/sql-optimization-patterns/resources/implementation-playbook.md'
+
+
+def module(name):
+    spec = importlib.util.spec_from_file_location(name, LINT / (name + '.py'))
+    result = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(result)
+    return result
+
+
+class WorkedExamples(unittest.TestCase):
+    def test_no_checks_and_invalid_metadata_are_not_success(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = subprocess.run([sys.executable, str(LINT / 'lint_runner.py'), directory], capture_output=True, text=True)
+            self.assertEqual(result.returncode, 2)
+            self.assertIn('"passed": false', result.stdout)
+            Path(directory, 'package.json').write_text('{')
+            result = subprocess.run([sys.executable, str(LINT / 'lint_runner.py'), directory], capture_output=True, text=True)
+            self.assertEqual(result.returncode, 2)
+
+    def test_node_fallback_never_downloads_a_checker(self):
+        with tempfile.TemporaryDirectory() as directory:
+            Path(directory, 'package.json').write_text(json.dumps({'devDependencies': {'typescript': '1', 'eslint': '1'}}))
+            runner = module('lint_runner')
+            checks = runner.detect_project_type(Path(directory))['linters']
+            self.assertEqual(len(checks), 2)
+            self.assertTrue(all('node_modules' in check['cmd'][0] for check in checks))
+            self.assertFalse(runner.run_linter(checks[0], Path(directory))['passed'])
+
+    def test_inventory_does_not_double_count_or_claim_unread_files(self):
+        checker = module('type_coverage')
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for index in range(31):
+                (root / f'f{index:02}.py').write_text('def identity(value: int) -> int:\n    return value\n')
+            result = checker.check_python_coverage(root)
+            self.assertEqual(result['files'], 30)
+            self.assertTrue(result['truncated'])
+            self.assertEqual(result['stats'], {'functions': 30, 'fully_annotated_functions': 30})
+            (root / 'f00.py').write_text('invalid syntax !')
+            self.assertEqual(len(checker.check_python_coverage(root)['errors']), 1)
+
+    def test_published_batch_loading_preserves_values_and_empty_case(self):
+        code = next(code for code in re.findall(r'```python\n(.*?)```', PLAYBOOK.read_text(), re.S) if '# batch-loading-example' in code)
+        namespace = {}
+        exec(compile(code, str(PLAYBOOK), 'exec'), namespace)
+        with sqlite3.connect(':memory:') as connection:
+            connection.executescript('CREATE TABLE orders(id INTEGER, user_id INTEGER, total INTEGER); INSERT INTO orders VALUES (1,1,10),(2,1,20),(3,2,30);')
+            load = namespace['load_orders']
+            self.assertEqual(load(connection, [1]), [(1,1,10),(2,1,20)])
+            self.assertEqual(load(connection, []), [])
+            self.assertEqual(load(connection, ['1) OR 1=1 --']), [])
+            with self.assertRaises(ValueError):
+                load(connection, list(range(501)))
+
+    def test_published_cursor_handles_equal_timestamps(self):
+        text = PLAYBOOK.read_text()
+        query = re.search(r'SELECT \* FROM users\nWHERE \(created_at, id\).*?LIMIT 20;', text, re.S).group()
+        with sqlite3.connect(':memory:') as connection:
+            connection.executescript("CREATE TABLE users(id INTEGER, created_at TEXT); INSERT INTO users VALUES (12346,'2024-01-15 10:30:00'),(12345,'2024-01-15 10:30:00'),(12344,'2024-01-15 10:30:00'),(1,'2024-01-14 10:30:00');")
+            self.assertEqual([row[0] for row in connection.execute(query)], [12344, 1])
+
+    def test_published_join_aggregation_preserves_zero_and_multiple_orders(self):
+        text = PLAYBOOK.read_text()
+        correlated = re.search(r'SELECT u.name, u.email,\n    \(SELECT COUNT\(\*\).*?FROM users u;', text, re.S).group()
+        joined = re.search(r'SELECT u.name, u.email, COUNT\(o.id\).*?GROUP BY u.id, u.name, u.email;', text, re.S).group()
+        with sqlite3.connect(':memory:') as connection:
+            connection.executescript("CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT, email TEXT); CREATE TABLE orders(id INTEGER, user_id INTEGER); INSERT INTO users VALUES (1,'A','a'),(2,'B','b'),(3,'C','c'); INSERT INTO orders VALUES (1,1),(2,1),(3,2);")
+            self.assertEqual(sorted(connection.execute(correlated)), sorted(connection.execute(joined)))
+            self.assertIn(('C', 'c', 0), list(connection.execute(joined)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,10 @@
+# Discovery and installation handoff follow-up - 2026-09-05
+
+- Fixed explicit English/Italian exclusions and grouped declared compatibility aliases while preserving explicit ID selection.
+- Added a text-only, exact-version direct-installer preview to shortlist comparison and Workbench, with shell quoting, an explicit destination, and invalid/inconsistent-artifact guards.
+- Corrected stale release-status guidance after verifying GitHub and npm 16.8.0 publication.
+- Reviewed and repaired the complete `lint-and-validate` and `sql-optimization-patterns` bundles. Added six runnable regression cases; see the scoped content review for evidence and limits.
+
 # Outcome discovery and clearer selection evidence - 2026-09-05
 
 - Added optional goal-based candidate discovery to catalog and Workbench, with explained term relevance and full-catalog access.


### PR DESCRIPTION
# Pull Request Description

Fix outcome searches that promoted an explicitly excluded technology: `React without Supabase` now excludes Supabase matches and displays the interpreted exclusion. Group declared compatibility aliases into one procedure card while preserving individual ID selection.

Add a text-only installation preview to shortlist comparison and Workbench. Users enter the destination and terminal; the generated command preserves exact IDs and catalog release, quotes arguments, and always uses `--dry-run`. Invalid or inconsistent imported artifacts hide preparation. The browser never executes a command or transmits project data. Correct stale release-status guidance after verifying the published 16.8.0 release.

The first additional worked-example cohort repairs the complete `lint-and-validate` and `sql-optimization-patterns` bundles: unrun checks no longer pass, local Node checker fallback cannot fetch packages, annotation sampling no longer fabricates coverage, and SQL examples preserve semantics and describe engine prerequisites. Six executable cases and a byte-specific review record document the scope; no whole-catalog effectiveness claim is made.

## Change Classification

- [x] Skill PR
- [x] Docs PR
- [x] Infra PR (catalog application and regression tests)

## Quality Bar Checklist ✅

- [x] **Standards**: Read quality bar and security guardrails.
- [x] **Metadata**: Validated the changed frontmatter.
- [x] **Risk Label**: SQL now declares critical because its guidance includes DDL and maintenance; boundaries are explicit.
- [x] **Triggers**: Both skill entry points describe their actual task.
- [x] **Limitations**: Distinguish invoked checks, lexical inventory, SQLite correctness and untested PostgreSQL behavior.
- [x] **Safety scan**: Documentation security passed.
- [x] **Automated Skill Review**: Inspected the exact-head workflow outcome: `manual-review-required`. This is not a Tessl pass. The complete-tree maintainer review is attested to `01afa8961edeca7528c157eabc6e8736e38a8852` through the guarded merge command.
- [x] **Manual Logic Review**: Read all five tracked files across both complete skill trees; inspected semantics, provenance, permissions, examples and limitations. Fingerprints are in the scoped review record.
- [x] **Local Test**: Six skill cases, web tests, typecheck, lint, build and real headless-browser interactions passed.
- [x] **Repo Checks**: Reference validation, all 122 script test groups, all 169 Core tests and catalog integrity passed.
- [x] **Source-Only PR**: Generated registries and all plugin mirrors are excluded; protected canonical sync owns them.
- [x] **Credits**: Existing community provenance is preserved; no new external work is attributed.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

Offensive-skill and imported-license checklist items are not applicable. No upstream identity or licensing claim was added.

## Validation

- Web: 217 tests in 31 files; 87.33% statements, 77.54% branches, 89.88% functions, 91.90% lines. Final command-quoting tests also passed after the Windows metacharacter guard.
- Six skill cases execute the published SQLite function/cursor/aggregation and exercise lint/inventory behavior in temporary fixtures. PostgreSQL-specific corrections were verified against official version-18 documentation; no PostgreSQL performance result is claimed.
- Generated POSIX command passed through a real shell into a stub executable and the real installer argument parser, preserving a path containing spaces, apostrophes and shell-like text literally.
- Headless Edge: English exclusion, grouped alias selection, exact version/IDs from an older recorded manifest, command preview and 390px layout; no page errors or goal/path transmission. PowerShell quoting is unit-tested; no Windows process was launched in this local check.
- Local full repository/Core suites passed. Strict audit: zero errors and zero warnings across 2,113 skills; warning budget 0/0. Changed-skill evidence covers both complete changed trees and has no blocking reasons.

## Screenshots (if applicable)

Desktop and mobile screenshots were inspected locally. Controls use the existing catalog/Workbench theme.
