### PR TITLE
fix: remediate meaningful Snyk file safety findings

### DIFF
--- a/skills/find-complementary-founders/scripts/assess_profile.py
+++ b/skills/find-complementary-founders/scripts/assess_profile.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import sys
+import stat
 from collections import defaultdict
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -395,9 +396,14 @@ def write_json(path: Path, data: dict, *, private: bool) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.is_symlink():
         raise ProfileError(f"Refusing to write through symlink: {path}")
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    flags = os.O_WRONLY | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_NONBLOCK", 0)
     fd = os.open(path, flags, 0o600 if private else 0o644)
     with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        file_stat = os.fstat(handle.fileno())
+        if not stat.S_ISREG(file_stat.st_mode) or file_stat.st_nlink != 1:
+            raise ProfileError(f"Refusing to write non-regular or multiply linked file: {path}")
+        os.ftruncate(handle.fileno(), 0)
         os.fchmod(handle.fileno(), 0o600 if private else 0o644)
         json.dump(data, handle, indent=2, ensure_ascii=False, sort_keys=True)
         handle.write("\n")

--- a/skills/instagram/scripts/config.py
+++ b/skills/instagram/scripts/config.py
@@ -7,6 +7,7 @@ Importado por todos os outros scripts.
 from __future__ import annotations
 
 import os
+import stat
 import shutil
 from pathlib import Path
 from typing import Any, Dict
@@ -23,6 +24,35 @@ EXPORTS_DIR = DATA_DIR / "exports"
 STATIC_DIR = ROOT_DIR / "static"
 DB_PATH = DATA_DIR / "instagram.db"
 
+def protect_state_path(path, *, directory=False):
+    """Repair only owned state paths; never follow links or mutate hard links."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    if path.is_symlink():
+        raise OSError(f"Refusing linked state path: {path}")
+    if directory:
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # Windows does not support opening directories this way; privacy there
+        # is governed by the user profile ACL, not POSIX permission bits.
+        if os.name == "nt":
+            path.chmod(0o700)
+            return
+        flags |= getattr(os, "O_DIRECTORY", 0)
+    elif not path.exists():
+        return
+    fd = os.open(path, flags)
+    try:
+        info = os.fstat(fd)
+        valid = stat.S_ISDIR(info.st_mode) if directory else stat.S_ISREG(info.st_mode) and info.st_nlink == 1
+        if not valid:
+            raise OSError(f"Refusing unsafe state path: {path}")
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o700 if directory else 0o600)
+        else:
+            os.chmod(path, 0o600)
+    finally:
+        os.close(fd)
+
+
 # Tokens and app secrets are stored in the SQLite database. Keep every newly
 # created database, journal, and sidecar private, and migrate legacy state once.
 os.umask(0o077)
@@ -30,14 +60,9 @@ if LEGACY_DATA_DIR.exists() and LEGACY_DATA_DIR != DATA_DIR and not DATA_DIR.exi
     DATA_DIR.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     shutil.move(str(LEGACY_DATA_DIR), str(DATA_DIR))
     print(f"AVISO: dados sensiveis do Instagram migrados para {DATA_DIR}")
-for directory in (DATA_DIR.parent.parent, DATA_DIR.parent, DATA_DIR, EXPORTS_DIR):
-    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-    try:
-        directory.chmod(0o700)
-    except OSError:
-        pass
-if DB_PATH.exists() and not DB_PATH.is_symlink():
-    DB_PATH.chmod(0o600)
+for directory in (DATA_DIR, EXPORTS_DIR):
+    protect_state_path(directory, directory=True)
+protect_state_path(DB_PATH)
 
 # ── Instagram Graph API ───────────────────────────────────────────────────────
 API_VERSION = "v21.0"

--- a/skills/junta-leiloeiros/scripts/.snyk
+++ b/skills/junta-leiloeiros/scripts/.snyk
@@ -1,0 +1,5 @@
+# Match the supported interpreter used to verify these requirements.
+# Scoped to this manifest; does not change organization-wide settings.
+version: v1.25.1
+language-settings:
+  python: '3.14'

--- a/skills/lint-and-validate/scripts/type_coverage.py
+++ b/skills/lint-and-validate/scripts/type_coverage.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import re
 import sys
+import stat
 
 MAX_FILES = 30
 MAX_BYTES = 1_000_000
@@ -31,7 +32,11 @@ def inventory(project_path, language):
             result['truncated'] = True
             break
         try:
-            with path.open('rb') as handle:
+            flags = os.O_RDONLY | getattr(os, 'O_NOFOLLOW', 0) | getattr(os, 'O_NONBLOCK', 0)
+            fd = os.open(path, flags)
+            with os.fdopen(fd, 'rb') as handle:
+                if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                    raise ValueError('source is not a regular file')
                 raw = handle.read(MAX_BYTES + 1)
             if len(raw) > MAX_BYTES:
                 raise ValueError('source exceeds byte limit')

--- a/skills/notebooklm/scripts/config.py
+++ b/skills/notebooklm/scripts/config.py
@@ -4,6 +4,7 @@ Centralizes constants, selectors, and paths
 """
 
 import os
+import stat
 from pathlib import Path
 
 # Paths
@@ -19,6 +20,35 @@ STATE_FILE = BROWSER_STATE_DIR / "state.json"
 AUTH_INFO_FILE = DATA_DIR / "auth_info.json"
 LIBRARY_FILE = DATA_DIR / "library.json"
 
+def protect_state_path(path, *, directory=False):
+    """Repair only owned state paths; never follow links or mutate hard links."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    if path.is_symlink():
+        raise OSError(f"Refusing linked state path: {path}")
+    if directory:
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # Windows does not support opening directories this way; privacy there
+        # is governed by the user profile ACL, not POSIX permission bits.
+        if os.name == "nt":
+            path.chmod(0o700)
+            return
+        flags |= getattr(os, "O_DIRECTORY", 0)
+    elif not path.exists():
+        return
+    fd = os.open(path, flags)
+    try:
+        info = os.fstat(fd)
+        valid = stat.S_ISDIR(info.st_mode) if directory else stat.S_ISREG(info.st_mode) and info.st_nlink == 1
+        if not valid:
+            raise OSError(f"Refusing unsafe state path: {path}")
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o700 if directory else 0o600)
+        else:
+            os.chmod(path, 0o600)
+    finally:
+        os.close(fd)
+
+
 # Browser profiles and storage-state files contain live Google credentials.
 # A restrictive umask also covers files created later by Chromium.
 os.umask(0o077)
@@ -31,18 +61,10 @@ def ensure_private_state():
         DATA_DIR.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         shutil.move(str(LEGACY_DATA_DIR), str(DATA_DIR))
         print(f"⚠️ Migrated sensitive NotebookLM state to private user storage: {DATA_DIR}")
-    for directory in (DATA_DIR.parent.parent, DATA_DIR.parent, DATA_DIR, BROWSER_STATE_DIR, BROWSER_PROFILE_DIR):
-        directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-        try:
-            directory.chmod(0o700)
-        except OSError:
-            pass
+    for directory in (DATA_DIR, BROWSER_STATE_DIR, BROWSER_PROFILE_DIR):
+        protect_state_path(directory, directory=True)
     for file_path in (STATE_FILE, AUTH_INFO_FILE, LIBRARY_FILE):
-        if file_path.exists() and not file_path.is_symlink():
-            try:
-                file_path.chmod(0o600)
-            except OSError:
-                pass
+        protect_state_path(file_path)
 
 # NotebookLM Selectors
 QUERY_INPUT_SELECTORS = [

--- a/skills/slack-gif-creator/.snyk
+++ b/skills/slack-gif-creator/.snyk
@@ -1,0 +1,5 @@
+# Match the supported interpreter used to verify these requirements.
+# Scoped to this manifest; does not change organization-wide settings.
+version: v1.25.1
+language-settings:
+  python: '3.14'

--- a/skills/videodb/scripts/ws_listener.py
+++ b/skills/videodb/scripts/ws_listener.py
@@ -124,7 +124,8 @@ def secure_open(path: Path, *, append: bool):
     """Open a regular file without following symlinks."""
     ensure_output_dir()
     flags = os.O_WRONLY | os.O_CREAT
-    flags |= os.O_APPEND if append else os.O_TRUNC
+    flags |= os.O_APPEND if append else 0
+    flags |= getattr(os, "O_NONBLOCK", 0)
     flags |= getattr(os, "O_NOFOLLOW", 0)
 
     fd = os.open(safe_output_path(path), flags, FILE_MODE)
@@ -134,6 +135,12 @@ def secure_open(path: Path, *, append: bool):
             raise OSError(f"Refusing to write non-regular file: {path}")
         if file_stat.st_nlink != 1:
             raise OSError(f"Refusing to write multiply linked file: {path}")
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, FILE_MODE)
+        else:
+            os.chmod(path, FILE_MODE)
+        if not append:
+            os.ftruncate(fd, 0)
         return fd
     except Exception:
         os.close(fd)

--- a/tools/scripts/tests/test_snyk_file_boundaries.py
+++ b/tools/scripts/tests/test_snyk_file_boundaries.py
@@ -1,0 +1,120 @@
+"""Regression proofs for local file findings reviewed from Snyk."""
+import os
+import json
+import subprocess
+import sys
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from symlink_test_utils import symlink_or_skip
+from test_secur0_remediations import load_module
+from test_ws_listener_security import load_module as load_listener
+
+
+class FileBoundaryTests(unittest.TestCase):
+    def test_listener_rejects_hardlink_before_truncating(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            module = load_listener('snyk_listener', root)
+            module.OUTPUT_DIR.mkdir(parents=True)
+            outside = root / 'outside'
+            outside.write_text('preserve me')
+            os.link(outside, module.PID_FILE)
+            with self.assertRaises(OSError):
+                module.secure_write_text(module.PID_FILE, 'new')
+            self.assertEqual(outside.read_text(), 'preserve me')
+
+    def test_listener_repairs_existing_permissions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            module = load_listener('snyk_listener_modes', Path(tmp))
+            module.OUTPUT_DIR.mkdir(parents=True)
+            module.EVENTS_FILE.write_text('old\n')
+            module.EVENTS_FILE.chmod(0o644)
+            module.secure_append_text(module.EVENTS_FILE, 'new\n')
+            self.assertEqual(stat.S_IMODE(module.EVENTS_FILE.stat().st_mode), 0o600)
+            self.assertEqual(module.EVENTS_FILE.read_text(), 'old\nnew\n')
+
+    def test_profile_rejects_hardlink_before_mutation(self):
+        module = load_module('snyk_profile', 'skills/find-complementary-founders/scripts/assess_profile.py')
+        with tempfile.TemporaryDirectory() as tmp:
+            outside = Path(tmp) / 'outside'
+            outside.write_text('preserve me')
+            outside.chmod(0o644)
+            output = Path(tmp) / 'result.private.json'
+            os.link(outside, output)
+            with self.assertRaises((OSError, module.ProfileError)):
+                module.write_json(output, {'secret': 'test'}, private=True)
+            self.assertEqual(outside.read_text(), 'preserve me')
+            self.assertEqual(stat.S_IMODE(outside.stat().st_mode), 0o644)
+
+    @unittest.skipUnless(hasattr(os, 'mkfifo'), 'POSIX named pipes required')
+    def test_inventory_rejects_fifo_without_waiting_for_writer(self):
+        module = load_module('snyk_inventory', 'skills/lint-and-validate/scripts/type_coverage.py')
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            os.mkfifo(root / 'pipe.py')
+            run = subprocess.run([sys.executable, module.__file__, str(root)], capture_output=True, text=True, timeout=5)
+            self.assertEqual(run.returncode, 1)
+            result = json.loads(run.stdout)['results'][0]
+            self.assertEqual(result['files'], 0)
+            self.assertEqual(result['errors'][0]['error'], 'source is not a regular file')
+
+    def test_state_links_are_rejected_without_changing_target(self):
+        for skill in ('instagram', 'notebooklm'):
+            with self.subTest(skill=skill), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                old_umask = os.umask(0o077)
+                try:
+                    with patch.dict(os.environ, {f'AAS_{skill.upper()}_DATA_DIR': str(root / skill)}):
+                        module = load_module(f'snyk_links_{skill}', f'skills/{skill}/scripts/config.py')
+                        if skill == 'notebooklm':
+                            module.ensure_private_state()
+                    outside = root / 'outside'
+                    outside.write_text('preserve me')
+                    outside.chmod(0o644)
+                    linked = module.DATA_DIR / 'linked'
+                    symlink_or_skip(self, outside, linked)
+                    with self.assertRaises(OSError):
+                        module.protect_state_path(linked)
+                    linked.unlink()
+                    os.link(outside, linked)
+                    with self.assertRaises(OSError):
+                        module.protect_state_path(linked)
+                    self.assertEqual(stat.S_IMODE(outside.stat().st_mode), 0o644)
+                    self.assertEqual(outside.read_text(), 'preserve me')
+                    external_dir = root / 'external'
+                    external_dir.mkdir(mode=0o755)
+                    external_dir.chmod(0o755)
+                    linked_dir = module.DATA_DIR / 'linked_dir'
+                    symlink_or_skip(self, external_dir, linked_dir)
+                    with self.assertRaises(OSError):
+                        module.protect_state_path(linked_dir, directory=True)
+                    self.assertEqual(stat.S_IMODE(external_dir.stat().st_mode), 0o755)
+                finally:
+                    os.umask(old_umask)
+
+    def test_state_initialization_preserves_parent_permissions(self):
+        for skill in ('instagram', 'notebooklm'):
+            with self.subTest(skill=skill), tempfile.TemporaryDirectory() as tmp:
+                parent = Path(tmp) / 'shared' / 'apps'
+                parent.mkdir(parents=True)
+                parent.chmod(0o755)
+                parent.parent.chmod(0o755)
+                old_umask = os.umask(0o077)
+                try:
+                    with patch.dict(os.environ, {f'AAS_{skill.upper()}_DATA_DIR': str(parent / skill)}):
+                        module = load_module(f'snyk_{skill}', f'skills/{skill}/scripts/config.py')
+                        if skill == 'notebooklm':
+                            module.ensure_private_state()
+                    self.assertEqual(stat.S_IMODE(parent.stat().st_mode), 0o755)
+                    self.assertEqual(stat.S_IMODE(parent.parent.stat().st_mode), 0o755)
+                    self.assertEqual(stat.S_IMODE(module.DATA_DIR.stat().st_mode), 0o700)
+                finally:
+                    os.umask(old_umask)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,13 @@
+# Snyk contextual file-safety remediation — 2026-09-06
+
+- Reproduced destructive hard-link writes in VideoDB and founder-profile export, incorrect parent-directory chmod in Instagram/NotebookLM, and insecure existing VideoDB file modes before fixing them.
+- Validate opened regular-file descriptors and link counts before truncation; preserve append content, repair private modes, and open nonblocking to reject named pipes safely.
+- Restrict state permission repair to the configured private tree, reject linked state files/directories, and propagate protection failures.
+- Reject non-regular source files in the bounded annotation inventory so a named pipe cannot stall a scan.
+- Added `tools/scripts/tests/test_snyk_file_boundaries.py` regression coverage. No new Snyk exclusions or ignore rules.
+- Reviewed the 29 canonical-source Snyk Code results: the remaining DOM anchor uses the active document URL with React escaping; the local viewer returns request-derived metadata as JSON; three secret findings are deliberate test canaries; PostgreSQL accepts whole SQL and database configuration from its local operator and sets a read-only session. Other remaining path findings accept operator-selected local paths rather than remote names. These contextual dispositions do not claim a scanner count of zero or a comprehensive audit of all bundled integrations.
+- Earlier dependency fixes (#1401, canonical #1402) raised Pillow to 12.3.0 and SoupSieve to 2.8.4. The two live EU CLI dependency scans found no security vulnerabilities; certifi's MPL-2.0 license-policy warning requires a license decision, not a dependency downgrade. Added manifest-local `.snyk` Python 3.14 settings for these two projects, matching the interpreter used in the successful scans, so SCM retests do not inherit the obsolete organization-wide Python 3.7 default. The organization setting is unchanged.
+
 # Discovery and installation handoff follow-up - 2026-09-05
 
 - Fixed explicit English/Italian exclusions and grouped declared compatibility aliases while preserving explicit ID selection.


### PR DESCRIPTION
# Pull Request Description

Fix reproducible local-file hazards found while triaging Snyk: VideoDB truncated hard-linked files before rejecting them and retained public file modes; profile export overwrote hard links; Instagram and NotebookLM chmodded shared parent directories. Validate opened files before mutation, reject linked state paths, and restrict permission repair to owned state. The annotation inventory now rejects named pipes without blocking.

Add manifest-local Python 3.14 Snyk settings for the two dependency projects already verified on that interpreter. This avoids the obsolete organization Python 3.7 default without changing other projects. No ignore rules or exclusions were added.

Validation: negative cases reproduced before fixes; six dedicated regressions pass, existing file/state tests pass, validation chain, references, docs security and zero-warning budget pass. The complete 126-file suite passed on the final changes, as did two catalog-page test files (four tests). Final live EU Snyk Code reports 37 contextual results (2 high, 2 medium, 33 low), including additional low findings through Windows compatibility paths; this is not a claim of zero scanner findings. Both affected SCM projects were retested successfully on Python 3.14: Pillow has zero issues; Junta has zero security vulnerabilities and one certifi MPL-2.0 license-policy warning. See walkthrough.md for disposition and dependency-scan limitations.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Existing safety conventions preserved.
- [x] **Metadata**: Existing frontmatter validates.
- [x] **Risk Label**: Existing declarations reviewed; unchanged.
- [x] **Triggers**: Existing triggers unchanged.
- [x] **Limitations**: Existing limitations retained; POSIX privacy and Windows ACL distinction documented in implementation.
- [x] **Security**: No offensive workflow added.
- [x] **Safety scan**: `npm run security:docs` passed.
- [x] **Automated Skill Review**: Workflow completed with `manual-review-required`; `review` was skipped. Maintainer semantic attestation was bound to `203471d3fff5988eaf5364656b52a3c1f28a0cda` through the protected merge command. This is not Tessl approval.
- [x] **Manual Logic Review**: File lifecycle, failure modes and dependency scan scope reviewed.
- [x] **Local Test**: Dedicated regressions and existing tests passed.
- [x] **Repo Checks**: Validation, references and warning-budget checks passed.
- [x] **Source-Only PR**: Generated state reserved for canonical synchronization.
- [x] **Credits**: No new external source.
- [x] **License provenance**: Existing provenance unchanged.
- [x] **Maintainer Edits**: Owner-authored topic branch.
