### PR TITLE
docs: bring project support forward in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,21 +44,17 @@ This is an independent community project. It is not affiliated with, sponsored b
 
 ## Support the Project
 
-**Help keep AAS free, useful, and actively maintained.** If its skills, plugins, or tools help you ship better work, a small monthly contribution helps sustain the work behind them: reviewing contributions, improving skill content, testing installation workflows, and maintaining releases.
+**We’re looking for sponsors to support Agentic Awesome Skills.** If you or your company would like to support the project, become a sponsor.
 
-**Our recurring funding target is €100 per month** to help cover the AI tools used for that work. Twenty people contributing €5 a month would meet this target. Regular support makes these costs easier to plan for; one-time contributions are welcome too.
+### [♥ Sponsor AAS →](https://github.com/sponsors/sickn33)
 
-### [♥ Support AAS on Buy Me a Coffee →](https://buymeacoffee.com/sickn33)
-
-Choose a monthly contribution if you can. Support is optional: AAS remains free and open-source for everyone.
+You can also [support AAS on Buy Me a Coffee](https://buymeacoffee.com/sickn33).
 
 <a href="https://buymeacoffee.com/sickn33">
   <img src="assets/buy-me-a-coffee-banner.png" alt="Support Agentic Awesome Skills on Buy Me a Coffee" width="420" />
 </a>
 
-You can also help by [reporting reproducible bugs](https://github.com/sickn33/agentic-awesome-skills/issues), [contributing fixes or skills](CONTRIBUTING.md), or sharing AAS with people who would find it useful.
-
-*Tooling support: [Snyk](https://snyk.io/) provides security tooling. This is separate from the recurring funding target above.*
+*Security tooling support: [Snyk](https://snyk.io/).*
 
 ## AAS Core: Agent-First Preview
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ This is an independent community project. It is not affiliated with, sponsored b
 [![OpenCode](https://img.shields.io/badge/OpenCode-CLI-gray?style=for-the-badge)](https://github.com/opencode-ai/opencode)
 [![Antigravity](https://img.shields.io/badge/Antigravity-AI%20IDE-red?style=for-the-badge)](https://github.com/sickn33/agentic-awesome-skills)
 
+## Support the Project
+
+**Help keep AAS free, useful, and actively maintained.** If its skills, plugins, or tools help you ship better work, a small monthly contribution helps sustain the work behind them: reviewing contributions, improving skill content, testing installation workflows, and maintaining releases.
+
+**Our recurring funding target is €100 per month** to help cover the AI tools used for that work. Twenty people contributing €5 a month would meet this target. Regular support makes these costs easier to plan for; one-time contributions are welcome too.
+
+### [♥ Support AAS on Buy Me a Coffee →](https://buymeacoffee.com/sickn33)
+
+Choose a monthly contribution if you can. Support is optional: AAS remains free and open-source for everyone.
+
+<a href="https://buymeacoffee.com/sickn33">
+  <img src="assets/buy-me-a-coffee-banner.png" alt="Support Agentic Awesome Skills on Buy Me a Coffee" width="420" />
+</a>
+
+You can also help by [reporting reproducible bugs](https://github.com/sickn33/agentic-awesome-skills/issues), [contributing fixes or skills](CONTRIBUTING.md), or sharing AAS with people who would find it useful.
+
+*Tooling support: [Snyk](https://snyk.io/) provides security tooling. This is separate from the recurring funding target above.*
+
 ## AAS Core: Agent-First Preview
 
 > **The agent composes. You control. AAS keeps the stack reproducible.**
@@ -89,6 +107,7 @@ Direct file search can find candidate prose, but it leaves the result in the con
 
 ## Table of Contents
 
+- [Support the Project](#support-the-project)
 - [AAS Core: Agent-First Preview](#aas-core-agent-first-preview)
 - [Why This Repo](#why-this-repo)
 - [Installation](#installation)
@@ -99,7 +118,6 @@ Direct file search can find candidate prose, but it leaves the result in the con
 - [Browse 2,113+ Skills](#browse-2113-skills)
 - [Troubleshooting](#troubleshooting)
 - [Stable Skills Manifest v1](#stable-skills-manifest-v1)
-- [Support the Project](#support-the-project)
 - [Contributing](#contributing)
 - [Community](#community)
 - [Credits & Sources](#credits--sources)
@@ -418,22 +436,6 @@ Host integrations should use:
 - [`data/skills_index.json`](./data/skills_index.json) as the compatibility mirror.
 
 This keeps discovery stable (`id`, `path`, metadata) while ensuring hosts only load `SKILL.md` for requested `@skill-id` values.
-
-## Support the Project
-
-The immediate goal is **€100 per month** to help cover the AI tools used to maintain AAS, review contributions, and keep releases moving. Small recurring contributions add up: 20 people giving €5 per month would cover that goal.
-
-[Support AAS on Buy Me a Coffee](https://buymeacoffee.com/sickn33) and select **Make this monthly** for recurring support. One-time contributions are welcome too. Support is optional; the project stays free and open-source for everyone.
-
-[![Buy me a coffee](assets/buy-me-a-coffee-banner.png)](https://buymeacoffee.com/sickn33)
-
-- [Help maintain AAS on Buy Me a Coffee](https://buymeacoffee.com/sickn33)
-- Security tooling support: [Snyk](https://snyk.io/)
-- Star the repository
-- Open reproducible issues
-- Contribute docs, fixes, and skills
-
----
 
 ## Contributing
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -668,4 +668,4 @@ Added the official theme-aware Star History chart and live global-rank badge to 
 
 ## README project support
 
-Moved [Support the Project](README.md#support-the-project) directly below the opening badges, with a prominent contribution link and a compact banner. Reframed the existing €100/month target around recurring maintenance costs, explained the work it supports, and distinguished Snyk tooling support from cash contributions.
+Moved [Support the Project](README.md#support-the-project) directly below the opening badges. Added a concise invitation for sponsors, with GitHub Sponsors and Buy Me a Coffee links, a compact banner, and the existing Snyk tooling attribution. Removed monetary targets and contribution calculations.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -665,3 +665,7 @@ The Windows packed verification now repeats the complete installation lifecycle 
 ## README Star History embeds
 
 Added the official theme-aware Star History chart and live global-rank badge to the existing [Star History section](README.md#star-history), retaining the direct chart link. Rank is fetched from Star History rather than hardcoded.
+
+## README project support
+
+Moved [Support the Project](README.md#support-the-project) directly below the opening badges, with a prominent contribution link and a compact banner. Reframed the existing €100/month target around recurring maintenance costs, explained the work it supports, and distinguished Snyk tooling support from cash contributions.


### PR DESCRIPTION
# Pull Request Description

Move project support immediately below the opening badges, with a concise invitation for sponsors. Link GitHub Sponsors and Buy Me a Coffee, keep the banner compact and retain the Snyk tooling attribution. Remove monetary targets and contribution calculations.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Read the quality bar and security guardrails.
- [x] **Repo Checks**: Validation, reference validation, docs security, documentation consistency and repository consistency checks pass.
- [x] **Source-Only PR**: README and walkthrough only; no generated registry changes.
- [x] **Credits**: Existing support provider attribution retained.
- [x] **Maintainer Edits**: Maintainer-owned branch.

Skill metadata, risk, triggers, limitations, semantic review and license provenance are not applicable: no skill content changes.

## Validation

Documentation consistency: 4 tests pass. Existing support URLs and banner retained. Full repository test suite completed before merge.
