### PR TITLE
Add VibeAudit to AAS Core: Agent-First Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ AAS Core gives the repository one product model:
 - **Validate and preview through the CLI.** `aas stack validate` checks the proposal, while `aas stack plan` produces an immutable, per-target plan without applying it.
 - **Review in Workbench.** The hosted Workbench imports and reviews stack/plan JSON in browser memory; it does not access your filesystem or install anything.
 - **Retain every useful distribution path.** Direct installs, plugins, bundles, workflows, and the full catalog remain available as payload and compatibility surfaces.
+- [VibeAudit](https://vibeaudit.sh/) - Pre-launch security audit for AI-built apps: reads the whole repo and returns findings with file:line and a paste-ready fix prompt each. Free quick scan.
 
 > [!IMPORTANT]
 > Structural and identity validity does not certify semantic fit, compatibility, setup correctness, operational safety, or safety to apply.


### PR DESCRIPTION
Adds VibeAudit under "AAS Core: Agent-First Preview": a pre-launch audit for apps built with AI coding tools. It reads the whole repository and reports security/billing/auth issues with file:line and a fix prompt for Cursor/Claude Code. Free quick scan, no signup; paid deep audit.

Disclosure: I'm the author. Public audits of popular starters for reference: https://vibeaudit.sh/audits — happy to adjust wording or placement.