### PR TITLE
docs: embed live Star History chart and rank in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,22 @@ We officially thank the following contributors for their help in making this rep
 
 ## Star History
 
+<a href="https://www.star-history.com/sickn33/agentic-awesome-skills">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/badge?repo=sickn33/agentic-awesome-skills&amp;type=rank&amp;theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/badge?repo=sickn33/agentic-awesome-skills&amp;type=rank" />
+    <img alt="Agentic Awesome Skills global rank on Star History" src="https://api.star-history.com/badge?repo=sickn33/agentic-awesome-skills&amp;type=rank" />
+  </picture>
+</a>
+
+<a href="https://www.star-history.com/?repos=sickn33%2Fagentic-awesome-skills&amp;type=date&amp;legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=sickn33/agentic-awesome-skills&amp;type=date&amp;theme=dark&amp;legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=sickn33/agentic-awesome-skills&amp;type=date&amp;legend=top-left" />
+    <img alt="GitHub star growth over time for Agentic Awesome Skills" src="https://api.star-history.com/chart?repos=sickn33/agentic-awesome-skills&amp;type=date&amp;legend=top-left" />
+  </picture>
+</a>
+
 [View the live Star History chart](https://www.star-history.com/?repos=sickn33%2Fagentic-awesome-skills&type=date&legend=top-left).
 
 If Agentic Awesome Skills has been useful, consider ⭐ starring the repo!

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -661,3 +661,7 @@ The packed preview matrix now includes Windows with PowerShell execution and rea
 ## PowerShell 5.1 and 16.9.0 readiness
 
 The Windows packed verification now repeats the complete installation lifecycle under Windows PowerShell 5.1, alongside PowerShell 7, with version-bound receipts and fail-closed aggregation. The 16.9.0 changelog covers the accumulated agent-owned CLI handoff, MCP fixes and Specialized Plugin refresh. Native Windows app interaction remains outside the observed coverage.
+
+## README Star History embeds
+
+Added the official theme-aware Star History chart and live global-rank badge to the existing [Star History section](README.md#star-history), retaining the direct chart link. Rank is fetched from Star History rather than hardcoded.


### PR DESCRIPTION
# Pull Request Description

Embed the official live Star History chart and global-rank badge in the existing README section. Both support light and dark themes, include descriptive alternative text, and link to Star History. Preserve the direct chart link as a fallback.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Read the quality bar and security guardrails.
- [x] **Repo Checks**: Validation, reference validation, docs security and documentation consistency checks pass.
- [x] **Source-Only PR**: Only README.md and the required walkthrough evidence change.
- [x] **Credits**: Official Star History embeds link to their source.
- [x] **Maintainer Edits**: Maintainer-owned branch.

Skill metadata, risk, triggers, limitations, semantic review and license provenance are not applicable: no skill content changes.

## Validation

All four official SVG URLs return HTTP 200 and SVG content. Documentation consistency: 4 tests pass. Full repository suite: all 125 test groups pass (network integration tests disabled by default).
