### PR TITLE
docs: publish funding transparency and preserve About disclosure

### DIFF
--- a/.github/MAINTENANCE.md
+++ b/.github/MAINTENANCE.md
@@ -128,6 +128,12 @@ Before ANY commit that adds/modifies skills, run the chain:
     npm run sync:github-about
     npm run audit:consistency:github
     ```
+    The approved GitHub About text is rendered by `build_about_description` in
+    `tools/scripts/sync_repo_metadata.py`. Preserve the community-token mint, fee
+    disclosure and trading non-endorsement alongside the software description;
+    keep it aligned with [Funding & transparency](../docs/users/funding-transparency.md)
+    and within 350 characters. Publish the linked page before applying the About.
+
     For a read-only summary of current repo health, run:
     ```bash
     npm run audit:maintainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- Publish [Funding & transparency](docs/users/funding-transparency.md), linked from
+  the README support section and documentation index, with the community-token
+  mint, maintainer fee receipt and trading non-endorsement. Keep the approved
+  GitHub About wording in metadata synchronization so maintenance preserves it.
+
 ## [17.0.0] - 2026-09-08 - "Evidence, Portable Bundles, and Grounded Profiles"
 
 A skill-library release for Claude Code, Cursor, Codex CLI and Gemini CLI,

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ This is an independent community project. It is not affiliated with, sponsored b
 
 You can also [support AAS on Buy Me a Coffee](https://buymeacoffee.com/sickn33).
 
+Read [Funding & transparency](docs/users/funding-transparency.md) for details on the community-managed token and fees received by the maintainer.
+
 <a href="https://buymeacoffee.com/sickn33">
   <img src="assets/buy-me-a-coffee-banner.png" alt="Support Agentic Awesome Skills on Buy Me a Coffee" width="420" />
 </a>

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ Current operational guidance lives in `users/`, `contributors/`, and the current
 
 ## Users
 
+- [Funding & transparency](users/funding-transparency.md) — community-managed token, maintainer fees, and other ways to support the project
+
 - [`users/aas-core.md`](users/aas-core.md) — canonical AAS Core preview guide
 - [`users/getting-started.md`](users/getting-started.md)
 - [`users/usage.md`](users/usage.md)

--- a/docs/users/funding-transparency.md
+++ b/docs/users/funding-transparency.md
@@ -1,0 +1,17 @@
+# Funding & transparency
+
+A token associated with Agentic Awesome Skills on Solana was created and is managed by members of the community. They allocated a share of its creator fees to me, Nick (`sickn33`), through Pump.fun.
+
+I personally receive income from these fees. They support my work maintaining and developing the project, and I am grateful for that support.
+
+**Token mint address (Solana):**
+
+`3PoVcc3rDcp5HC3C92Sx6WguMDqGzpK6RtbF9tR8pump`
+
+I do not endorse, promote, or encourage buying or selling the token. It is mentioned here to disclose the fee arrangement, not as a recommendation to buy, sell, or hold it. Buying it is a speculative transaction, not a direct donation to project development. It may lose all of its value, and I make no promises about its price, liquidity, or financial returns.
+
+The token is not required to use or contribute to AAS. Holding it gives no ownership of the project, rights to its income, governance rights, or priority for features and support. Maintenance and development priorities remain independent of its market performance.
+
+This disclosure covers this specific token. A matching name or logo does not identify another token as part of this arrangement.
+
+To support the project directly, use [GitHub Sponsors](https://github.com/sponsors/sickn33) or [Buy Me a Coffee](https://buymeacoffee.com/sickn33). Code contributions, documentation improvements, and issue reports are also welcome; see the [contribution guide](../../CONTRIBUTING.md).

--- a/skills/antigravity-maintainer-batch-release/SKILL.md
+++ b/skills/antigravity-maintainer-batch-release/SKILL.md
@@ -106,6 +106,13 @@ When changing maintainer scripts, workflows, or policy, update the canonical ski
 
 When auditing repository documentation, compare operational guides and translations with exact-base scripts and workflow behavior. Check local links, heading anchors and documented npm commands with `tools/scripts/tests/test_documentation_consistency.py`; dated evidence and backup snapshots are historical, not current instructions. Keep canonical guides discoverable from `docs/README.md`, distinguish source merge from release availability, and report the scope of the audit without claiming that all skill procedures or external integrations ran.
 
+When synchronizing GitHub About, preserve the approved funding disclosure from
+`build_about_description` in `tools/scripts/sync_repo_metadata.py`: the software
+description, community-token mint, fee receipt and trading non-endorsement must
+fit within 350 characters. Keep the README disclosure link and
+`docs/users/funding-transparency.md` aligned, publish the page first, then apply
+`npm run sync:github-about` and verify `npm run audit:consistency:github`.
+
 ## Specialized Plugin Consistency
 
 Use `data/specialized-plugin-candidates.json` for specialized-plugin membership and `data/editorial-bundles.json` for the installable composition, descriptions, limits and starter prompts. Review changes against canonical `skills_index.json`; keep IDs stable unless a migration is explicitly requested. Derive the web catalog and prerender/live-verifier counts from these sources instead of maintaining copied lists or fixed counts. Verify full skill-list expansion, source-to-web parity and a negative stale-count case. The specialized-resource regression must reject missing prose-declared local support paths and verify their bytes in generated specialized bundles; fenced application examples remain a separate semantic review. Run the pure-example regressions when editing documented calculations or chunking behavior. Regenerate plugin artifacts as evidence, but leave their commit to the protected canonical-sync lane. A source refresh does not authorize release or deployment.

--- a/tools/scripts/sync_repo_metadata.py
+++ b/tools/scripts/sync_repo_metadata.py
@@ -93,10 +93,13 @@ BUNDLES_FOOTER_RE = re.compile(
 
 
 def build_about_description(metadata: dict) -> str:
+    # Keep this approved disclosure aligned with docs/users/funding-transparency.md.
     return (
-        "AAS Core is the local, agent-first control plane for complete catalog discovery, agent-owned selection, "
-        f"stack validation, and planning, backed by {metadata['total_skills_label']} agentic skills. "
-        "Includes CLI, local MCP, catalog, plugins, and Workbench."
+        "AAS Core: local skill discovery, agent-owned selection and stack planning. "
+        "CLI, MCP, plugins and Workbench. Community-managed token: "
+        "3PoVcc3rDcp5HC3C92Sx6WguMDqGzpK6RtbF9tR8pump · "
+        "Maintainer receives fees; does not endorse trading — "
+        "see Funding & transparency in README."
     )
 
 

--- a/tools/scripts/tests/test_sync_repo_metadata.py
+++ b/tools/scripts/tests/test_sync_repo_metadata.py
@@ -172,15 +172,21 @@ The 1,273+ reusable `SKILL.md` playbooks, specialized plugins, bundles, workflow
             self.assertIn("1,304+ skill", jetski_cortex)
             self.assertNotIn("1,1", jetski_cortex)
 
-    def test_build_about_description_uses_live_skill_count(self):
-        description = sync_repo_metadata.build_about_description(
-            {
-                "total_skills_label": "1,304+",
-            }
-        )
-        self.assertIn("AAS Core is the local, agent-first control plane", description)
-        self.assertIn("1,304+ agentic skills", description)
-        self.assertIn("local MCP", description)
+    def test_about_preserves_approved_funding_disclosure(self):
+        description = sync_repo_metadata.build_about_description({"total_skills_label": "1,304+"})
+        self.assertLessEqual(len(description), 350)
+        self.assertIn("AAS Core: local skill discovery", description)
+        self.assertIn("CLI, MCP, plugins and Workbench", description)
+        self.assertIn("Maintainer receives fees; does not endorse trading", description)
+        self.assertIn("see Funding & transparency in README", description)
+        mint = "3PoVcc3rDcp5HC3C92Sx6WguMDqGzpK6RtbF9tR8pump"
+        self.assertIn(mint, description)
+        root = Path(__file__).resolve().parents[3]
+        page = (root / "docs/users/funding-transparency.md").read_text()
+        self.assertIn(f"`{mint}`", page)
+        self.assertIn("docs/users/funding-transparency.md", (root / "README.md").read_text())
+        # A later catalog-count refresh must not erase the approved disclosure.
+        self.assertEqual(description, sync_repo_metadata.build_about_description({"total_skills_label": "9,999+"}))
 
     def test_core_release_capability_is_major_based_and_fail_closed(self):
         self.assertEqual(


### PR DESCRIPTION
# Pull Request Description

Publish the maintainer-approved Funding & transparency page and link it from the README support section and documentation index. The page identifies the community-managed token, discloses creator-fee income, rejects trading endorsement and explains that token ownership grants no project rights.

Keep the approved 270-character About description in the existing metadata synchronizer so later maintenance retains the mint and disclosure. Update its regression, maintainer guide and canonical workflow skill together. The linked page must be available on main before the About is applied.

## Change Classification

- [x] Skill PR — canonical maintainer workflow note
- [x] Docs PR
- [x] Infra PR — About metadata text and regression

## Issue Link (Optional)

Not applicable.

## Quality Bar Checklist ✅

- [x] Standards: contributor quality bar and security guardrails reviewed.
- [x] Metadata, risk, triggers and limitations: existing maintainer skill contract preserved; validation passed.
- [x] Safety scan: documentation security and reference checks passed.
- [x] Manual Logic Review: complete changed maintainer skill reviewed; publication sequence and authorization boundary preserved.
- [x] Local Test: full repository suite, metadata regression and documentation consistency checks passed.
- [x] Repo Checks: validation chain and warning budget passed; About dry run matched approved wording.
- [x] Source-Only PR: generated catalog and plugin mirrors excluded; protected canonical sync owns them.
- [x] Credits and license provenance: no externally imported skill or code.
- [x] Maintainer Edits: repository-owner branch.

Automated Skill Review: inspect its truthful result on the exact PR head before guarded merge; any manual-review-required outcome needs that exact-head attestation.

## Publication scope

Documentation on GitHub and repository About only. No package release, tag change or Pages deployment. Fee-allocation percentages and on-chain configuration are not represented as independently verified by these checks.
