### PR TITLE
fix: harden archive and installer boundaries and browser reviews

### DIFF
--- a/apps/web-app/src/pages/SkillDetail.tsx
+++ b/apps/web-app/src/pages/SkillDetail.tsx
@@ -91,6 +91,7 @@ export function SkillDetail(): React.ReactElement {
   const [contentLoading, setContentLoading] = useState(true);
   const [copied, setCopied] = useState(false);
   const [copiedFull, setCopiedFull] = useState(false);
+  const [copyError, setCopyError] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [customContext, setCustomContext] = useState('');
   const [retryToken, setRetryToken] = useState(0);
@@ -149,6 +150,7 @@ export function SkillDetail(): React.ReactElement {
 
   useEffect(() => {
     if (contextLoading || !skill) return;
+    let active = true;
 
     const loadMarkdown = async () => {
       setContentLoading(true);
@@ -171,8 +173,10 @@ export function SkillDetail(): React.ReactElement {
         for (const url of candidateUrls) {
           try {
             markdown = await fetchMarkdownOnce(url, skill.id);
+            if (!active) return;
             break;
           } catch (err) {
+            if (!active) return;
             lastError = err instanceof Error ? err : new Error(String(err));
           }
         }
@@ -183,15 +187,29 @@ export function SkillDetail(): React.ReactElement {
 
         setContent(markdown);
       } catch (err) {
+        if (!active) return;
         console.error('Failed to load skill content', err);
         setError(err instanceof Error ? err.message : 'Could not load skill content.');
       } finally {
-        setContentLoading(false);
+        if (active) setContentLoading(false);
       }
     };
 
-    loadMarkdown();
+    void loadMarkdown();
+    return () => { active = false; };
   }, [skill, contextLoading, retryToken]);
+
+  const copyText = async (text: string, markCopied: (value: boolean) => void) => {
+    setCopyError('');
+    markCopied(false);
+    try {
+      await navigator.clipboard.writeText(text);
+      markCopied(true);
+      setTimeout(() => markCopied(false), 2000);
+    } catch {
+      setCopyError('Clipboard unavailable. Select and copy the text directly from this page.');
+    }
+  };
 
   const copyToClipboard = () => {
     if (!skill) return;
@@ -201,9 +219,7 @@ export function SkillDetail(): React.ReactElement {
       ? `${basePrompt}\n\nContext:\n${customContext}`
       : basePrompt;
 
-    navigator.clipboard.writeText(finalPrompt);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    void copyText(finalPrompt, setCopied);
   };
 
   const copyFullToClipboard = () => {
@@ -211,9 +227,7 @@ export function SkillDetail(): React.ReactElement {
       ? `${content}\n\nContext:\n${customContext}`
       : content;
 
-    navigator.clipboard.writeText(finalPrompt);
-    setCopiedFull(true);
-    setTimeout(() => setCopiedFull(false), 2000);
+    void copyText(finalPrompt, setCopiedFull);
   };
 
   if (!contextLoading && !skill) {
@@ -358,6 +372,7 @@ export function SkillDetail(): React.ReactElement {
             </div>
           </div>
 
+          {copyError ? <p role="alert">{copyError}</p> : null}
           <label htmlFor="context" className="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-300">
             Interactive Prompt Builder (Optional)
           </label>

--- a/apps/web-app/src/pages/__tests__/SkillDetail.test.tsx
+++ b/apps/web-app/src/pages/__tests__/SkillDetail.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 import { SkillDetail } from '../SkillDetail';
 import { renderWithRouter } from '../../utils/testUtils';
 import { createMockSkill } from '../../factories/skill';
@@ -237,6 +238,26 @@ describe('SkillDetail', () => {
     });
   });
 
+  it('ignores an older markdown request after navigating to another skill', async () => {
+    const first = createMockSkill({ id: 'delayed-first', name: 'delayed-first', path: 'delayed-first' });
+    const second = createMockSkill({ id: 'current-second', name: 'current-second', path: 'current-second' });
+    (useSkills as Mock).mockReturnValue({ skills: [first, second], stars: {}, loading: false });
+    let finishFirst!: (response: unknown) => void;
+    global.fetch = vi.fn().mockImplementation((url: string) => url.includes('delayed-first')
+      ? new Promise((resolve) => { finishFirst = resolve; })
+      : Promise.resolve({ ok: true, text: async () => '# Current second content' }));
+    const router = createMemoryRouter([{ path: '/skill/:id', element: <SkillDetail /> }],
+      { initialEntries: ['/skill/delayed-first'] });
+    render(<RouterProvider router={router} />);
+    await waitFor(() => expect(finishFirst).toBeDefined());
+    await act(() => router.navigate('/skill/current-second'));
+    await waitFor(() => expect(screen.getByTestId('markdown-content')).toHaveTextContent('Current second content'));
+    await act(async () => { finishFirst({ ok: true, text: async () => '# Stale first content' }); });
+    expect(screen.getByTestId('markdown-content')).toHaveTextContent('Current second content');
+    fireEvent.click(screen.getByRole('button', { name: /Copy Full Content/i }));
+    expect(navigator.clipboard.writeText).toHaveBeenLastCalledWith('# Current second content');
+  });
+
   describe('Copy functionality', () => {
     it('should copy skill name to clipboard when clicked', async () => {
       const mockSkill = createMockSkill({ id: 'click-test', name: 'click-test' });
@@ -266,6 +287,19 @@ describe('SkillDetail', () => {
       fireEvent.click(copyButton);
 
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Use @click-test');
+    });
+
+    it.each(['Copy @Skill', 'Copy Full Content'])('reports a failed %s without claiming success', async (button) => {
+      const skill = createMockSkill({ id: 'clipboard-failure', name: 'clipboard-failure' });
+      (useSkills as Mock).mockReturnValue({ skills: [skill], stars: {}, loading: false });
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '# Copyable content' });
+      renderWithRouter(<SkillDetail />, { route: '/skill/clipboard-failure', path: '/skill/:id', useProvider: false });
+      const copy = await screen.findByRole('button', { name: button });
+      vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error('clipboard permission denied'));
+      fireEvent.click(copy);
+      expect(await screen.findByRole('alert')).toHaveTextContent('Clipboard unavailable');
+      expect(copy).toHaveTextContent(button);
+      expect(copy).not.toHaveTextContent('Copied');
     });
 
     it('should link to Core artifact review without promising composition', async () => {

--- a/apps/web-app/src/utils/__tests__/workbenchReview.test.ts
+++ b/apps/web-app/src/utils/__tests__/workbenchReview.test.ts
@@ -79,6 +79,19 @@ describe('workbenchReview', () => {
     expect(() => parseWorkbenchArtifact(JSON.stringify(stack), 'stack')).toThrow('duplicate IDs');
   });
 
+  it('rejects duplicate JSON properties before their overwritten values disappear', () => {
+    const input = JSON.stringify(validStack());
+    for (const ambiguous of [
+      input.replace('"schemaVersion":2', '"schemaVersion":1,"schemaVersion":2'),
+      input.replace('"version":"15.0.0"', '"version":"1.0.0","version":"15.0.0"'),
+      input.replace('"version":"15.0.0"', String.raw`"ver\u0073ion":"1.0.0","version":"15.0.0"`),
+    ]) expect(() => parseWorkbenchArtifact(ambiguous, 'stack')).toThrow('duplicate JSON property');
+    const stack = validStack();
+    (stack.profile as Record<string, unknown>).goals = ['braces {}, colon : and comma , in strings', 'escaped "quote"'];
+    stack.targets = [{ host: 'codex', scope: 'project' }, { host: 'claude', scope: 'user' }];
+    expect(parseWorkbenchArtifact(JSON.stringify(stack), 'stack').kind).toBe('stack');
+  });
+
   it('rejects the retired v1 policy shape', () => {
     const stack = validStack();
     stack.schemaVersion = 1;

--- a/apps/web-app/src/utils/workbenchReview.ts
+++ b/apps/web-app/src/utils/workbenchReview.ts
@@ -384,6 +384,26 @@ function utf8ByteLength(value: string): number {
   return new TextEncoder().encode(value).byteLength;
 }
 
+// JSON.parse validates syntax but discards duplicate keys. Inspect tokens from
+// valid JSON before projecting fields so a review never hides overwritten data.
+function rejectDuplicateJsonProperties(input: string): void {
+  const scopes: Array<{ keys: Set<string>; expectingKey: boolean } | null> = [];
+  const tokens = input.matchAll(/"(?:[^"\\]|\\.)*"|[{}[\],:]/g);
+  for (const [token] of tokens) {
+    const current = scopes[scopes.length - 1];
+    if (token === '{') scopes.push({ keys: new Set(), expectingKey: true });
+    else if (token === '[') scopes.push(null);
+    else if (token === '}' || token === ']') scopes.pop();
+    else if (token === ',' && current) current.expectingKey = true;
+    else if (token === ':' && current) current.expectingKey = false;
+    else if (token.startsWith('"') && current?.expectingKey) {
+      const key = JSON.parse(token) as string;
+      if (current.keys.has(key)) fail('Artifact contains a duplicate JSON property.');
+      current.keys.add(key);
+    }
+  }
+}
+
 export function parseWorkbenchArtifact(input: string, expectedKind: WorkbenchArtifactKind): ParsedWorkbenchArtifact {
   const byteLength = utf8ByteLength(input);
   if (byteLength === 0) fail('Paste or select a JSON artifact first.');
@@ -395,6 +415,7 @@ export function parseWorkbenchArtifact(input: string, expectedKind: WorkbenchArt
   } catch {
     fail('Artifact is not valid JSON.');
   }
+  rejectDuplicateJsonProperties(input);
   checkDepth(parsed);
   if (expectedKind === 'evidence') {
     if (!validateEvidenceShape(parsed)) fail('Evidence does not match the supported selection-evidence schema.');

--- a/docs/maintainers/deep-input-boundary-audit-2026-09-05.md
+++ b/docs/maintainers/deep-input-boundary-audit-2026-09-05.md
@@ -1,0 +1,31 @@
+# Substantive input-boundary audit — 2026-09-05
+
+Base: `8384acc66138ca3af86758d93edfac2d2a3570ee` (protected main).
+Scope: direct installer destination handling, package archive ingestion, local Core/CLI/MCP boundaries, Workbench imports, catalog navigation and copy behavior, canonical bundled-script syntax, dependency alerts and existing regression suites. No release, npm publication, Pages deployment, telemetry, or real host configuration changes.
+
+## Confirmed defects and corrections
+
+| Defect | Reproduction / consequence | Correction |
+| --- | --- | --- |
+| Archive entry budget omitted directories and PAX/GNU metadata | Three directories passed a limit of two; metadata headers could also bypass the budget, including when no payload was selected. | Count every nonempty header before processing metadata. Keep `fileCount` as the regular-file statistic. |
+| Archive ancestor checks compared raw spelling | Both orders of `package/Foo` and `package/foo/bar` passed, despite colliding on case-insensitive filesystems; Unicode-equivalent parents had the same problem. | Compare normalized ancestor keys, with indexed lookups instead of scanning every earlier entry. |
+| Installer manifest overwrote a hardlink target | Writing the install manifest changed a separate file outside the install directory that shared its inode. | Reject nonregular, linked or oversized manifests; bound reads to 1 MiB and replace a staged private manifest by rename. Failed replacement preserves original bytes and removes staging. |
+| Workbench silently accepted duplicate JSON keys | A duplicated catalog version or schema version was overwritten by `JSON.parse`; CLI strict scanning already rejected the same ambiguity. | Inspect validated JSON tokens before field projection, including escaped-equivalent keys and nested objects. No imported values appear in the error. |
+| Late markdown responses overwrote the current skill | Navigate from a delayed skill to another, then resolve the old request: the new heading displayed old markdown and the copy action used that content. | Retire effect updates on navigation/unmount, including stale failures and fallback requests. Regression checks displayed and copied content. |
+| Copy buttons claimed success before clipboard completion | Rejected clipboard writes were not caught and the buttons switched immediately to “Copied”. | Await completion, show success only after it succeeds, and provide a visible manual-copy message on failure. |
+
+The archive, hardlink, duplicate-key and navigation regressions were observed failing before their fixes. Added failure-preservation checks also cover a refused manifest replacement and oversized manifests. These are concrete bounded regression cases, not fuzzing or an experimental transaction certification.
+
+## Coverage and evidence
+
+- Parse-only inspection of every tracked nonsymlink `.py`, `.sh` and `.js` file under canonical `skills/`: **773 Python, 75 shell, 29 JavaScript; 877 total; no syntax failures**. Python used `compile` without execution or bytecode output; shell used parsing only; JavaScript used syntax checking. No bundled scripts were executed.
+- Structural/usability audit of all 2,113 skills: zero reported warnings, errors or informational findings; warning budget remains 0/0. This is structural evidence, not semantic certification.
+- Dependency audit of root and web lockfiles: zero known vulnerabilities at audit time. GitHub Dependabot, code scanning and secret scanning open-alert counts were each zero.
+- Reviewed the registry updater's pinned npm origin, transfer byte limit and integrity verification; cache resolver identity matching; inert skill-file read limits and containment; MCP strict JSON and CLI import behavior; installer destination staging and pruning; Workbench schema and digest checks; markdown link transformation and asynchronous navigation.
+- Passed: 122 root test groups, 171 Core tests, 221 web tests, web typecheck/build/lint, skill validation, reference validation, docs security and offline catalog integrity. Edge desktop and 390 px mobile checks verified duplicate rejection, valid replacement, clipboard-denial messaging, no page errors and no horizontal overflow. Core coverage includes actual npm-packed runtime installation into a temporary cache and an isolated MCP process, plus real stdio artifact round trips. No user client configuration is changed.
+
+## Limits and remaining work
+
+This is not a semantic certification of all 2,113 skills. Syntax success does not prove API correctness, useful instructions, compatible dependencies, external-provider behavior, or safe execution of every bundled script. Windows filesystem behavior and a real user-host MCP invocation were not manually tested in this pass. Existing supported tests and small deterministic negative cases cover the changed boundaries; experimental apply/recovery remains outside scope.
+
+PR #1337 remains excluded under its existing fork source-safety blocker (`new_unapproved_path`, `new_unknown_extension`); this audit does not bypass that decision. Source fixes require the protected merge gates and do not change the published 16.8.0 package or deployed catalog until a separately authorized release.

--- a/tools/bin/install.js
+++ b/tools/bin/install.js
@@ -13,6 +13,7 @@ const REPO = "https://github.com/sickn33/agentic-awesome-skills.git";
 const NPM_REGISTRY = "https://registry.npmjs.org";
 const HOME = process.env.HOME || process.env.USERPROFILE || "";
 const INSTALL_MANIFEST_FILE = ".antigravity-install-manifest.json";
+const MAX_INSTALL_MANIFEST_BYTES = 1024 * 1024;
 const DEFAULT_RELEASE_REF = packageMetadata.version ? `v${packageMetadata.version}` : null;
 const FULL_GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
 const EXACT_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
@@ -737,6 +738,13 @@ function resolveManagedPath(targetPath, entry) {
 function resolveInstallManifestPath(targetPath) {
   const manifestPath = path.join(targetPath, INSTALL_MANIFEST_FILE);
   assertSafeDestinationPath(manifestPath, targetPath);
+  let stat;
+  try { stat = fs.lstatSync(manifestPath); } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+  if (stat && (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.size > MAX_INSTALL_MANIFEST_BYTES)) {
+    throw new Error(`Refusing unsafe install manifest: ${manifestPath}`);
+  }
   return manifestPath;
 }
 
@@ -747,8 +755,20 @@ function readInstallManifest(targetPath) {
   }
   let fd = null;
   try {
-    fd = fs.openSync(manifestPath, "r");
-    const parsed = JSON.parse(fs.readFileSync(fd, "utf8"));
+    fd = fs.openSync(manifestPath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0));
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || stat.nlink !== 1 || stat.size > MAX_INSTALL_MANIFEST_BYTES) {
+      throw new Error("Unsafe manifest changed while opening");
+    }
+    const bytes = Buffer.alloc(MAX_INSTALL_MANIFEST_BYTES + 1);
+    let length = 0;
+    while (length < bytes.length) {
+      const read = fs.readSync(fd, bytes, length, bytes.length - length, null);
+      if (read === 0) break;
+      length += read;
+    }
+    if (length > MAX_INSTALL_MANIFEST_BYTES) throw new Error("Manifest exceeds the size limit");
+    const parsed = JSON.parse(bytes.subarray(0, length).toString("utf8"));
     if (!parsed || !Array.isArray(parsed.entries)) {
       return [];
     }
@@ -791,11 +811,14 @@ function writeInstallManifest(targetPath, installEntries) {
     null,
     2,
   ) + "\n";
-  const fd = fs.openSync(manifestPath, "w", 0o600);
+  const stageRoot = fs.mkdtempSync(path.join(targetPath, ".antigravity-manifest-"));
+  const stagedManifest = path.join(stageRoot, "manifest.json");
   try {
-    fs.writeFileSync(fd, manifest, "utf8");
+    fs.writeFileSync(stagedManifest, manifest, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    resolveInstallManifestPath(targetPath);
+    fs.renameSync(stagedManifest, manifestPath);
   } finally {
-    fs.closeSync(fd);
+    fs.rmSync(stageRoot, { recursive: true, force: true });
   }
 }
 

--- a/tools/lib/aas-v1/cache/archive.js
+++ b/tools/lib/aas-v1/cache/archive.js
@@ -86,7 +86,9 @@ function parseTar(tarBytes, options = {}) {
   const entries = [];
   const seen = new Map();
   const collisionKeys = new Map();
+  const ancestorKeys = new Set();
   let offset = 0;
+  let entryCount = 0;
   let fileCount = 0;
   let expandedBytes = 0;
   let pendingPath = null;
@@ -100,6 +102,8 @@ function parseTar(tarBytes, options = {}) {
       continue;
     }
     zeroBlocks = 0;
+    entryCount += 1;
+    if (entryCount > limits.maxEntries) throw cacheError("AAS_ARCHIVE_ENTRY_LIMIT", "archive exceeds the entry-count limit");
     const expectedChecksum = parseOctal(header.subarray(148, 156), "checksum");
     let checksum = 0;
     for (let index = 0; index < 512; index += 1) checksum += index >= 148 && index < 156 ? 0x20 : header[index];
@@ -134,19 +138,24 @@ function parseTar(tarBytes, options = {}) {
     if (directory && size !== 0) throw cacheError("AAS_ARCHIVE_HEADER_INVALID", "directory entry has data");
     fileCount += regular ? 1 : 0;
     expandedBytes += regular ? size : 0;
-    if (fileCount > limits.maxEntries) throw cacheError("AAS_ARCHIVE_ENTRY_LIMIT", "archive exceeds the file-count limit");
     if (regular && size > limits.maxSingleFileBytes) throw cacheError("AAS_ARCHIVE_FILE_LIMIT", "archive file exceeds the size limit");
     if (expandedBytes > limits.maxExpandedTotalBytes) throw cacheError("AAS_ARCHIVE_TOTAL_LIMIT", "archive exceeds the expanded-byte limit");
     const kind = directory ? "directory" : "file";
     if (seen.has(archivePath)) throw cacheError("AAS_ARCHIVE_DUPLICATE_PATH", "archive contains a duplicate path");
     const key = collisionKey(archivePath);
     if (collisionKeys.has(key)) throw cacheError("AAS_ARCHIVE_PATH_COLLISION", "archive paths collide by case or Unicode normalization");
-    for (const [existingPath, existingKind] of seen) {
-      if ((archivePath.startsWith(`${existingPath}/`) && existingKind === "file")
-        || (existingPath.startsWith(`${archivePath}/`) && kind === "file")) {
+    const parents = [];
+    for (let slash = key.indexOf("/"); slash !== -1; slash = key.indexOf("/", slash + 1)) {
+      const parent = key.slice(0, slash);
+      parents.push(parent);
+      if (seen.get(collisionKeys.get(parent)) === "file") {
         throw cacheError("AAS_ARCHIVE_FILE_DIRECTORY_COLLISION", "archive file and directory paths collide");
       }
     }
+    if (regular && ancestorKeys.has(key)) {
+      throw cacheError("AAS_ARCHIVE_FILE_DIRECTORY_COLLISION", "archive file and directory paths collide");
+    }
+    for (const parent of parents) ancestorKeys.add(parent);
     seen.set(archivePath, kind);
     collisionKeys.set(key, archivePath);
     if (regular && (!selected || selected.has(archivePath))) entries.push({ path: archivePath, mode, bytes: Buffer.from(body) });

--- a/tools/scripts/tests/aas_v1_archive.test.js
+++ b/tools/scripts/tests/aas_v1_archive.test.js
@@ -41,3 +41,46 @@ test("archive paths reject NTFS streams, device aliases, reserved characters, an
   ]) assert.throws(() => safeArchivePath(value), { code: "AAS_ARCHIVE_PATH_INVALID" });
   assert.equal(safeArchivePath("package/console.txt"), "package/console.txt");
 });
+
+function smallTar(specs) {
+  const blocks = [];
+  for (const { name, type = "0", body = "" } of specs) {
+    const bytes = Buffer.from(body);
+    const header = Buffer.alloc(512);
+    header.write(name, 0, 100, "utf8");
+    header.write("0000644\0", 100, "ascii");
+    header.write(bytes.length.toString(8).padStart(11, "0") + "\0", 124, "ascii");
+    header.fill(0x20, 148, 156);
+    header.write(type, 156, "ascii");
+    const checksum = header.reduce((sum, byte) => sum + byte, 0);
+    header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, "ascii");
+    blocks.push(header, bytes, Buffer.alloc((512 - bytes.length % 512) % 512));
+  }
+  return Buffer.concat([...blocks, Buffer.alloc(1024)]);
+}
+
+test("archive entry budget includes directories and path metadata even when selecting no files", () => {
+  for (const type of ["5", "x", "g", "L"]) {
+    const entries = Array.from({ length: 3 }, (_, index) => ({
+      name: `package/entry-${index}`, type, body: type === "L" ? `package/file-${index}\0` : "",
+    }));
+    // End long-path metadata with a regular file; metadata cannot escape the budget.
+    if (type === "L") entries.push({ name: "package/end", type: "0", body: "" });
+    assert.throws(() => parsePackageArchive(smallTar(entries), { limits: { maxEntries: 2 }, selectPaths: [] }),
+      { code: "AAS_ARCHIVE_ENTRY_LIMIT" });
+  }
+  const exact = smallTar([{ name: "package", type: "5" }, { name: "package/file" }]);
+  assert.equal(parsePackageArchive(exact, { limits: { maxEntries: 2 } }).fileCount, 1);
+});
+
+test("archive ancestor collisions use normalized paths in either entry order", () => {
+  for (const [parent, child] of [["package/Foo", "package/foo/bar"], ["package/café", "package/cafe\u0301/bar"]]) {
+    for (const names of [[parent, child], [child, parent]]) {
+      assert.throws(() => parsePackageArchive(smallTar(names.map((name) => ({ name })))),
+        { code: "AAS_ARCHIVE_FILE_DIRECTORY_COLLISION" });
+    }
+  }
+  assert.doesNotThrow(() => parsePackageArchive(smallTar([
+    { name: "package/a/one" }, { name: "package/a/two" }, { name: "package/a", type: "5" },
+  ])));
+});

--- a/tools/scripts/tests/installer_update_sync.test.js
+++ b/tools/scripts/tests/installer_update_sync.test.js
@@ -31,6 +31,38 @@ function readManifestEntries(targetDir) {
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "installer-update-sync-"));
 
 try {
+  const linkedTarget = path.join(tmpRoot, "hardlink-manifest-target");
+  fs.mkdirSync(linkedTarget);
+  const outsideManifest = path.join(tmpRoot, "outside-manifest.json");
+  const originalManifest = '{"entries":[]}';
+  fs.writeFileSync(outsideManifest, originalManifest);
+  fs.linkSync(outsideManifest, path.join(linkedTarget, ".antigravity-install-manifest.json"));
+  for (const action of [
+    () => installer.readInstallManifest(linkedTarget),
+    () => installer.writeInstallManifest(linkedTarget, ["skill-a"]),
+    () => installer.buildDryRunTargetPlan({ name: "Linked", path: linkedTarget }, ["skill-a"]),
+  ]) assert.throws(action, /unsafe install manifest/i);
+  assert.equal(fs.readFileSync(outsideManifest, "utf8"), originalManifest,
+    "manifest writes must never truncate an external hardlinked file");
+
+  const atomicTarget = path.join(tmpRoot, "atomic-manifest-target");
+  fs.mkdirSync(atomicTarget);
+  installer.writeInstallManifest(atomicTarget, ["original-skill"]);
+  const atomicManifest = path.join(atomicTarget, ".antigravity-install-manifest.json");
+  const beforeFailure = fs.readFileSync(atomicManifest, "utf8");
+  const rename = fs.renameSync;
+  try {
+    fs.renameSync = (source, destination) => {
+      if (destination === atomicManifest) throw new Error("controlled manifest replacement failure");
+      return rename(source, destination);
+    };
+    assert.throws(() => installer.writeInstallManifest(atomicTarget, ["replacement-skill"]), /controlled manifest replacement failure/);
+  } finally { fs.renameSync = rename; }
+  assert.equal(fs.readFileSync(atomicManifest, "utf8"), beforeFailure);
+  assert.deepEqual(fs.readdirSync(atomicTarget), [".antigravity-install-manifest.json"]);
+  fs.writeFileSync(atomicManifest, Buffer.alloc(1024 * 1024 + 1));
+  assert.throws(() => installer.readInstallManifest(atomicTarget), /unsafe install manifest/i);
+
   const repoV1 = path.join(tmpRoot, "repo-v1");
   const repoV2 = path.join(tmpRoot, "repo-v2");
   const targetDir = path.join(tmpRoot, "target");

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -615,3 +615,10 @@
 - Updated the web app lockfile to the newest versions allowed by its existing dependency ranges; npm audit remains at zero vulnerabilities.
 - Rewrote the unsafe-path control-character check to satisfy the stricter linter while preserving rejection behavior, with a regression test for NUL-containing paths.
 - Made the Vitest Vite-config import explicit so the native config-loader compatibility warning is gone.
+
+## 2026-09-05 — Substantive input-boundary audit
+
+- Corrected archive entry accounting and normalized ancestor collision checks, installer manifest hardlink handling and replacement, duplicate Workbench JSON keys, stale skill navigation results, and premature clipboard success.
+- Added reproductions and regression tests; checked the syntax of all 877 tracked Python, shell and JavaScript skill scripts without executing them.
+- Full scope, evidence and limits: [deep input-boundary audit](docs/maintainers/deep-input-boundary-audit-2026-09-05.md).
+- Source maintenance only; no release or deployment.


### PR DESCRIPTION
# Pull Request Description

Correct six confirmed failures at package, filesystem and browser boundaries. Archives now count directory/metadata entries and reject normalized file/ancestor collisions without quadratic scanning. Installer manifests reject hardlinks and oversized/nonregular files and are replaced without truncating the previous file. Workbench rejects duplicate JSON properties. Skill navigation ignores superseded requests, and copy buttons report actual clipboard completion.

The pre-fix reproductions accepted over-budget directories and ambiguous archive paths, overwrote an external hardlinked file, accepted overwritten JSON properties, and displayed an old skill under a new heading. Regression tests cover these cases plus manifest replacement failure and clipboard denial.

Audit details and limitations: `docs/maintainers/deep-input-boundary-audit-2026-09-05.md`. Source maintenance only; no version bump, release, deployment or telemetry.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Validation

- 122 root test groups and 171 Core tests pass, including an actual packed runtime in an isolated temporary cache and real stdio artifact round trips.
- 221 web tests, typecheck, build/prerender and lint pass.
- Skill validation, reference validation, docs security and offline catalog integrity pass. Full structural audit: 2,113 skills, zero warnings/errors/info; frozen warning budget 0/0.
- Parse-only check of all 877 tracked Python/shell/JavaScript skill scripts: no syntax failures. This does not certify their semantics or provider APIs.
- Root/web npm audit and open GitHub Dependabot/code/secret scanning alerts: zero at audit time.
- Edge desktop and 390 px mobile checks: duplicate rejection, valid import replacement, clipboard-denial fallback, no page errors or horizontal overflow.

## Quality Bar Checklist ✅

- [x] **Standards**: Read quality-bar and security-guardrails.
- [x] **Safety scan**: `npm run security:docs` passed.
- [x] **Manual Logic Review**: Reviewed changed runtime/browser behavior, failure paths and bounded reproductions.
- [x] **Local Test**: Relevant full suites and browser checks passed.
- [x] **Repo Checks**: `npm run validate:references` passed.
- [x] **Source-Only PR**: No generated registries, mirrors or marketplaces included.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

Skill metadata/triggers/risk/limitations, Tessl skill-content review and new-source credits/license provenance are not applicable: no canonical skill subtree changes.

## Screenshots (if applicable)

Desktop/mobile screenshots retained with the local audit evidence; the UI layout is unchanged.
